### PR TITLE
Small fixes for APIs

### DIFF
--- a/Protos/V1/applications_common.proto
+++ b/Protos/V1/applications_common.proto
@@ -8,7 +8,7 @@ package armonik.api.grpc.v1.applications;
 import "google/protobuf/timestamp.proto";
 import "objects.proto";
 
-option csharp_namespace = "Armonik.Api.Grpc.V1.Applications";
+option csharp_namespace = "ArmoniK.Api.gRPC.V1.Applications";
 
 /**
  * A raw application object.

--- a/Protos/V1/applications_common.proto
+++ b/Protos/V1/applications_common.proto
@@ -55,7 +55,10 @@ message ListApplicationsRequest {
    */
   enum OrderByField {
     ORDER_BY_FIELD_UNSPECIFIED = 0; /** Unspecified. */
-    ORDER_BY_FIELD_ID = 1; /** Application ID. */
+    ORDER_BY_FIELD_NAME = 1; /** Application name. */
+    ORDER_BY_FIELD_VERSION = 2; /** Application version. */
+    ORDER_BY_FIELD_NAMESPACE = 3; /** Application namespace. */
+    ORDER_BY_FIELD_SERVICE = 4; /** Application service. */
   }
 
   /**

--- a/Protos/V1/applications_service.proto
+++ b/Protos/V1/applications_service.proto
@@ -8,7 +8,7 @@ package armonik.api.grpc.v1.applications;
 import "applications_common.proto";
 import "google/protobuf/timestamp.proto";
 
-option csharp_namespace = "Armonik.Api.Grpc.V1.Applications";
+option csharp_namespace = "ArmoniK.Api.gRPC.V1.Applications";
 
 /**
  * Service for handling applications.

--- a/Protos/V1/results_common.proto
+++ b/Protos/V1/results_common.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package armonik.api.grpc.v1.results;
 
+import "google/protobuf/timestamp.proto";
 import "result_status.proto";
 
 option csharp_namespace = "ArmoniK.Api.gRPC.V1.Results";
@@ -16,7 +17,7 @@ message ResultRaw {
   string name = 2; /** The result name. */
   string owner_task_id = 3; /** The owner task ID. */
   result_status.ResultStatus status = 4; /** The result status. */
-  string created_at = 5; /** The result creation date. */
+  google.protobuf.Timestamp created_at = 5; /** The result creation date. */
 }
 
 /**
@@ -38,8 +39,8 @@ message ListResultsRequest {
     string name = 2; /** The result name. */
     string owner_task_id = 3; /** The owner task ID. */
     result_status.ResultStatus status = 4; /** The result status. */
-    string created_after = 5; /** Use the creation date of a result to filter results created after the input. */
-    string created_before = 6; /** Use the creation date of a result to filter results created before the input. */
+    google.protobuf.Timestamp created_after = 5; /** Use the creation date of a result to filter results created after the input. */
+    google.protobuf.Timestamp created_before = 6; /** Use the creation date of a result to filter results created before the input. */
   }
 
   /**


### PR DESCRIPTION
Make the API coherent.
- Use timestamp for dates instead of strings
- Fix Applications namespace
- Add corresponding fields in Applications list orderby