### PR TITLE
chore: update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,25 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    "group:allNonMajor",
+    ":semanticCommits"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePrefixes": [
+        "ArmoniK"
+      ],
+      "groupName": "release packages Armonik"
+    },
+    {
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "excludePackagePrefixes": [
+        "ArmoniK"
+      ],
+      "groupName": "other dependencies"
+    }
   ]
 }


### PR DESCRIPTION
Configured Renovate to track dependencies in the repository.

   - Put all the ArmoniK packages in one PR and all non-ArmoniK packages in another PR