### PR TITLE
chore: update gen csharp path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,11 +2,11 @@
   "protoc": {
     "compile_on_save": true,
     "options": [
-        "--proto_path=${workspaceRoot}/Protos/V1",
-        "--csharp_out=${workspaceRoot}/gen/csharp"
+      "--proto_path=${workspaceRoot}/Protos/V1",
+      "--csharp_out=${workspaceRoot}/packages/csharp/generated/"
     ]
-},
-"cSpell.words": [
-  "Armoni"
-]
+  },
+  "cSpell.words": [
+    "Armoni"
+  ]
 }


### PR DESCRIPTION
fix #235

I move the folder under `packages/csharp` in order to have the same structure as `angular` and to let the ability to add it for other languages in the future.
