### PR TITLE
perf: avoid making copies when using gRPC ByteStrings

### DIFF
--- a/packages/csharp/ArmoniK.Api.Client/Submitter/SubmitterClientExt.cs
+++ b/packages/csharp/ArmoniK.Api.Client/Submitter/SubmitterClientExt.cs
@@ -205,8 +205,8 @@ namespace ArmoniK.Api.Client.Submitter
                      {
                        TaskPayload = new DataChunk
                                      {
-                                       Data = ByteString.CopyFrom(taskRequest.Payload.Span.Slice(start,
-                                                                                                 chunkSize)),
+                                       Data = UnsafeByteOperations.UnsafeWrap(taskRequest.Payload.Memory.Slice(start,
+                                                                                                               chunkSize)),
                                      },
                      };
 

--- a/packages/csharp/ArmoniK.Api.Worker/Worker/TaskHandler.cs
+++ b/packages/csharp/ArmoniK.Api.Worker/Worker/TaskHandler.cs
@@ -162,9 +162,9 @@ public class TaskHandler : ITaskHandler
                                               CommunicationToken = Token,
                                               Data = new DataChunk
                                                      {
-                                                       Data = ByteString.CopyFrom(data.AsMemory()
-                                                                                      .Span.Slice(start,
-                                                                                                  chunkSize)),
+                                                       Data = UnsafeByteOperations.UnsafeWrap(data.AsMemory()
+                                                                                                  .Slice(start,
+                                                                                                         chunkSize)),
                                                      },
                                             })
                   .ConfigureAwait(false);

--- a/packages/csharp/ArmoniK.Api.Worker/Worker/TaskRequestExtensions.cs
+++ b/packages/csharp/ArmoniK.Api.Worker/Worker/TaskRequestExtensions.cs
@@ -127,8 +127,8 @@ public static class TaskRequestExtensions
                      CommunicationToken = token,
                      TaskPayload = new DataChunk
                                    {
-                                     Data = ByteString.CopyFrom(taskRequest.Payload.Span.Slice(start,
-                                                                                               chunkSize)),
+                                     Data = UnsafeByteOperations.UnsafeWrap(taskRequest.Payload.Memory.Slice(start,
+                                                                                                             chunkSize)),
                                    },
                    };
 


### PR DESCRIPTION
Previously, we were making copies when giving byte arrays to gRPC ByteStrings. This PR fixes it by using UnsafeOpterations.UnsafeWrap to only pass references instead of copying the data.
