### PR TITLE
ci: stop two workflows from cancelling each others

### DIFF
--- a/.github/workflows/validate-docs-generation.yml
+++ b/.github/workflows/validate-docs-generation.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 concurrency:
-  group: "ci-${{ github.ref }}"
+  group: "ci-validate-doc-${{ github.ref }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Stop CI and Validate Doc workflows from cancelling each other since they have the same concurrency group.
