### PR TITLE
chore: remove unused vscode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
-    "recommendations": [
-        "zxh404.vscode-proto3",
-        "dotjoshjohnson.xml",
-        "redhat.vscode-yaml"
-    ]
+  "recommendations": [
+    "zxh404.vscode-proto3",
+    "dotjoshjohnson.xml",
+  ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,5 +2,6 @@
   "recommendations": [
     "zxh404.vscode-proto3",
     "dotjoshjohnson.xml",
+    "github.vscode-github-actions"
   ]
 }


### PR DESCRIPTION
There is no yml file (others than Actions) so this extension is not necessary. If we want, we can add the GitHub Actions extension.