### PR TITLE
docs: add packages version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,8 @@
         "--proto_path=${workspaceRoot}/Protos/V1",
         "--csharp_out=${workspaceRoot}/gen/csharp"
     ]
-}
+},
+"cSpell.words": [
+  "Armoni"
+]
 }

--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
 # ArmoniK.Api
 
+| Javascript |   C#   | Python |
+| :--------: | :----: | :----: |
+| [![NPM version](https://img.shields.io/npm/v/@aneoconsultingfr/armonik.api.angular?color=fe5001&label=Angular)](https://www.npmjs.com/package/@aneoconsultingfr/armonik.api.angular) | [![Nuget version](https://img.shields.io/nuget/v/ArmoniK.Api.Client?color=fe5001&label=Client)](https://www.nuget.org/packages/ArmoniK.Api.Client) | [![PyPI version](https://img.shields.io/pypi/v/armonik?color=fe5001&label=armonik)](https://pypi.org/project/armonik/) |
+[![NPM version](https://img.shields.io/npm/v/@aneoconsultingfr/armonik.api?color=fe5001&label=Web)](https://www.npmjs.com/package/@aneoconsultingfr/armonik.api) | [![Nuget version](https://img.shields.io/nuget/v/ArmoniK.Api.Common?color=fe5001&label=Common)](https://www.nuget.org/packages/ArmoniK.Api.Common) | |
+|  | [![Nuget version](https://img.shields.io/nuget/v/ArmoniK.Api.Common.Channel?color=fe5001&label=Common.Channel)](https://www.nuget.org/packages/ArmoniK.Api.Common.Channel) |  |
+|  | [![Nuget version](https://img.shields.io/nuget/v/ArmoniK.Api.Core?color=fe5001&label=Core)](https://www.nuget.org/packages/ArmoniK.Api.Core) |  |
+| | [![Nuget version](https://img.shields.io/nuget/v/ArmoniK.Api.Worker?color=fe5001&label=Worker)](https://www.nuget.org/packages/ArmoniK.Api.Worker) | |
+
 This project is part of the [ArmoniK](https://github.com/aneoconsulting/ArmoniK) project.
-In particular it is a consitutent of its [Core](https://github.com/aneoconsulting/ArmoniK.Core)
+In particular it is a constituent of its [Core](https://github.com/aneoconsulting/ArmoniK.Core)
 component which, among its main functionalities, implements several gRPC services aiming to
 provide a user with a robust task scheduler for a high throughput computing application.
 
-The .proto files in the directory [./Protos/V1](https://github.com/aneoconsulting/ArmoniK.Api/tree/main/Protos/V1) 
+The .proto files in the directory [./Protos/V1](https://github.com/aneoconsulting/ArmoniK.Api/tree/main/Protos/V1)
 provide the core data model and functionalities for ArmoniK and are used to generate the different SDKs.
 
 ## Documentation


### PR DESCRIPTION
In order to easily find packages on registry, I added links to them using nice bagde. These are also used in other packages like "order-github-changelog" or "generate-next-version".