### PR TITLE
ci: Added version check for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
+  # We need to verify the version in some packages with the tag in order to have the same version in all packages (python, csharp, angular, web).
+  # Some packages use an internal version (like csharp, angular and web) and some use the tag version (like python).
   verify-versions:
     name: Verify Versions
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,31 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
+  verify-versions:
+    name: Verify Versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - run: npm i -g pnpm @antfu/ni
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: pnpm
+
+      - name: Install Dependencies
+        run: nci
+
+      - name: Verify Versions
+        run: nr verify-versions ${{ github.ref_name }}
+
   release-csharp-packages:
+    needs: [verify-versions]
     name: Release C# Packages
     runs-on: ubuntu-latest
     strategy:
@@ -45,6 +69,7 @@ jobs:
         run: dotnet nuget push /tmp/packages/ArmoniK.Api.*.nupkg -k ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
   release-python-package:
+    needs: [verify-versions]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -72,6 +97,7 @@ jobs:
           packages_dir: packages/python/pkg/
 
   release-angular-packages:
+    needs: [verify-versions]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -104,6 +130,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
   release-web-packages:
+    needs: [verify-versions]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -139,6 +166,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
   update-changelog:
+    needs: [verify-versions]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/scripts/verify-versions.ts
+++ b/scripts/verify-versions.ts
@@ -10,6 +10,7 @@ import {
 import { _readAndFind } from "./versions/_readAndFind";
 
 const versions = new Map<string, string>();
+const [, , ...args] = process.argv;
 
 consola.info("Finding JS projects versions");
 jsFiles.forEach(_readAndFind(jsPattern, versions));
@@ -34,6 +35,12 @@ if (uniqueVersions.length > 1) {
   });
   process.exit(1);
 } else {
+  if (args.length > 0) {
+    if (uniqueVersions[0] != args[0]) {
+      consola.fatal(`Found ${uniqueVersions[0]} for all projects but does not match expected ${args[0]}`);
+      process.exit(1);
+    }
+  }
   consola.success(`Found ${uniqueVersions[0]} for all projects`);
   process.exit(0);
 }

--- a/scripts/verify-versions.ts
+++ b/scripts/verify-versions.ts
@@ -34,13 +34,10 @@ if (uniqueVersions.length > 1) {
     consola.info(version, filesPerVersion.get(version));
   });
   process.exit(1);
+} else if(args.length > 0 && uniqueVersions[0] != args[0]) {
+  consola.fatal(`Found ${uniqueVersions[0]} for all projects but does not match expected ${args[0]}`);
+  process.exit(1);
 } else {
-  if (args.length > 0) {
-    if (uniqueVersions[0] != args[0]) {
-      consola.fatal(`Found ${uniqueVersions[0]} for all projects but does not match expected ${args[0]}`);
-      process.exit(1);
-    }
-  }
   consola.success(`Found ${uniqueVersions[0]} for all projects`);
   process.exit(0);
 }


### PR DESCRIPTION
When we do a release, this will check if we forgot to change the version of the packages, preventing issues where Python would send a new version to pypi but C# packages would be the old version