### PR TITLE
build: configure protoc extension and suggest extensions for vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "zxh404.vscode-proto3",
+        "dotjoshjohnson.xml",
+        "redhat.vscode-yaml"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,9 @@
 {
-  "cSpell.words": ["Armoni"]
+  "protoc": {
+    "compile_on_save": true,
+    "options": [
+        "--proto_path=${workspaceRoot}/Protos/V1",
+        "--csharp_out=${workspaceRoot}/gen/csharp"
+    ]
+}
 }


### PR DESCRIPTION
- suggest extensions to use for vscode
- Configure proto3 extension to validate and generate grpc code from proto
