### PR TITLE
fix: add missing properties in session summary

### DIFF
--- a/Protos/V1/sessions_common.proto
+++ b/Protos/V1/sessions_common.proto
@@ -30,6 +30,12 @@ message SessionSummary {
   session_status.SessionStatus status = 2;
   google.protobuf.Timestamp created_at = 3;
   google.protobuf.Timestamp cancelled_at = 4;
+
+  int64 total_tasks = 5;
+  int64 completed_tasks = 6;
+  int64 in_error_tasks = 7;
+  int64 cancelled_tasks = 8;
+  int64 pending_tasks = 9;
 }
 
 /**


### PR DESCRIPTION
En ce qui concerne les "pending" tasks, la question se pose. Mais dans l'affiche, l'ensemble de ces valeurs me permettent de savoir le statut de la session (qui est relative aux tâches). C'est à dire que si des tâches sont en processing au moment où la session est visualisée, alors la session est en "processing".
Mais il est peut être possible de contourner cela pour le pending en disant simplement que la session est active (mais qu'il ne se passe rien dedans via son propre statut)

fix https://github.com/aneoconsulting/ArmoniK/issues/517