### PR TITLE
chore: group renovate's pr using datasources

### DIFF
--- a/.github/workflows/publish-edge.yml
+++ b/.github/workflows/publish-edge.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   version:
-    if: github.actor != 'renovate[bot]' || github.repository_owner != 'aneoconsultingfr'
+    if: github.actor != 'renovate[bot]' && github.repository_owner == 'aneoconsultingfr'
     runs-on: ubuntu-latest
     name: Version
     steps:
@@ -24,7 +24,7 @@ jobs:
       # Print to the summary
         run: echo "VERSION=$(npx @aneoconsultingfr/generate-next-version@latest --edge)" >> $GITHUB_STEP_SUMMARY
   tests:
-    if: github.actor != 'renovate[bot]' || github.repository_owner != 'aneoconsultingfr'
+    if: github.actor != 'renovate[bot]' && github.repository_owner == 'aneoconsultingfr'
     name: Tests
     runs-on: ubuntu-latest
     strategy:
@@ -179,7 +179,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
   release-python-package:
-    if: github.actor != 'renovate[bot]' || github.repository_owner != 'aneoconsultingfr'
+    if: github.actor != 'renovate[bot]' && github.repository_owner == 'aneoconsultingfr'
     name: Release Python Package
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/publish-edge.yml
+++ b/.github/workflows/publish-edge.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   version:
+    if: github.actor != 'renovate[bot]' || github.repository_owner != 'aneoconsultingfr'
     runs-on: ubuntu-latest
     name: Version
     steps:
@@ -23,6 +24,7 @@ jobs:
       # Print to the summary
         run: echo "VERSION=$(npx @aneoconsultingfr/generate-next-version@latest --edge)" >> $GITHUB_STEP_SUMMARY
   tests:
+    if: github.actor != 'renovate[bot]' || github.repository_owner != 'aneoconsultingfr'
     name: Tests
     runs-on: ubuntu-latest
     strategy:
@@ -177,6 +179,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
   release-python-package:
+    if: github.actor != 'renovate[bot]' || github.repository_owner != 'aneoconsultingfr'
     name: Release Python Package
     runs-on: ubuntu-latest
     defaults:

--- a/renovate.json
+++ b/renovate.json
@@ -3,23 +3,24 @@
   "extends": [
     "config:base",
     "group:allNonMajor",
-    ":semanticCommits"
+    ":semanticCommitTypeAll(chore)",
+    "helpers:pinGitHubActionDigests"
   ],
+  "rangeStrategy": "bump",
   "packageRules": [
     {
-      "matchPackagePrefixes": [
-        "ArmoniK"
-      ],
-      "groupName": "release packages Armonik"
+      "groupName": "npm packages",
+      "groupSlug": "npm",
+      "matchDatasources": [
+        "npm"
+      ]
     },
     {
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "excludePackagePrefixes": [
-        "ArmoniK"
-      ],
-      "groupName": "other dependencies"
-    }
+      "groupName": "github actions",
+      "groupSlug": "github-actions",
+      "matchDatasources": [
+        "github-tags"
+      ]
+    },
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,6 @@
       "matchDatasources": [
         "github-tags"
       ]
-    },
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,20 @@
       ]
     },
     {
+      "groupName": "nuget packages",
+      "groupSlug": "nuget",
+      "matchDatasources": [
+        "nuget"
+      ]
+    },
+    {
+      "groupName": "python packages",
+      "groupSlug": "pypi",
+      "matchDatasources": [
+        "pypi"
+      ]
+    },
+    {
       "groupName": "github actions",
       "groupSlug": "github-actions",
       "matchDatasources": [


### PR DESCRIPTION
I group renovate PR using [datasources](https://docs.renovatebot.com/modules/datasource/). This will simplify the review and the merge.

For security reasons, I use "helpers:pinGitHubActionDigests" to pin actions to a specific commit.

An example of the config: https://github.com/esoubiran-aneo/ArmoniK.Api