### PR TITLE
chore: split npm packages with docs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,16 @@
       ]
     },
     {
+      "groupName": "docs npm packages",
+      "groupSlug": "docs-npm",
+      "matchPaths": [
+        ".docs/**"
+      ],
+      "matchDatasources": [
+        "npm"
+      ]
+    },
+    {
       "groupName": "nuget packages",
       "groupSlug": "nuget",
       "matchDatasources": [
@@ -35,6 +45,6 @@
       "matchDatasources": [
         "github-tags"
       ]
-    }
+    },
   ]
 }


### PR DESCRIPTION
In order to have easier PR to merge, we need to split renovate npm rules into packages for the application and packages for the docs.