### PR TITLE
fix: formatter and fmt installation

### DIFF
--- a/packages/cpp/ArmoniK.Api.Common/CMakeLists.txt
+++ b/packages/cpp/ArmoniK.Api.Common/CMakeLists.txt
@@ -32,6 +32,7 @@ set(CMAKE_FIND_DEBUG_MODE FALSE)
 find_package(Protobuf REQUIRED)
 find_package(gRPC CONFIG REQUIRED)
 find_package(Threads)
+find_package(fmt CONFIG REQUIRED)
 
 include(FetchContent)
 
@@ -45,12 +46,6 @@ if(NOT simdjson_POPULATED)
     FetchContent_Populate(simdjson)
 endif()
 
-FetchContent_Declare(
-        fmt
-        URL https://github.com/fmtlib/fmt/archive/refs/tags/10.0.0.tar.gz
-)
-FetchContent_MakeAvailable(fmt)
-
 set(CMAKE_FIND_DEBUG_MODE FALSE)
 
 SET(SOURCES_FILES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/source")
@@ -63,8 +58,7 @@ file(MAKE_DIRECTORY ${PROJECT_BUILD_DIR})
 
 add_library(${PROJECT_NAME} STATIC ${PROTO_GENERATED_FILES} ${SRC_CLIENT_FILES} ${HEADER_CLIENT_FILES} ${simdjson_SOURCE_DIR}/singleheader/simdjson.cpp ${simdjson_SOURCE_DIR}/singleheader/simdjson.h)
 
-target_link_libraries(${PROJECT_NAME} PUBLIC protobuf::libprotobuf gRPC::grpc++_unsecure)
-target_link_libraries(${PROJECT_NAME} PRIVATE fmt::fmt)
+target_link_libraries(${PROJECT_NAME} PUBLIC protobuf::libprotobuf gRPC::grpc++_unsecure fmt::fmt)
 target_compile_definitions(${PROJECT_NAME} PUBLIC API_COMMON_NAMESPACE=${NAMESPACE})
 
 setup_options(${PROJECT_NAME})

--- a/packages/cpp/ArmoniK.Api.Common/source/logger/formatter.cpp
+++ b/packages/cpp/ArmoniK.Api.Common/source/logger/formatter.cpp
@@ -94,7 +94,7 @@ public:
 };
 
 std::unique_ptr<IFormatter> formatter_clef() { return std::make_unique<ClefFormatter>(); }
-std::unique_ptr<IFormatter> formatter_clef(bool styling) { return std::make_unique<PlainFormatter>(styling); }
+std::unique_ptr<IFormatter> formatter_plain(bool styling) { return std::make_unique<PlainFormatter>(styling); }
 
 // Interface destructor
 IFormatter::~IFormatter() = default;

--- a/packages/cpp/tools/BuildEnv.Dockerfile
+++ b/packages/cpp/tools/BuildEnv.Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && DEBIAN_FRONTEND="noninteractive" TZ="Europe/London" apt-ge
     libgrpc-dev \
     libgrpc++-dev \
     libprotobuf-dev \
+    libfmt-dev \
 	&& apt-get clean
 
 ENV protobuf_BUILD_TESTS=OFF

--- a/packages/cpp/tools/Dockerfile.ubuntu
+++ b/packages/cpp/tools/Dockerfile.ubuntu
@@ -12,7 +12,8 @@ RUN apt-get update && DEBIAN_FRONTEND="noninteractive" TZ="Europe/London" apt-ge
     protobuf-compiler-grpc \
     grpc-proto \
     libgrpc-dev \
-    libgrpc++-dev
+    libgrpc++-dev \
+    libfmt-dev
 
 # Set environment variables for protobuf
 ENV protobuf_BUILD_TESTS=OFF

--- a/packages/cpp/tools/Dockerfile.worker
+++ b/packages/cpp/tools/Dockerfile.worker
@@ -22,7 +22,8 @@ RUN apk update && apk add --no-cache \
     grpc \
     grpc-dev \
     protobuf \
-    protobuf-dev
+    protobuf-dev \
+    libfmt-dev
 
 # Update the PATH environment variable to include the gRPC libraries and binaries
 ENV LD_LIBRARY_PATH="/app/install/lib:$LD_LIBRARY_PATH"


### PR DESCRIPTION
Due to license constraints, we cannot ship out the fmt library. Thus a fetchcontent is not possible
Also found an issue that appears only at link time (formatter_plain not defined)