### PR TITLE
ci: release edge on tag

### DIFF
--- a/.github/workflows/publish-edge.yml
+++ b/.github/workflows/publish-edge.yml
@@ -13,16 +13,20 @@ jobs:
     if: github.actor != 'renovate[bot]' && github.repository_owner == 'aneoconsulting'
     runs-on: ubuntu-latest
     name: Version
+    outputs:
+      version: ${{ steps.genver.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-
       - name: Generate Version
+        id: genver
+        run: echo "VERSION=$(npx @aneoconsultingfr/generate-next-version@latest --edge)" >> "$GITHUB_OUTPUT"
+      - name: Summary version
       # Print to the summary
-        run: echo "VERSION=$(npx @aneoconsultingfr/generate-next-version@latest --edge)" >> $GITHUB_STEP_SUMMARY
+        run: echo "VERSION={{ steps.genver.outputs.version }}" >> $GITHUB_STEP_SUMMARY
   tests:
     if: github.actor != 'renovate[bot]' && github.repository_owner == 'aneoconsulting'
     name: Tests
@@ -59,7 +63,8 @@ jobs:
           reporter: dotnet-trx
 
   release-csharp-packages:
-    needs: [tests]
+    needs: [tests, version]
+    if: contains( ${{ needs.version.outputs.version }} , "-")
     name: Release C# Packages
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -85,7 +90,7 @@ jobs:
           dotnet-version: 6.x
 
       - name: Generate Version
-        run: echo "VERSION=$(npx @aneoconsultingfr/generate-next-version@latest --edge)" >> $GITHUB_ENV
+        run: echo "VERSION=${{ needs.version.outputs.version }}" >> $GITHUB_ENV
 
       - name: Build the package
         run: |
@@ -100,7 +105,8 @@ jobs:
         run: dotnet nuget push /tmp/packages/ArmoniK.Api.*.nupkg -k ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
   release-angular-package:
-    if: github.ref == 'refs/heads/main'
+    needs: [version]
+    if: github.ref == 'refs/heads/main' && contains( ${{ needs.version.outputs.version }} , "-")
     name: Release Angular Package
     runs-on: ubuntu-latest
     steps:
@@ -127,7 +133,7 @@ jobs:
         run: cd packages/angular && nr proto:generate:linux
 
       - name: Update version
-        run: nr update-versions $(npx @aneoconsultingfr/generate-next-version@latest --edge)
+        run: nr update-versions ${{ needs.version.outputs.version }}
 
       - name: Build package
         run: cd packages/angular && nr build
@@ -138,7 +144,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
   release-web-package:
-    if: github.ref == 'refs/heads/main'
+    needs: [version]
+    if: github.ref == 'refs/heads/main' && contains( ${{ needs.version.outputs.version }} , "-")
     name: Release Web Package
     runs-on: ubuntu-latest
     steps:
@@ -171,7 +178,7 @@ jobs:
         run: cd packages/web && nr build
 
       - name: Update version
-        run: nr update-versions $(npx @aneoconsultingfr/generate-next-version@latest --edge)
+        run: nr update-versions ${{ needs.version.outputs.version }}
 
       - name: Release package
         run: nr ci:publish-edge web
@@ -179,7 +186,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
   release-python-package:
-    if: github.actor != 'renovate[bot]' && github.repository_owner == 'aneoconsulting'
+    needs: [version]
+    if: github.actor != 'renovate[bot]' && github.repository_owner == 'aneoconsulting' && contains( ${{ needs.version.outputs.version }} , "-")
     name: Release Python Package
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/publish-edge.yml
+++ b/.github/workflows/publish-edge.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  version:
+  genversion:
     if: github.actor != 'renovate[bot]' && github.repository_owner == 'aneoconsulting'
     runs-on: ubuntu-latest
     name: Version
@@ -26,7 +26,20 @@ jobs:
         run: echo "VERSION=$(npx @aneoconsultingfr/generate-next-version@latest --edge)" >> "$GITHUB_OUTPUT"
       - name: Summary version
       # Print to the summary
-        run: echo "VERSION={{ steps.genver.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+        run: echo "VERSION=${{ steps.genver.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+
+  version:
+    if: contains( ${{ needs.genversion.outputs.version }} , "-")
+    needs: [genversion]
+    runs-on: ubuntu-latest
+    name: Check Version
+    outputs:
+      version: ${{ steps.outver.outputs.version }}
+    steps:
+      - name: Output Version
+        id: outver
+        run: echo "VERSION=${{ needs.genversion.outputs.version }}" >> "$GITHUB_OUTPUT"
+
   tests:
     if: github.actor != 'renovate[bot]' && github.repository_owner == 'aneoconsulting'
     name: Tests
@@ -64,7 +77,6 @@ jobs:
 
   release-csharp-packages:
     needs: [tests, version]
-    if: contains( ${{ needs.version.outputs.version }} , "-")
     name: Release C# Packages
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -89,16 +101,13 @@ jobs:
         with:
           dotnet-version: 6.x
 
-      - name: Generate Version
-        run: echo "VERSION=${{ needs.version.outputs.version }}" >> $GITHUB_ENV
-
       - name: Build the package
         run: |
           dotnet build ${{ matrix.package }} -c Release
 
       - name: Pack the package
         run: |
-          dotnet pack ${{ matrix.package }} -c Release -o /tmp/packages -p:PackageVersion=$VERSION
+          dotnet pack ${{ matrix.package }} -c Release -o /tmp/packages -p:PackageVersion=${{ needs.version.outputs.version }}
           ls /tmp/packages
 
       - name: Push the package
@@ -106,7 +115,7 @@ jobs:
 
   release-angular-package:
     needs: [version]
-    if: github.ref == 'refs/heads/main' && contains( ${{ needs.version.outputs.version }} , "-")
+    if: github.ref == 'refs/heads/main'
     name: Release Angular Package
     runs-on: ubuntu-latest
     steps:
@@ -145,7 +154,7 @@ jobs:
 
   release-web-package:
     needs: [version]
-    if: github.ref == 'refs/heads/main' && contains( ${{ needs.version.outputs.version }} , "-")
+    if: github.ref == 'refs/heads/main'
     name: Release Web Package
     runs-on: ubuntu-latest
     steps:
@@ -187,7 +196,7 @@ jobs:
 
   release-python-package:
     needs: [version]
-    if: github.actor != 'renovate[bot]' && github.repository_owner == 'aneoconsulting' && contains( ${{ needs.version.outputs.version }} , "-")
+    if: github.actor != 'renovate[bot]' && github.repository_owner == 'aneoconsulting'
     name: Release Python Package
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
If the edge package to release should have been a normal release and not an edge package, prevents the publish edge from publishing