### PR TITLE
ci: update params to publish to pypi

### DIFF
--- a/.github/workflows/publish-edge.yml
+++ b/.github/workflows/publish-edge.yml
@@ -207,20 +207,20 @@ jobs:
         with:
           name: python-packages
           path: packages/python/pkg/
-      
+
       - name: Publish to PyPITest
         if: github.ref != 'refs/heads/main'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.DEV_PYPI_API_TOKEN }}
-          print_hash: true
-          packages_dir: packages/python/pkg/
-          repository_url: https://test.pypi.org/legacy/
-  
+          print-hash: true
+          packages-dir: packages/python/pkg/
+          repository-url: https://test.pypi.org/legacy/
+
       - name: Publish to PyPI
         if: github.ref == 'refs/heads/main'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-          print_hash: true
-          packages_dir: packages/python/pkg/
+          print-hash: true
+          packages-dir: packages/python/pkg/


### PR DESCRIPTION
Move away from deprecated api used in th pypi action