### PR TITLE
feat: Added mTLS support to C# Api

### DIFF
--- a/packages/csharp/ArmoniK.Api.Client/ArmoniK.Api.Client.csproj
+++ b/packages/csharp/ArmoniK.Api.Client/ArmoniK.Api.Client.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Grpc.Net.ClientFactory" Version="2.49.0" />
     <PackageReference Include="Grpc.Tools" Version="2.49.1">
@@ -42,7 +43,7 @@
     <Protobuf Include="..\..\..\Protos\V1\submitter_service.proto" GrpcServices="Client">
       <Link>gRPC\Protos\submitter_service.proto</Link>
     </Protobuf>
-     <Protobuf Include="..\..\..\Protos\V1\applications_service.proto" GrpcServices="Client">
+    <Protobuf Include="..\..\..\Protos\V1\applications_service.proto" GrpcServices="Client">
       <Link>gRPC\Protos\applications_service.proto</Link>
     </Protobuf>
     <Protobuf Include="..\..\..\Protos\V1\sessions_service.proto" GrpcServices="Client">
@@ -54,7 +55,7 @@
     <Protobuf Include="..\..\..\Protos\V1\results_service.proto" GrpcServices="Client">
       <Link>gRPC\Protos\results_service.proto</Link>
     </Protobuf>
-     <Protobuf Include="..\..\..\Protos\V1\auth_service.proto" GrpcServices="Client">
+    <Protobuf Include="..\..\..\Protos\V1\auth_service.proto" GrpcServices="Client">
       <Link>gRPC\Protos\auth_service.proto</Link>
     </Protobuf>
     <Protobuf Include="..\..\..\Protos\V1\partitions_service.proto" GrpcServices="Client">

--- a/packages/csharp/ArmoniK.Api.Client/Options/GrpcClient.cs
+++ b/packages/csharp/ArmoniK.Api.Client/Options/GrpcClient.cs
@@ -54,5 +54,10 @@ namespace ArmoniK.Api.Client.Options
     ///   Path to the key file in pem format
     /// </summary>
     public string KeyPem { get; set; } = "";
+
+    /// <summary>
+    ///   Path to the certificate file in p12/pfx format
+    /// </summary>
+    public string CertP12 { get; set; } = "";
   }
 }

--- a/packages/csharp/ArmoniK.Api.Common.Channel/ArmoniK.Api.Common.Channel.csproj
+++ b/packages/csharp/ArmoniK.Api.Common.Channel/ArmoniK.Api.Common.Channel.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageVersion>3.7.2</PackageVersion>
+    <PackageOutputPath>../publish</PackageOutputPath>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/csharp/ArmoniK.Api.Core/ArmoniK.Api.Core.csproj
+++ b/packages/csharp/ArmoniK.Api.Core/ArmoniK.Api.Core.csproj
@@ -17,6 +17,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <AssemblyOriginatorKeyFile>../kp.snk</AssemblyOriginatorKeyFile>
     <PackageVersion>3.7.2</PackageVersion>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/csharp/ArmoniK.Api.Worker/ArmoniK.Api.Worker.csproj
+++ b/packages/csharp/ArmoniK.Api.Worker/ArmoniK.Api.Worker.csproj
@@ -17,6 +17,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <AssemblyOriginatorKeyFile>../kp.snk</AssemblyOriginatorKeyFile>
     <PackageVersion>3.7.2</PackageVersion>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">


### PR DESCRIPTION
mTLS support was implemented incorrectly, this PR aims at correcting this problem and have a functional implementation.
Note that it *should* only support TLS 1.2 at most, as TLS 1.3 is not supported on netstandard.