### PR TITLE
test: Add tests for TaskHandler class

### DIFF
--- a/.github/workflows/publish-edge.yml
+++ b/.github/workflows/publish-edge.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         projects:
-          - packages/csharp/ArmoniK.Api.Worker.Tests
+          - packages/csharp/ArmoniK.Api.Tests
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/publish-edge.yml
+++ b/.github/workflows/publish-edge.yml
@@ -32,8 +32,41 @@ jobs:
         run: |
           echo ${{ steps.version.outputs.version }} >> $GITHUB_STEP_SUMMARY
 
-  release-csharp-packages:
+  tests:
+    runs-on: ubuntu-latest
     needs: create-version
+    strategy:
+      fail-fast: false
+      matrix:
+        projects:
+          - packages/csharp/ArmoniK.Api.Worker.Tests
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.ref }}
+
+    # Install the .NET Core workload
+    - name: Install .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.x
+
+    - name: Run tests
+      run: |
+        cd ${{ matrix.projects }}
+        dotnet test --logger "trx;LogFileName=test-results.trx"
+
+    - name: Test Report
+      uses: dorny/test-reporter@v1
+      if: success() || failure()
+      with:
+        name: Test - ${{ matrix.os }} ${{ matrix.projects }}
+        path: ${{ matrix.projects }}/TestResults/test-results.trx
+        reporter: dotnet-trx
+
+  release-csharp-packages:
+    needs: [ create-version, tests ]
     name: Release C# Packages
     runs-on: ubuntu-latest
     env:

--- a/.gitignore
+++ b/.gitignore
@@ -369,3 +369,6 @@ dist
 !packages/common
 !packages/csharp
 !packages/python
+
+
+**/launchSettings.json

--- a/packages/csharp/ArmoniK.Api.Tests/TaskHandlerTest.cs
+++ b/packages/csharp/ArmoniK.Api.Tests/TaskHandlerTest.cs
@@ -76,13 +76,11 @@ public class TaskHandlerTest
 
   private class MyClientStreamWriter<T> : IClientStreamWriter<T>
   {
-    private         bool             isComplete_;
     public readonly ConcurrentBag<T> Messages = new();
+    private         bool             isComplete_;
 
     public MyClientStreamWriter()
-    {
-      isComplete_ = false;
-    }
+      => isComplete_ = false;
 
     public Task WriteAsync(T message)
     {
@@ -117,7 +115,7 @@ public class TaskHandlerTest
 
     public override AsyncClientStreamingCall<Result, ResultReply> SendResult(Metadata          headers           = null,
                                                                              DateTime?         deadline          = null,
-                                                                             CancellationToken cancellationToken = default(CancellationToken))
+                                                                             CancellationToken cancellationToken = default)
       => new(resultStream_,
              Task.FromResult(new ResultReply()),
              Task.FromResult(new Metadata()),
@@ -129,7 +127,7 @@ public class TaskHandlerTest
 
     public override AsyncClientStreamingCall<CreateTaskRequest, CreateTaskReply> CreateTask(Metadata          headers           = null,
                                                                                             DateTime?         deadline          = null,
-                                                                                            CancellationToken cancellationToken = default(CancellationToken))
+                                                                                            CancellationToken cancellationToken = default)
       => new(taskStream_,
              Task.FromResult(new CreateTaskReply()),
              Task.FromResult(new Metadata()),

--- a/packages/csharp/ArmoniK.Api.Tests/TaskHandlerTest.cs
+++ b/packages/csharp/ArmoniK.Api.Tests/TaskHandlerTest.cs
@@ -1,0 +1,600 @@
+// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2021-2022. All rights reserved.
+//   W. Kirschenmann   <wkirschenmann@aneo.fr>
+//   J. Gurhem         <jgurhem@aneo.fr>
+//   D. Dubuc          <ddubuc@aneo.fr>
+//   L. Ziane Khodja   <lzianekhodja@aneo.fr>
+//   F. Lemaitre       <flemaitre@aneo.fr>
+//   S. Djebbar        <sdjebbar@aneo.fr>
+//   J. Fonseca        <jfonseca@aneo.fr>
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ArmoniK.Api.gRPC.V1;
+using ArmoniK.Api.gRPC.V1.Agent;
+using ArmoniK.Api.gRPC.V1.Worker;
+using ArmoniK.Api.Worker.Worker;
+
+using Google.Protobuf;
+
+using Grpc.Core;
+
+using Microsoft.Extensions.Logging;
+
+using NUnit.Framework;
+
+namespace ArmoniK.Api.Worker.Tests;
+
+[TestFixture]
+public class TaskHandlerTest
+{
+  [SetUp]
+  public void SetUp()
+  {
+  }
+
+  [TearDown]
+  public virtual void TearDown()
+  {
+  }
+
+  private class MyAsyncStreamReader : IAsyncStreamReader<ProcessRequest>
+  {
+    private readonly IAsyncEnumerator<ProcessRequest> asyncEnumerator_;
+
+    public MyAsyncStreamReader(IEnumerable<ProcessRequest> requests)
+      => asyncEnumerator_ = requests.ToAsyncEnumerable()
+                                    .GetAsyncEnumerator();
+
+    public async Task<bool> MoveNext(CancellationToken cancellationToken)
+      => await asyncEnumerator_.MoveNextAsync(cancellationToken)
+                               .ConfigureAwait(false);
+
+    public ProcessRequest Current
+      => asyncEnumerator_.Current;
+  }
+
+  private class MyClientStreamWriter<T> : IClientStreamWriter<T>
+  {
+    private         bool             isComplete_;
+    public readonly ConcurrentBag<T> Messages = new();
+
+    public MyClientStreamWriter()
+    {
+      isComplete_ = false;
+    }
+
+    public Task WriteAsync(T message)
+    {
+      if (isComplete_)
+      {
+        throw new InvalidOperationException("Stream has been completed");
+      }
+
+      Messages.Add(message);
+      return Task.CompletedTask;
+    }
+
+    public WriteOptions WriteOptions { get; set; }
+
+    public Task CompleteAsync()
+    {
+      isComplete_ = true;
+      return Task.CompletedTask;
+    }
+  }
+
+  private class MyAgent : Agent.AgentClient
+  {
+    private readonly MyClientStreamWriter<Result>            resultStream_;
+    private readonly MyClientStreamWriter<CreateTaskRequest> taskStream_;
+
+    public MyAgent()
+    {
+      resultStream_ = new MyClientStreamWriter<Result>();
+      taskStream_   = new MyClientStreamWriter<CreateTaskRequest>();
+    }
+
+    public override AsyncClientStreamingCall<Result, ResultReply> SendResult(Metadata          headers           = null,
+                                                                             DateTime?         deadline          = null,
+                                                                             CancellationToken cancellationToken = default(CancellationToken))
+      => new(resultStream_,
+             Task.FromResult(new ResultReply()),
+             Task.FromResult(new Metadata()),
+             () => Status.DefaultSuccess,
+             () => new Metadata(),
+             () =>
+             {
+             });
+
+    public override AsyncClientStreamingCall<CreateTaskRequest, CreateTaskReply> CreateTask(Metadata          headers           = null,
+                                                                                            DateTime?         deadline          = null,
+                                                                                            CancellationToken cancellationToken = default(CancellationToken))
+      => new(taskStream_,
+             Task.FromResult(new CreateTaskReply()),
+             Task.FromResult(new Metadata()),
+             () => Status.DefaultSuccess,
+             () => new Metadata(),
+             () =>
+             {
+             });
+
+    public List<Result> GetResults()
+      => resultStream_.Messages.ToList();
+
+    public List<CreateTaskRequest> GetTaskRequests()
+      => taskStream_.Messages.ToList();
+  }
+
+
+  [Test]
+  [TestCaseSource(typeof(TaskHandlerTest),
+                  nameof(TaskHandlerCreateShouldThrowTestCases))]
+  public void TaskHandlerCreateShouldThrow(IEnumerable<ProcessRequest> requests)
+  {
+    var stream = new MyAsyncStreamReader(requests);
+
+    var agent = new MyAgent();
+
+    Assert.ThrowsAsync<InvalidOperationException>(async () => await TaskHandler.Create(stream,
+                                                                                       agent,
+                                                                                       new LoggerFactory(),
+                                                                                       CancellationToken.None)
+                                                                               .ConfigureAwait(false));
+  }
+
+  [Test]
+  [TestCaseSource(typeof(TaskHandlerTest),
+                  nameof(TaskHandlerCreateShouldSucceedTestCases))]
+  public async Task TaskHandlerCreateShouldSucceed(IEnumerable<ProcessRequest> requests)
+  {
+    var stream = new MyAsyncStreamReader(requests);
+
+    var agent = new MyAgent();
+
+    var taskHandler = await TaskHandler.Create(stream,
+                                               agent,
+                                               new LoggerFactory(),
+                                               CancellationToken.None)
+                                       .ConfigureAwait(false);
+
+    Assert.NotNull(taskHandler.Token);
+    Assert.IsNotEmpty(taskHandler.Token);
+    Assert.IsNotEmpty(taskHandler.Payload);
+    Assert.IsNotEmpty(taskHandler.SessionId);
+    Assert.IsNotEmpty(taskHandler.TaskId);
+  }
+
+  [Test]
+  public async Task CheckTaskHandlerDataAreCorrect()
+  {
+    var stream = new MyAsyncStreamReader(WorkingRequest1);
+
+    var agent = new MyAgent();
+
+    var taskHandler = await TaskHandler.Create(stream,
+                                               agent,
+                                               new LoggerFactory(),
+                                               CancellationToken.None)
+                                       .ConfigureAwait(false);
+
+    Assert.IsNotEmpty(taskHandler.Payload);
+    Assert.AreEqual("testPayload1Payload2",
+                    ByteString.CopyFrom(taskHandler.Payload)
+                              .ToStringUtf8());
+    Assert.AreEqual(2,
+                    taskHandler.DataDependencies.Count);
+    Assert.AreEqual("Data1Data2",
+                    ByteString.CopyFrom(taskHandler.DataDependencies.Values.First())
+                              .ToStringUtf8());
+    Assert.AreEqual("Data1Data2Data2Data2",
+                    ByteString.CopyFrom(taskHandler.DataDependencies.Values.Last())
+                              .ToStringUtf8());
+    Assert.AreEqual("TaskId",
+                    taskHandler.TaskId);
+    Assert.AreEqual("SessionId",
+                    taskHandler.SessionId);
+    Assert.AreEqual("Token",
+                    taskHandler.Token);
+
+    await taskHandler.SendResult("test",
+                                 Encoding.ASCII.GetBytes("TestData"));
+
+    var results = agent.GetResults();
+    foreach (var r in results)
+    {
+      Console.WriteLine(r);
+    }
+
+    Assert.AreEqual(4,
+                    results.Count);
+
+    Assert.AreEqual(Result.TypeOneofCase.Init,
+                    results[0]
+                      .TypeCase);
+    Assert.AreEqual(true,
+                    results[0]
+                      .Init.LastResult);
+
+    Assert.AreEqual(Result.TypeOneofCase.Data,
+                    results[1]
+                      .TypeCase);
+    Assert.AreEqual(true,
+                    results[1]
+                      .Data.DataComplete);
+
+    Assert.AreEqual(Result.TypeOneofCase.Data,
+                    results[2]
+                      .TypeCase);
+    Assert.AreEqual("TestData",
+                    results[2]
+                      .Data.Data);
+
+    Assert.AreEqual(Result.TypeOneofCase.Init,
+                    results[3]
+                      .TypeCase);
+    Assert.AreEqual("test",
+                    results[3]
+                      .Init.Key);
+
+
+    await taskHandler.CreateTasksAsync(new List<TaskRequest>
+                                       {
+                                         new()
+                                         {
+                                           Payload = ByteString.CopyFromUtf8("Payload"),
+                                           DataDependencies =
+                                           {
+                                             "DD",
+                                           },
+                                           ExpectedOutputKeys =
+                                           {
+                                             "EOK",
+                                           },
+                                         },
+                                       });
+
+    var tasks = agent.GetTaskRequests();
+    Console.WriteLine();
+    foreach (var t in tasks)
+    {
+      Console.WriteLine(t);
+    }
+
+    Assert.AreEqual(5,
+                    tasks.Count);
+
+    Assert.AreEqual(CreateTaskRequest.TypeOneofCase.InitTask,
+                    tasks[0]
+                      .TypeCase);
+    Assert.AreEqual(true,
+                    tasks[0]
+                      .InitTask.LastTask);
+
+    Assert.AreEqual(CreateTaskRequest.TypeOneofCase.TaskPayload,
+                    tasks[1]
+                      .TypeCase);
+    Assert.AreEqual(true,
+                    tasks[1]
+                      .TaskPayload.DataComplete);
+
+    Assert.AreEqual(CreateTaskRequest.TypeOneofCase.TaskPayload,
+                    tasks[2]
+                      .TypeCase);
+    Assert.AreEqual("Payload",
+                    tasks[2]
+                      .TaskPayload.Data);
+
+    Assert.AreEqual(CreateTaskRequest.TypeOneofCase.InitTask,
+                    tasks[3]
+                      .TypeCase);
+    Assert.AreEqual("DD",
+                    tasks[3]
+                      .InitTask.Header.DataDependencies.Single());
+    Assert.AreEqual("EOK",
+                    tasks[3]
+                      .InitTask.Header.ExpectedOutputKeys.Single());
+
+    Assert.AreEqual(CreateTaskRequest.TypeOneofCase.InitRequest,
+                    tasks[4]
+                      .TypeCase);
+  }
+
+  private static readonly ProcessRequest InitData1 = new()
+                                                     {
+                                                       CommunicationToken = "Token",
+                                                       Compute = new ProcessRequest.Types.ComputeRequest
+                                                                 {
+                                                                   InitData = new ProcessRequest.Types.ComputeRequest.Types.InitData
+                                                                              {
+                                                                                Key = "DataKey1",
+                                                                              },
+                                                                 },
+                                                     };
+
+  private static readonly ProcessRequest InitData2 = new()
+                                                     {
+                                                       CommunicationToken = "Token",
+                                                       Compute = new ProcessRequest.Types.ComputeRequest
+                                                                 {
+                                                                   InitData = new ProcessRequest.Types.ComputeRequest.Types.InitData
+                                                                              {
+                                                                                Key = "DataKey2",
+                                                                              },
+                                                                 },
+                                                     };
+
+  private static readonly ProcessRequest LastDataTrue = new()
+                                                        {
+                                                          CommunicationToken = "Token",
+                                                          Compute = new ProcessRequest.Types.ComputeRequest
+                                                                    {
+                                                                      InitData = new ProcessRequest.Types.ComputeRequest.Types.InitData
+                                                                                 {
+                                                                                   LastData = true,
+                                                                                 },
+                                                                    },
+                                                        };
+
+  private static readonly ProcessRequest LastDataFalse = new()
+                                                         {
+                                                           CommunicationToken = "Token",
+                                                           Compute = new ProcessRequest.Types.ComputeRequest
+                                                                     {
+                                                                       InitData = new ProcessRequest.Types.ComputeRequest.Types.InitData
+                                                                                  {
+                                                                                    LastData = false,
+                                                                                  },
+                                                                     },
+                                                         };
+
+  private static readonly ProcessRequest InitRequestPayload = new()
+                                                              {
+                                                                CommunicationToken = "Token",
+                                                                Compute = new ProcessRequest.Types.ComputeRequest
+                                                                          {
+                                                                            InitRequest = new ProcessRequest.Types.ComputeRequest.Types.InitRequest
+                                                                                          {
+                                                                                            Payload = new DataChunk
+                                                                                                      {
+                                                                                                        Data = ByteString.CopyFromUtf8("test"),
+                                                                                                      },
+                                                                                            Configuration = new Configuration
+                                                                                                            {
+                                                                                                              DataChunkMaxSize = 100,
+                                                                                                            },
+                                                                                            ExpectedOutputKeys =
+                                                                                            {
+                                                                                              "EOK",
+                                                                                            },
+                                                                                            SessionId = "SessionId",
+                                                                                            TaskId    = "TaskId",
+                                                                                          },
+                                                                          },
+                                                              };
+
+  private static readonly ProcessRequest InitRequestEmptyPayload = new()
+                                                                   {
+                                                                     CommunicationToken = "Token",
+                                                                     Compute = new ProcessRequest.Types.ComputeRequest
+                                                                               {
+                                                                                 InitRequest = new ProcessRequest.Types.ComputeRequest.Types.InitRequest
+                                                                                               {
+                                                                                                 Configuration = new Configuration
+                                                                                                                 {
+                                                                                                                   DataChunkMaxSize = 100,
+                                                                                                                 },
+                                                                                                 ExpectedOutputKeys =
+                                                                                                 {
+                                                                                                   "EOK",
+                                                                                                 },
+                                                                                                 SessionId = "SessionId",
+                                                                                                 TaskId    = "TaskId",
+                                                                                               },
+                                                                               },
+                                                                   };
+
+  private static readonly ProcessRequest Payload1 = new()
+                                                    {
+                                                      CommunicationToken = "Token",
+                                                      Compute = new ProcessRequest.Types.ComputeRequest
+                                                                {
+                                                                  Payload = new DataChunk
+                                                                            {
+                                                                              Data = ByteString.CopyFromUtf8("Payload1"),
+                                                                            },
+                                                                },
+                                                    };
+
+  private static readonly ProcessRequest Payload2 = new()
+                                                    {
+                                                      CommunicationToken = "Token",
+                                                      Compute = new ProcessRequest.Types.ComputeRequest
+                                                                {
+                                                                  Payload = new DataChunk
+                                                                            {
+                                                                              Data = ByteString.CopyFromUtf8("Payload2"),
+                                                                            },
+                                                                },
+                                                    };
+
+  private static readonly ProcessRequest PayloadComplete = new()
+                                                           {
+                                                             CommunicationToken = "Token",
+                                                             Compute = new ProcessRequest.Types.ComputeRequest
+                                                                       {
+                                                                         Payload = new DataChunk
+                                                                                   {
+                                                                                     DataComplete = true,
+                                                                                   },
+                                                                       },
+                                                           };
+
+  private static readonly ProcessRequest Data1 = new()
+                                                 {
+                                                   CommunicationToken = "Token",
+                                                   Compute = new ProcessRequest.Types.ComputeRequest
+                                                             {
+                                                               Data = new DataChunk
+                                                                      {
+                                                                        Data = ByteString.CopyFromUtf8("Data1"),
+                                                                      },
+                                                             },
+                                                 };
+
+  private static readonly ProcessRequest Data2 = new()
+                                                 {
+                                                   CommunicationToken = "Token",
+                                                   Compute = new ProcessRequest.Types.ComputeRequest
+                                                             {
+                                                               Data = new DataChunk
+                                                                      {
+                                                                        Data = ByteString.CopyFromUtf8("Data2"),
+                                                                      },
+                                                             },
+                                                 };
+
+  private static readonly ProcessRequest DataComplete = new()
+                                                        {
+                                                          CommunicationToken = "Token",
+                                                          Compute = new ProcessRequest.Types.ComputeRequest
+                                                                    {
+                                                                      Data = new DataChunk
+                                                                             {
+                                                                               DataComplete = true,
+                                                                             },
+                                                                    },
+                                                        };
+
+  public static IEnumerable TaskHandlerCreateShouldThrowTestCases
+  {
+    get
+    {
+      yield return new TestCaseData(new ProcessRequest[]
+                                    {
+                                    }.AsEnumerable());
+      yield return new TestCaseData(new[]
+                                    {
+                                      InitData1,
+                                    }.AsEnumerable());
+      yield return new TestCaseData(new[]
+                                    {
+                                      InitData2,
+                                    }.AsEnumerable());
+      yield return new TestCaseData(new[]
+                                    {
+                                      LastDataTrue,
+                                    }.AsEnumerable());
+      yield return new TestCaseData(new[]
+                                    {
+                                      LastDataFalse,
+                                    }.AsEnumerable());
+      yield return new TestCaseData(new[]
+                                    {
+                                      InitRequestPayload,
+                                    }.AsEnumerable()).SetArgDisplayNames(nameof(InitRequestPayload));
+      yield return new TestCaseData(new[]
+                                    {
+                                      DataComplete,
+                                    }.AsEnumerable()).SetArgDisplayNames(nameof(DataComplete));
+      yield return new TestCaseData(new[]
+                                    {
+                                      InitRequestEmptyPayload,
+                                    }.AsEnumerable()).SetArgDisplayNames(nameof(InitRequestEmptyPayload));
+      yield return new TestCaseData(new[]
+                                    {
+                                      InitRequestPayload,
+                                      PayloadComplete,
+                                      InitData1,
+                                      Data1,
+                                      LastDataTrue,
+                                    }.AsEnumerable()).SetArgDisplayNames("NotWorkingRequest1");
+      yield return new TestCaseData(new[]
+                                    {
+                                      InitRequestPayload,
+                                      InitData1,
+                                      Data1,
+                                      DataComplete,
+                                      LastDataTrue,
+                                    }.AsEnumerable()).SetArgDisplayNames("NotWorkingRequest2");
+      yield return new TestCaseData(new[]
+                                    {
+                                      InitRequestPayload,
+                                      PayloadComplete,
+                                      Data1,
+                                      DataComplete,
+                                      LastDataTrue,
+                                    }.AsEnumerable()).SetArgDisplayNames("NotWorkingRequest3");
+    }
+  }
+
+  private static readonly IEnumerable<ProcessRequest> WorkingRequest1 = new[]
+                                                                        {
+                                                                          InitRequestPayload,
+                                                                          Payload1,
+                                                                          Payload2,
+                                                                          PayloadComplete,
+                                                                          InitData1,
+                                                                          Data1,
+                                                                          Data2,
+                                                                          DataComplete,
+                                                                          InitData2,
+                                                                          Data1,
+                                                                          Data2,
+                                                                          Data2,
+                                                                          Data2,
+                                                                          DataComplete,
+                                                                          LastDataTrue,
+                                                                        }.AsEnumerable();
+
+  private static readonly IEnumerable<ProcessRequest> WorkingRequest2 = new[]
+                                                                        {
+                                                                          InitRequestPayload,
+                                                                          Payload1,
+                                                                          PayloadComplete,
+                                                                          InitData1,
+                                                                          Data1,
+                                                                          DataComplete,
+                                                                          LastDataTrue,
+                                                                        }.AsEnumerable();
+
+  private static readonly IEnumerable<ProcessRequest> WorkingRequest3 = new[]
+                                                                        {
+                                                                          InitRequestPayload,
+                                                                          PayloadComplete,
+                                                                          InitData1,
+                                                                          Data1,
+                                                                          DataComplete,
+                                                                          LastDataTrue,
+                                                                        }.AsEnumerable();
+
+  public static IEnumerable TaskHandlerCreateShouldSucceedTestCases
+  {
+    get
+    {
+      yield return new TestCaseData(WorkingRequest1).SetArgDisplayNames(nameof(WorkingRequest1));
+      yield return new TestCaseData(WorkingRequest2).SetArgDisplayNames(nameof(WorkingRequest2));
+      yield return new TestCaseData(WorkingRequest3).SetArgDisplayNames(nameof(WorkingRequest3));
+    }
+  }
+}

--- a/packages/csharp/ArmoniK.Api.Worker/AssemblyInfo.cs
+++ b/packages/csharp/ArmoniK.Api.Worker/AssemblyInfo.cs
@@ -1,0 +1,21 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// In SDK-style projects such as this one, several assembly attributes that were historically
+// defined in this file are now automatically added during build and populated with
+// values defined in project properties. For details of which attributes are included
+// and how to customise this process see: https://aka.ms/assembly-info-properties
+
+
+// Setting ComVisible to false makes the types in this assembly not visible to COM
+// components.  If you need to access a type in this assembly from COM, set the ComVisible
+// attribute to true on that type.
+
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM.
+
+[assembly: Guid("047205dd-4253-4605-8cf1-e8fd025200ff")]
+
+[assembly:
+  InternalsVisibleTo("ArmoniK.Api.Worker.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b9cbe494cb23f1c9a351b8d0f211ba3f27afd44f1e683f1c08077b08372ad2649a9427e888c2aad68f010776c168f7a755e6ec591e48fcdd6928d2d6f1aeba06f7c3857437a5a15c7407756e17c3e1877a92eb5f9c82369731520f257bbca1f61a4caaa8aafc7aa40c5810cb81f16c68b4d4f8aa3044b09f7b417ca553bd53be")]

--- a/packages/csharp/ArmoniK.Api.Worker/Worker/TaskHandler.cs
+++ b/packages/csharp/ArmoniK.Api.Worker/Worker/TaskHandler.cs
@@ -241,6 +241,11 @@ public class TaskHandler : ITaskHandler
     Configuration    = initRequest.Configuration;
     token_           = requestStream_.Current.CommunicationToken;
 
+    if (initRequest.Payload is null)
+    {
+      throw new InvalidOperationException("Payload from InitRequest should not be null");
+    }
+
 
     if (initRequest.Payload.DataComplete)
     {


### PR DESCRIPTION
When moving TaskHandler from Core to Api, the tests became obsolete. This PR adds new tests for TaskHandler.

fix https://github.com/aneoconsulting/ArmoniK/issues/341
