### PR TITLE
fix: Publish Edge pipeline does not generate the right tag when on main branch

### DIFF
--- a/.github/workflows/publish-edge.yml
+++ b/.github/workflows/publish-edge.yml
@@ -25,7 +25,7 @@ jobs:
         id: version
         uses: codacy/git-version@2.7.1
         with:
-          release-branch: main
+          release-branch: release
           dev-branch: main
 
       - name: Print version


### PR DESCRIPTION
This PR fixes the version generate by codacy git-version when running on main branch.
