### PR TITLE
chore: update renovate config to split npm

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,26 @@
       ]
     },
     {
+      "groupName": " angular npm packages",
+      "groupSlug": "angular-npm",
+      "matchPaths": [
+        "packages/angular/**"
+      ],
+      "matchDatasources": [
+        "npm"
+      ]
+    },
+    {
+      "groupName": " web npm packages",
+      "groupSlug": "web-npm",
+      "matchPaths": [
+        "packages/web/**"
+      ],
+      "matchDatasources": [
+        "npm"
+      ]
+    },
+    {
       "groupName": "nuget packages",
       "groupSlug": "nuget",
       "matchDatasources": [


### PR DESCRIPTION
In order to easily merge PR from renovate, we need to split npm packages depending of the projet.

You can find an example of the result here https://github.com/esoubiran-aneo/ArmoniK.Api/issues/3