### PR TITLE
Remove submitter from worker and move session object

### DIFF
--- a/Api/csharp/ArmoniK.Api.Worker/ArmoniK.Api.Worker.csproj
+++ b/Api/csharp/ArmoniK.Api.Worker/ArmoniK.Api.Worker.csproj
@@ -46,9 +46,6 @@
     <Protobuf Include="..\..\..\Protos\V1\agent_service.proto" GrpcServices="Both">
       <Link>gRPC\Protos\agent_service.proto</Link>
     </Protobuf>
-    <Protobuf Include="..\..\..\Protos\V1\submitter_service.proto" GrpcServices="Both">
-      <Link>gRPC\Protos\submitter_service.proto</Link>
-    </Protobuf>
     <Protobuf Include="..\..\..\Protos\V1\sessions_service.proto" GrpcServices="Both">
       <Link>gRPC\Protos\sessions_service.proto</Link>
     </Protobuf>

--- a/Protos/V1/objects.proto
+++ b/Protos/V1/objects.proto
@@ -18,6 +18,10 @@ message TaskOptions {
 	string partition_id = 5;
 }
 
+message Session {
+	string id = 1;
+}
+
 
 message Configuration {
 	int32 data_chunk_max_size = 1;

--- a/Protos/V1/submitter_service.proto
+++ b/Protos/V1/submitter_service.proto
@@ -47,11 +47,6 @@ service Submitter{
 	rpc WatchResults (stream WatchResultRequest) returns (stream WatchResultStream);
 }
 
-
-message Session {
-	string id = 1;
-}
-
 message SessionList {
   repeated Session sessions = 1;
 }


### PR DESCRIPTION
The worker api currently has access to the submitter service. Afaik, this shouldn't be the case, as it should instead use the agent service. If it's here for a good reason, I'll ammend the PR to only move the session object to objects.proto