### PR TITLE
ci: fix concurrency issue in lint pr

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -9,10 +9,6 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha }}
-  cancel-in-progress: true
-
 jobs:
   main:
     permissions:

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -10,7 +10,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
The CI "Lint PR" is very fast and we have a concurrency issue. I thing that we case easily remove the cancel-in-progress to avoid that main cancel a branch.

see https://github.com/aneoconsulting/ArmoniK.Api/actions/workflows/semantic-pull-request.yml to view some Actions cancelled witout reason.