### PR TITLE
feat: add health checks

### DIFF
--- a/Protos/V1/health_checks_common.proto
+++ b/Protos/V1/health_checks_common.proto
@@ -7,7 +7,7 @@ option csharp_namespace = "Armonik.Api.Grpc.V1.HealthChecks";
 /**
  * Represents the available health status
  */
- enum HealthStatusEnum {
+enum HealthStatusEnum {
   HEALTH_STATUS_ENUM_UNSPECIFIED = 0; /** Unspecified */
   HEALTH_STATUS_ENUM_HEALTHY = 1; /** Service is working without issues */
   HEALTH_STATUS_ENUM_DEGRADED = 2; /** Service has issues but still works */
@@ -31,4 +31,3 @@ message CheckHealthResponse {
 
   repeated ServiceHealth services = 1;
 }
-

--- a/Protos/V1/health_checks_common.proto
+++ b/Protos/V1/health_checks_common.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package armonik.api.grpc.v1.health_checks;
 
-option csharp_namespace = "Armonik.Api.Grpc.V1.HealthChecks";
+option csharp_namespace = "ArmoniK.Api.gRPC.V1.HealthChecks";
 
 /**
  * Represents the available health status

--- a/Protos/V1/health_checks_common.proto
+++ b/Protos/V1/health_checks_common.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package armonik.api.grpc.v1.health_checks;
+
+option csharp_namespace = "Armonik.Api.Grpc.V1.HealthChecks";
+
+/**
+ * Represents the available health status
+ */
+ enum HealthStatusEnum {
+  HEALTH_STATUS_ENUM_UNSPECIFIED = 0; /** Unspecified */
+  HEALTH_STATUS_ENUM_HEALTHY = 1; /** Service is working without issues */
+  HEALTH_STATUS_ENUM_DEGRADED = 2; /** Service has issues but still works */
+  HEALTH_STATUS_ENUM_UNHEALTHY = 3; /** Service does not work */
+}
+
+/**
+* Request to check if all services are healthy
+*/
+message CheckHealthRequest {}
+
+/**
+* Response to check if all services are healthy
+*/
+message CheckHealthResponse {
+  message ServiceHealth {
+    string name = 1; // Name of the service (e.g. "control_plane", "database", "redis")
+    string message = 2;
+    HealthStatusEnum healthy = 3;
+  }
+
+  repeated ServiceHealth services = 1;
+}
+

--- a/Protos/V1/health_checks_service.proto
+++ b/Protos/V1/health_checks_service.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package armonik.api.grpc.v1.health_checks;
+
+import "health_checks_common.proto";
+
+option csharp_namespace = "Armonik.Api.Grpc.V1.HealthChecks";
+
+/**
+ * The HealthChecksService provides methods to verify the health of the cluster.
+ */
+service HealthChecksService {
+  /**
+   * Checks the health of the cluster. This can be used to verify that the cluster is up and running.
+   */
+  rpc CheckHealth(CheckHealthRequest) returns (CheckHealthResponse) {}
+
+}

--- a/Protos/V1/health_checks_service.proto
+++ b/Protos/V1/health_checks_service.proto
@@ -4,7 +4,7 @@ package armonik.api.grpc.v1.health_checks;
 
 import "health_checks_common.proto";
 
-option csharp_namespace = "Armonik.Api.Grpc.V1.HealthChecks";
+option csharp_namespace = "ArmoniK.Api.gRPC.V1.HealthChecks";
 
 /**
  * The HealthChecksService provides methods to verify the health of the cluster.

--- a/Protos/V1/health_checks_service.proto
+++ b/Protos/V1/health_checks_service.proto
@@ -14,5 +14,4 @@ service HealthChecksService {
    * Checks the health of the cluster. This can be used to verify that the cluster is up and running.
    */
   rpc CheckHealth(CheckHealthRequest) returns (CheckHealthResponse) {}
-
 }

--- a/packages/common/protofiles.sh
+++ b/packages/common/protofiles.sh
@@ -7,6 +7,7 @@ export README_PATH=$REPOSITORY_PATH/README.md
 armonik_worker_files=("agent_service.proto" "worker_service.proto")
 armonik_client_files=("submitter_service.proto" "tasks_service.proto" "sessions_service.proto" \
                       "results_service.proto" "applications_service.proto" "auth_service.proto" \
+                      "health_checks_service.proto" \
                       "events_service.proto" "partitions_service.proto" "versions_service.proto")
 armonik_common_files=("objects.proto" "task_status.proto" "session_status.proto" \
                       "result_status.proto" "agent_common.proto" "sessions_common.proto"  \
@@ -17,5 +18,5 @@ armonik_common_files=("objects.proto" "task_status.proto" "session_status.proto"
                       "sessions_fields.proto" "sessions_filters.proto" \
                       "applications_fields.proto" "applications_filters.proto" \
                       "partitions_fields.proto" "partitions_filters.proto" \
-                      "results_fields.proto" "results_filters.proto" \
+                      "results_fields.proto" "results_filters.proto" "health_checks_common.proto" \
                       "filters_common.proto")

--- a/packages/cpp/ArmoniK.Api.Client/CMakeLists.txt
+++ b/packages/cpp/ArmoniK.Api.Client/CMakeLists.txt
@@ -4,6 +4,7 @@ set(PROJECT_BUILD_DIR ${BUILD_DIR}/${PROJECT_NAME})
 
 set(PROTO_FILES
     "submitter_service.proto"
+    "health_checks_service.proto"
     "applications_service.proto"
     "sessions_service.proto"
     "tasks_service.proto"
@@ -17,6 +18,7 @@ set(PROTO_MESSAGES
     "auth_common.proto"
     "sessions_common.proto"
     "submitter_common.proto"
+    "health_checks_common.proto"
     "tasks_common.proto"
     "results_common.proto"
     "partitions_common.proto"

--- a/packages/csharp/ArmoniK.Api.Client/ArmoniK.Api.Client.csproj
+++ b/packages/csharp/ArmoniK.Api.Client/ArmoniK.Api.Client.csproj
@@ -70,5 +70,8 @@
     <Protobuf Include="..\..\..\Protos\V1\versions_service.proto" GrpcServices="Client">
       <Link>gRPC\Protos\versions_service.proto</Link>
     </Protobuf>
+    <Protobuf Include="..\..\..\Protos\V1\health_checks_service.proto" GrpcServices="Client">
+      <Link>gRPC\Protos\health_checks_service.proto</Link>
+    </Protobuf>
   </ItemGroup>
 </Project>

--- a/packages/csharp/ArmoniK.Api.Common/ArmoniK.Api.Common.csproj
+++ b/packages/csharp/ArmoniK.Api.Common/ArmoniK.Api.Common.csproj
@@ -58,6 +58,10 @@
       <GrpcServices>Message</GrpcServices>
       <ProtoCompile>True</ProtoCompile>
     </Protobuf>
+    <Protobuf Include="..\..\..\Protos\V1\health_checks_common.proto" Link="health_checks_common.proto">
+      <GrpcServices>Message</GrpcServices>
+      <ProtoCompile>True</ProtoCompile>
+    </Protobuf>
     <Protobuf Include="..\..\..\Protos\V1\sessions_common.proto" Link="sessions_common.proto">
       <GrpcServices>Message</GrpcServices>
       <ProtoCompile>True</ProtoCompile>

--- a/packages/csharp/ArmoniK.Api.Core/ArmoniK.Api.Core.csproj
+++ b/packages/csharp/ArmoniK.Api.Core/ArmoniK.Api.Core.csproj
@@ -67,6 +67,9 @@
     <Protobuf Include="..\..\..\Protos\V1\versions_service.proto" GrpcServices="Both">
       <Link>gRPC\Protos\versions_service.proto</Link>
     </Protobuf>
+    <Protobuf Include="..\..\..\Protos\V1\health_checks_service.proto" GrpcServices="Both">
+      <Link>gRPC\Protos\health_checks_service.proto</Link>
+    </Protobuf>
   </ItemGroup>
 
 </Project>

--- a/packages/csharp/ArmoniK.Api.Mock/Program.cs
+++ b/packages/csharp/ArmoniK.Api.Mock/Program.cs
@@ -79,6 +79,7 @@ app.MapGrpcService<Agent>();
 app.MapGrpcService<Applications>();
 app.MapGrpcService<Authentication>();
 app.MapGrpcService<Events>();
+app.MapGrpcService<HealthChecks>();
 app.MapGrpcService<Partitions>();
 app.MapGrpcService<Results>();
 app.MapGrpcService<Sessions>();

--- a/packages/csharp/ArmoniK.Api.Mock/Services/HealthChecks.cs
+++ b/packages/csharp/ArmoniK.Api.Mock/Services/HealthChecks.cs
@@ -1,0 +1,43 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2023.All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+
+using ArmoniK.Api.gRPC.V1.HealthChecks;
+
+using Grpc.Core;
+
+namespace ArmoniK.Api.Mock.Services;
+
+[Counting]
+public class HealthChecks : HealthChecksService.HealthChecksServiceBase
+{
+  [Count]
+  public override Task<CheckHealthResponse> CheckHealth(CheckHealthRequest request,
+                                                        ServerCallContext  context)
+    => Task.FromResult(new CheckHealthResponse
+                       {
+                         Services =
+                         {
+                           new CheckHealthResponse.Types.ServiceHealth
+                           {
+                             Healthy = HealthStatusEnum.Healthy,
+                             Message = "Mock is healthy",
+                             Name    = "mock",
+                           },
+                         },
+                       });
+}


### PR DESCRIPTION
fix #168

This will allow connected client to know is the API is up and running (so client can communicate with it) and if the cluter is up and running.