### PR TITLE
feat: send data between agent and worker through files instead of stream-based requests

### DIFF
--- a/Protos/V1/agent_common.proto
+++ b/Protos/V1/agent_common.proto
@@ -47,41 +47,17 @@ message CreateTaskReply {
   string communication_token = 4; /** Communication token received by the worker during task processing */
 }
 
+// Request to retrieve data
 message DataRequest {
   string communication_token = 1; /** Communication token received by the worker during task processing */
-  string key = 2;
+  // Id of the result that will be retrieved
+  string result_id = 2;
 }
 
-message DataReply {
-  message Init {
-    string key = 1;
-    oneof has_result {
-      DataChunk data = 2;
-      string error = 3;
-    }
-  }
-  string communication_token = 1; /** Communication token received by the worker during task processing */
-  oneof type {
-    Init init = 2;
-    DataChunk data = 3;
-    string error = 4;
-  }
-}
-
-message Result {
-  oneof type {
-    InitKeyedDataStream init = 1;
-    DataChunk data = 2;
-  }
-  string communication_token = 3; /** Communication token received by the worker during task processing */
-}
-
-message ResultReply {
-  string communication_token = 3; /** Communication token received by the worker during task processing */
-  oneof type {
-    Empty Ok = 1;
-    string Error = 2;
-  }
+// Response when data is available in the shared folder
+message DataResponse {
+  // Id of the result that will be retrieved
+  string result_id = 2;
 }
 
 /*
@@ -156,7 +132,7 @@ message SubmitTasksResponse {
 }
 
 /*
-* Request for creating results without data
+* Request for creating results with data
 */
 message CreateResultsRequest {
   /**
@@ -180,11 +156,9 @@ message CreateResultsResponse {
 }
 
 /*
-* Request for uploading results data through stream.
-* Data must be sent in multiple chunks.
-* Only one result can be uploaded.
+* Request for notifying results data are available in files.
 */
-message UploadResultDataRequest {
+message NotifyResultDataRequest {
   /**
   * The metadata to identify the result to update.
   */
@@ -195,23 +169,15 @@ message UploadResultDataRequest {
 
   /**
   * The possible messages that constitute a UploadResultDataRequest
-  * They should be sent in the following order:
-  * - id
-  * - data_chunk (stream can have multiple data_chunk messages that represent data divided in several parts)
-  *
-  * Data chunk cannot exceed the size returned by the GetServiceConfiguration rpc method
   */
-  oneof type {
-    ResultIdentifier id = 1; /** The identifier of the result to which add data. */
-    bytes data_chunk = 2; /** A chunk of data. */
-  }
+  repeated ResultIdentifier ids = 1; /** The identifier of the result to which add data. */
   string communication_token = 4; /** Communication token received by the worker during task processing */
 }
 
 /*
-* Response for uploading data with stream for result
+* Response for notifying data file availability for result
+* Received when data are successfully copied to the ObjectStorage
 */
-message UploadResultDataResponse {
-  string result_id = 1; /** The Id of the result to which data were added */
-  string communication_token = 2; /** Communication token received by the worker during task processing */
+message NotifyResultDataResponse {
+  repeated string result_ids = 1; /** The Id of the result to which data were added */
 }

--- a/Protos/V1/agent_service.proto
+++ b/Protos/V1/agent_service.proto
@@ -7,6 +7,8 @@ import "agent_common.proto";
 option csharp_namespace = "ArmoniK.Api.gRPC.V1.Agent";
 
 service Agent {
+  rpc CreateTask(stream CreateTaskRequest) returns (CreateTaskReply);
+
   /**
    * Create the metadata of multiple results at once
    * Data have to be uploaded separately
@@ -19,18 +21,35 @@ service Agent {
   rpc CreateResults(CreateResultsRequest) returns (CreateResultsResponse) {}
 
   /**
-    * Upload data for result with stream
+    * Notify Agent that a data file representing the Result to upload is available in the shared folder
+    * The name of the file should be the result id
+    * Blocks until data are stored in Object Storage
     */
-  rpc UploadResultData(stream UploadResultDataRequest) returns (UploadResultDataResponse) {}
+  rpc NotifyResultData(NotifyResultDataRequest) returns (NotifyResultDataResponse) {}
 
   /**
    * Create tasks metadata and submit task for processing.
    */
   rpc SubmitTasks(SubmitTasksRequest) returns (SubmitTasksResponse) {}
 
-  rpc CreateTask(stream CreateTaskRequest) returns (CreateTaskReply);
-  rpc GetResourceData(DataRequest) returns (stream DataReply);
-  rpc GetCommonData(DataRequest) returns (stream DataReply);
-  rpc GetDirectData(DataRequest) returns (stream DataReply);
-  rpc SendResult(stream Result) returns (ResultReply);
+  /**
+    * Retrieve Resource Data from the Agent
+    * Data is stored in the shared folder between Agent and Worker as a file with the result id as name
+    * Blocks until data are available in the shared folder
+    */
+  rpc GetResourceData(DataRequest) returns (DataResponse);
+
+  /**
+    * Retrieve Resource Data from the Agent
+    * Data is stored in the shared folder between Agent and Worker as a file with the result id as name
+    * Blocks until data are available in the shared folder
+    */
+  rpc GetCommonData(DataRequest) returns (DataResponse);
+
+  /**
+    * Retrieve Resource Data from the Agent
+    * Data is stored in the shared folder between Agent and Worker as a file with the result id as name
+    * Blocks until data are available in the shared folder
+    */
+  rpc GetDirectData(DataRequest) returns (DataResponse);
 }

--- a/Protos/V1/worker_common.proto
+++ b/Protos/V1/worker_common.proto
@@ -7,35 +7,19 @@ import "objects.proto";
 option csharp_namespace = "ArmoniK.Api.gRPC.V1.Worker";
 
 message ProcessRequest {
-  message ComputeRequest {
-    message InitRequest {
-      Configuration configuration = 1;
-      string session_id = 2;
-      string task_id = 3;
-      TaskOptions task_options = 4;
-      repeated string expected_output_keys = 5;
-      DataChunk payload = 6;
-    }
-    message InitData {
-      oneof type {
-        string key = 1;
-        bool last_data = 2;
-      }
-    }
-    oneof type {
-      InitRequest init_request = 1;
-      DataChunk payload = 2;
-      InitData init_data = 3;
-      DataChunk data = 4;
-    }
-  }
   string communication_token = 1;
-  ComputeRequest compute = 2;
+  string session_id = 2;
+  string task_id = 3;
+  TaskOptions task_options = 4;
+  repeated string expected_output_keys = 5;
+  string payload_id = 6;
+  repeated string data_dependencies = 7;
+  string data_folder = 8;
+  Configuration configuration = 9;
 }
 
 message ProcessReply {
-  string communication_token = 1;
-  Output output = 2;
+  Output output = 1;
 }
 
 message HealthCheckReply {

--- a/Protos/V1/worker_service.proto
+++ b/Protos/V1/worker_service.proto
@@ -8,6 +8,6 @@ import "worker_common.proto";
 option csharp_namespace = "ArmoniK.Api.gRPC.V1.Worker";
 
 service Worker {
-  rpc Process(stream ProcessRequest) returns (ProcessReply);
+  rpc Process(ProcessRequest) returns (ProcessReply);
   rpc HealthCheck(Empty) returns (HealthCheckReply);
 }

--- a/packages/csharp/ArmoniK.Api.Mock/Services/Agent.cs
+++ b/packages/csharp/ArmoniK.Api.Mock/Services/Agent.cs
@@ -14,9 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Linq;
 using System.Threading.Tasks;
 
-using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Agent;
 
 using Grpc.Core;
@@ -38,63 +38,6 @@ public class Agent : gRPC.V1.Agent.Agent.AgentBase
 
   /// <inheritdocs />
   [Count]
-  public override async Task GetCommonData(DataRequest                    request,
-                                           IServerStreamWriter<DataReply> responseStream,
-                                           ServerCallContext              context)
-    => await responseStream.WriteAsync(new DataReply
-                                       {
-                                         Data = new DataChunk
-                                                {
-                                                  DataComplete = true,
-                                                },
-                                       })
-                           .ConfigureAwait(false);
-
-  /// <inheritdocs />
-  [Count]
-  public override async Task GetDirectData(DataRequest                    request,
-                                           IServerStreamWriter<DataReply> responseStream,
-                                           ServerCallContext              context)
-    => await responseStream.WriteAsync(new DataReply
-                                       {
-                                         Data = new DataChunk
-                                                {
-                                                  DataComplete = true,
-                                                },
-                                       })
-                           .ConfigureAwait(false);
-
-  /// <inheritdocs />
-  [Count]
-  public override async Task GetResourceData(DataRequest                    request,
-                                             IServerStreamWriter<DataReply> responseStream,
-                                             ServerCallContext              context)
-    => await responseStream.WriteAsync(new DataReply
-                                       {
-                                         Data = new DataChunk
-                                                {
-                                                  DataComplete = true,
-                                                },
-                                       })
-                           .ConfigureAwait(false);
-
-  /// <inheritdocs />
-  [Count]
-  public override async Task<ResultReply> SendResult(IAsyncStreamReader<Result> requestStream,
-                                                     ServerCallContext          context)
-  {
-    await foreach (var _ in requestStream.ReadAllAsync())
-    {
-    }
-
-    return new ResultReply
-           {
-             Ok = new Empty(),
-           };
-  }
-
-  /// <inheritdocs />
-  [Count]
   public override Task<CreateResultsMetaDataResponse> CreateResultsMetaData(CreateResultsMetaDataRequest request,
                                                                             ServerCallContext            context)
     => Task.FromResult(new CreateResultsMetaDataResponse
@@ -111,21 +54,6 @@ public class Agent : gRPC.V1.Agent.Agent.AgentBase
                          CommunicationToken = request.CommunicationToken,
                        });
 
-  /// <inheritdocs />
-  [Count]
-  public override async Task<UploadResultDataResponse> UploadResultData(IAsyncStreamReader<UploadResultDataRequest> requestStream,
-                                                                        ServerCallContext                           context)
-  {
-    await foreach (var _ in requestStream.ReadAllAsync())
-    {
-    }
-
-    return new UploadResultDataResponse
-           {
-             ResultId           = "result-id",
-             CommunicationToken = "communication-token",
-           };
-  }
 
   /// <inheritdocs />
   [Count]
@@ -134,5 +62,44 @@ public class Agent : gRPC.V1.Agent.Agent.AgentBase
     => Task.FromResult(new CreateResultsResponse
                        {
                          CommunicationToken = request.CommunicationToken,
+                       });
+
+  /// <inheritdocs />
+  [Count]
+  public override Task<DataResponse> GetCommonData(DataRequest       request,
+                                                   ServerCallContext context)
+    => Task.FromResult(new DataResponse
+                       {
+                         ResultId = request.ResultId,
+                       });
+
+  /// <inheritdocs />
+  [Count]
+  public override Task<DataResponse> GetDirectData(DataRequest       request,
+                                                   ServerCallContext context)
+    => Task.FromResult(new DataResponse
+                       {
+                         ResultId = request.ResultId,
+                       });
+
+  /// <inheritdocs />
+  [Count]
+  public override Task<DataResponse> GetResourceData(DataRequest       request,
+                                                     ServerCallContext context)
+    => Task.FromResult(new DataResponse
+                       {
+                         ResultId = request.ResultId,
+                       });
+
+  /// <inheritdocs />
+  [Count]
+  public override Task<NotifyResultDataResponse> NotifyResultData(NotifyResultDataRequest request,
+                                                                  ServerCallContext       context)
+    => Task.FromResult(new NotifyResultDataResponse
+                       {
+                         ResultIds =
+                         {
+                           request.Ids.Select(identifier => identifier.ResultId),
+                         },
                        });
 }

--- a/packages/csharp/ArmoniK.Api.Worker/Worker/ITaskHandler.cs
+++ b/packages/csharp/ArmoniK.Api.Worker/Worker/ITaskHandler.cs
@@ -32,6 +32,9 @@ using JetBrains.Annotations;
 
 namespace ArmoniK.Api.Worker.Worker;
 
+/// <summary>
+///   Higher level interface to implement to create tasks and populate results
+/// </summary>
 [PublicAPI]
 public interface ITaskHandler : IAsyncDisposable
 {
@@ -68,7 +71,7 @@ public interface ITaskHandler : IAsyncDisposable
   /// <summary>
   ///   The configuration parameters for the interaction with ArmoniK.
   /// </summary>
-  Configuration? Configuration { get; }
+  Configuration Configuration { get; }
 
   /// <summary>
   ///   This method allows to create subtasks.
@@ -140,15 +143,4 @@ public interface ITaskHandler : IAsyncDisposable
   ///   The task submission response
   /// </returns>
   Task<CreateResultsResponse> CreateResultsAsync(IEnumerable<CreateResultsRequest.Types.ResultCreate> results);
-
-  /// <summary>
-  ///   Upload data to an existing result
-  /// </summary>
-  /// <param name="key">The result Id</param>
-  /// <param name="data">The data to submit for the given result</param>
-  /// <returns>
-  ///   The upload data response
-  /// </returns>
-  Task<UploadResultDataResponse> UploadResultData(string key,
-                                                  byte[] data);
 }

--- a/packages/csharp/ArmoniK.Api.Worker/Worker/TaskHandler.cs
+++ b/packages/csharp/ArmoniK.Api.Worker/Worker/TaskHandler.cs
@@ -38,7 +38,7 @@ using Microsoft.Extensions.Logging;
 
 namespace ArmoniK.Api.Worker.Worker;
 
-public class ReadFromFolderDict : IReadOnlyDictionary<string, byte[]>
+internal class ReadFromFolderDict : IReadOnlyDictionary<string, byte[]>
 {
   private readonly Dictionary<string, byte[]> data_ = new();
   private readonly IList<string>              dataDependencies_;

--- a/packages/csharp/ArmoniK.Api.Worker/Worker/TaskHandler.cs
+++ b/packages/csharp/ArmoniK.Api.Worker/Worker/TaskHandler.cs
@@ -22,7 +22,10 @@
 // limitations under the License.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,77 +34,147 @@ using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Agent;
 using ArmoniK.Api.gRPC.V1.Worker;
 
-using Google.Protobuf;
-
-using Grpc.Core;
-
 using Microsoft.Extensions.Logging;
 
 namespace ArmoniK.Api.Worker.Worker;
+
+public class ReadFromFolderDict : IReadOnlyDictionary<string, byte[]>
+{
+  private readonly Dictionary<string, byte[]> data_ = new();
+  private readonly IList<string>              dataDependencies_;
+  private readonly string                     folder_;
+
+  public ReadFromFolderDict(string        folder,
+                            IList<string> dataDependencies)
+  {
+    folder_           = folder;
+    dataDependencies_ = dataDependencies;
+  }
+
+  /// <inheritdoc />
+  public IEnumerator<KeyValuePair<string, byte[]>> GetEnumerator()
+    => dataDependencies_.Select(key => new KeyValuePair<string, byte[]>(key,
+                                                                        this[key]))
+                        .GetEnumerator();
+
+  IEnumerator IEnumerable.GetEnumerator()
+    => GetEnumerator();
+
+  /// <inheritdoc />
+  public int Count
+    => dataDependencies_.Count;
+
+  /// <inheritdoc />
+  public bool ContainsKey(string key)
+    => dataDependencies_.Contains(key);
+
+  /// <inheritdoc />
+  public bool TryGetValue(string                            key,
+                          [MaybeNullWhen(false)] out byte[] value)
+  {
+    var r = ContainsKey(key);
+    if (r)
+    {
+      value = this[key];
+      return r;
+    }
+
+    value = null;
+    return r;
+  }
+
+  /// <inheritdoc />
+  public byte[] this[string key]
+  {
+    get
+    {
+      if (data_.TryGetValue(key,
+                            out var value))
+      {
+        return value;
+      }
+
+      var bytes = File.ReadAllBytes(Path.Combine(folder_,
+                                                 key));
+      data_.Add(key,
+                bytes);
+      return bytes;
+    }
+  }
+
+  /// <inheritdoc />
+  public IEnumerable<string> Keys
+    => dataDependencies_;
+
+  /// <inheritdoc />
+  public IEnumerable<byte[]> Values
+    => dataDependencies_.Select(key => this[key]);
+}
 
 public class TaskHandler : ITaskHandler
 {
   private readonly CancellationToken    cancellationToken_;
   private readonly Agent.AgentClient    client_;
+  private readonly string               folder_;
   private readonly ILogger<TaskHandler> logger_;
   private readonly ILoggerFactory       loggerFactory_;
 
-  private readonly IAsyncStreamReader<ProcessRequest> requestStream_;
 
-  private IReadOnlyDictionary<string, byte[]>? dataDependencies_;
-  private IList<string>?                       expectedResults_;
-
-  private bool isInitialized_;
-
-  private byte[]?      payload_;
-  private string?      sessionId_;
-  private string?      taskId_;
-  private TaskOptions? taskOptions_;
-  private string?      token_;
-
-
-  private TaskHandler(IAsyncStreamReader<ProcessRequest> requestStream,
-                      Agent.AgentClient                  client,
-                      CancellationToken                  cancellationToken,
-                      ILoggerFactory                     loggerFactory)
+  public TaskHandler(ProcessRequest    processRequest,
+                     Agent.AgentClient client,
+                     ILoggerFactory    loggerFactory,
+                     CancellationToken cancellationToken)
   {
-    requestStream_     = requestStream;
     client_            = client;
     cancellationToken_ = cancellationToken;
     loggerFactory_     = loggerFactory;
     logger_            = loggerFactory.CreateLogger<TaskHandler>();
+    folder_            = processRequest.DataFolder;
+
+    Token           = processRequest.CommunicationToken;
+    SessionId       = processRequest.SessionId;
+    TaskId          = processRequest.TaskId;
+    TaskOptions     = processRequest.TaskOptions;
+    ExpectedResults = processRequest.ExpectedOutputKeys;
+    DataDependencies = new ReadFromFolderDict(processRequest.DataFolder,
+                                              processRequest.DataDependencies);
+    Configuration = processRequest.Configuration;
+
+
+    try
+    {
+      Payload = File.ReadAllBytes(Path.Combine(processRequest.DataFolder,
+                                               processRequest.PayloadId));
+    }
+    catch (ArgumentException e)
+    {
+      throw new InvalidOperationException("Payload not found",
+                                          e);
+    }
   }
 
-  public string Token
-    => token_ ?? throw TaskHandlerException(nameof(Token));
+  public string Token { get; }
 
   /// <inheritdoc />
-  public string SessionId
-    => sessionId_ ?? throw TaskHandlerException(nameof(SessionId));
+  public Configuration Configuration { get; }
 
   /// <inheritdoc />
-  public string TaskId
-    => taskId_ ?? throw TaskHandlerException(nameof(TaskId));
+  public string SessionId { get; }
 
   /// <inheritdoc />
-  public TaskOptions TaskOptions
-    => taskOptions_ ?? throw TaskHandlerException(nameof(TaskOptions));
+  public string TaskId { get; }
 
   /// <inheritdoc />
-  public byte[] Payload
-    => payload_ ?? throw TaskHandlerException(nameof(Payload));
+  public TaskOptions TaskOptions { get; }
 
   /// <inheritdoc />
-  public IReadOnlyDictionary<string, byte[]> DataDependencies
-    => dataDependencies_ ?? throw TaskHandlerException(nameof(DataDependencies));
+  public byte[] Payload { get; }
 
   /// <inheritdoc />
-  public IList<string> ExpectedResults
-    => expectedResults_ ?? throw TaskHandlerException(nameof(ExpectedResults));
+  public IReadOnlyDictionary<string, byte[]> DataDependencies { get; }
 
-  // this ? was added due to the initialization pattern with the Create method
   /// <inheritdoc />
-  public Configuration? Configuration { get; private set; }
+  public IList<string> ExpectedResults { get; }
 
   /// <inheritdoc />
   public async Task<CreateTaskReply> CreateTasksAsync(IEnumerable<TaskRequest> tasks,
@@ -144,7 +217,7 @@ public class TaskHandler : ITaskHandler
                                                   {
                                                     results,
                                                   },
-                                                  SessionId = sessionId_,
+                                                  SessionId = SessionId,
                                                 })
                     .ConfigureAwait(false);
 
@@ -153,70 +226,30 @@ public class TaskHandler : ITaskHandler
   public async Task SendResult(string key,
                                byte[] data)
   {
-    using var stream = client_.SendResult();
-
-    await stream.RequestStream.WriteAsync(new Result
-                                          {
-                                            CommunicationToken = Token,
-                                            Init = new InitKeyedDataStream
-                                                   {
-                                                     Key = key,
-                                                   },
-                                          })
-                .ConfigureAwait(false);
-    var start = 0;
-
-    while (start < data.Length)
+    await using (var fs = new FileStream(Path.Combine(folder_,
+                                                      key),
+                                         FileMode.OpenOrCreate))
     {
-      var chunkSize = Math.Min(Configuration!.DataChunkMaxSize,
-                               data.Length - start);
+      await using var w = new BinaryWriter(fs);
+      w.Write(data);
+    }
 
-      await stream.RequestStream.WriteAsync(new Result
+    await client_.NotifyResultDataAsync(new NotifyResultDataRequest
+                                        {
+                                          CommunicationToken = Token,
+                                          Ids =
+                                          {
+                                            new NotifyResultDataRequest.Types.ResultIdentifier
                                             {
-                                              CommunicationToken = Token,
-                                              Data = new DataChunk
-                                                     {
-                                                       Data = UnsafeByteOperations.UnsafeWrap(data.AsMemory()
-                                                                                                  .Slice(start,
-                                                                                                         chunkSize)),
-                                                     },
-                                            })
-                  .ConfigureAwait(false);
-
-      start += chunkSize;
-    }
-
-    await stream.RequestStream.WriteAsync(new Result
-                                          {
-                                            CommunicationToken = Token,
-                                            Data = new DataChunk
-                                                   {
-                                                     DataComplete = true,
-                                                   },
-                                          })
-                .ConfigureAwait(false);
-
-    await stream.RequestStream.WriteAsync(new Result
-                                          {
-                                            CommunicationToken = Token,
-                                            Init = new InitKeyedDataStream
-                                                   {
-                                                     LastResult = true,
-                                                   },
-                                          })
-                .ConfigureAwait(false);
-
-    await stream.RequestStream.CompleteAsync()
-                .ConfigureAwait(false);
-
-    var reply = await stream.ResponseAsync.ConfigureAwait(false);
-    if (reply.TypeCase == ResultReply.TypeOneofCase.Error)
-    {
-      logger_.LogError(reply.Error);
-      throw new InvalidOperationException($"Cannot send result id={key}");
-    }
+                                              SessionId = SessionId,
+                                              ResultId  = key,
+                                            },
+                                          },
+                                        })
+                 .ConfigureAwait(false);
   }
 
+  /// <inheritdoc />
   public ValueTask DisposeAsync()
     => ValueTask.CompletedTask;
 
@@ -226,7 +259,7 @@ public class TaskHandler : ITaskHandler
     => await client_.SubmitTasksAsync(new SubmitTasksRequest
                                       {
                                         CommunicationToken = Token,
-                                        SessionId          = sessionId_,
+                                        SessionId          = SessionId,
                                         TaskCreations =
                                         {
                                           taskCreations,
@@ -240,217 +273,11 @@ public class TaskHandler : ITaskHandler
     => await client_.CreateResultsAsync(new CreateResultsRequest
                                         {
                                           CommunicationToken = Token,
-                                          SessionId          = sessionId_,
+                                          SessionId          = SessionId,
                                           Results =
                                           {
                                             results,
                                           },
                                         })
                     .ConfigureAwait(false);
-
-  public async Task<UploadResultDataResponse> UploadResultData(string key,
-                                                               byte[] data)
-  {
-    var stream = client_.UploadResultData();
-
-    await stream.RequestStream.WriteAsync(new UploadResultDataRequest
-                                          {
-                                            Id = new UploadResultDataRequest.Types.ResultIdentifier
-                                                 {
-                                                   ResultId  = key,
-                                                   SessionId = sessionId_,
-                                                 },
-                                            CommunicationToken = Token,
-                                          })
-                .ConfigureAwait(false);
-
-    var start = 0;
-    while (start < data.Length)
-    {
-      var chunkSize = Math.Min(Configuration!.DataChunkMaxSize,
-                               data.Length - start);
-
-      await stream.RequestStream.WriteAsync(new UploadResultDataRequest
-                                            {
-                                              CommunicationToken = Token,
-                                              DataChunk = UnsafeByteOperations.UnsafeWrap(data.AsMemory()
-                                                                                              .Slice(start,
-                                                                                                     chunkSize)),
-                                            })
-                  .ConfigureAwait(false);
-
-      start += chunkSize;
-    }
-
-    await stream.RequestStream.CompleteAsync()
-                .ConfigureAwait(false);
-
-    return await stream.ResponseAsync.ConfigureAwait(false);
-  }
-
-  public static async Task<TaskHandler> Create(IAsyncStreamReader<ProcessRequest> requestStream,
-                                               Agent.AgentClient                  agentClient,
-                                               ILoggerFactory                     loggerFactory,
-                                               CancellationToken                  cancellationToken)
-  {
-    var output = new TaskHandler(requestStream,
-                                 agentClient,
-                                 cancellationToken,
-                                 loggerFactory);
-    await output.Init()
-                .ConfigureAwait(false);
-    return output;
-  }
-
-  private async Task Init()
-  {
-    if (!await requestStream_.MoveNext()
-                             .ConfigureAwait(false))
-    {
-      throw new InvalidOperationException("Request stream ended unexpectedly.");
-    }
-
-    if (requestStream_.Current.Compute.TypeCase != ProcessRequest.Types.ComputeRequest.TypeOneofCase.InitRequest)
-    {
-      throw new InvalidOperationException("Expected a Compute request type with InitRequest to start the stream.");
-    }
-
-    var initRequest = requestStream_.Current.Compute.InitRequest;
-    sessionId_       = initRequest.SessionId;
-    taskId_          = initRequest.TaskId;
-    taskOptions_     = initRequest.TaskOptions;
-    expectedResults_ = initRequest.ExpectedOutputKeys;
-    Configuration    = initRequest.Configuration;
-    token_           = requestStream_.Current.CommunicationToken;
-
-    if (initRequest.Payload is null)
-    {
-      throw new InvalidOperationException("Payload from InitRequest should not be null");
-    }
-
-
-    if (initRequest.Payload.DataComplete)
-    {
-      payload_ = initRequest.Payload.Data.ToByteArray();
-    }
-    else
-    {
-      var chunks    = new List<ByteString>();
-      var dataChunk = initRequest.Payload;
-
-      chunks.Add(dataChunk.Data);
-
-      while (!dataChunk.DataComplete)
-      {
-        if (!await requestStream_.MoveNext(cancellationToken_)
-                                 .ConfigureAwait(false))
-        {
-          throw new InvalidOperationException("Request stream ended unexpectedly.");
-        }
-
-        if (requestStream_.Current.Compute.TypeCase != ProcessRequest.Types.ComputeRequest.TypeOneofCase.Payload)
-        {
-          throw new InvalidOperationException("Expected a Compute request type with Payload to continue the stream.");
-        }
-
-        dataChunk = requestStream_.Current.Compute.Payload;
-
-        chunks.Add(dataChunk.Data);
-      }
-
-
-      var size = chunks.Sum(s => s.Length);
-
-      var payload = new byte[size];
-
-      var start = 0;
-
-      foreach (var chunk in chunks)
-      {
-        chunk.CopyTo(payload,
-                     start);
-        start += chunk.Length;
-      }
-
-      payload_ = payload;
-    }
-
-    var dataDependencies = new Dictionary<string, byte[]>();
-
-    ProcessRequest.Types.ComputeRequest.Types.InitData initData;
-    do
-    {
-      if (!await requestStream_.MoveNext(cancellationToken_)
-                               .ConfigureAwait(false))
-      {
-        throw new InvalidOperationException("Request stream ended unexpectedly.");
-      }
-
-
-      if (requestStream_.Current.Compute.TypeCase != ProcessRequest.Types.ComputeRequest.TypeOneofCase.InitData)
-      {
-        throw new InvalidOperationException("Expected a Compute request type with InitData to continue the stream.");
-      }
-
-      initData = requestStream_.Current.Compute.InitData;
-      if (!string.IsNullOrEmpty(initData.Key))
-      {
-        var chunks = new List<ByteString>();
-
-        while (true)
-        {
-          if (!await requestStream_.MoveNext(cancellationToken_)
-                                   .ConfigureAwait(false))
-          {
-            throw new InvalidOperationException("Request stream ended unexpectedly.");
-          }
-
-          if (requestStream_.Current.Compute.TypeCase != ProcessRequest.Types.ComputeRequest.TypeOneofCase.Data)
-          {
-            throw new InvalidOperationException("Expected a Compute request type with Data to continue the stream.");
-          }
-
-          var dataChunk = requestStream_.Current.Compute.Data;
-
-          if (dataChunk.TypeCase == DataChunk.TypeOneofCase.Data)
-          {
-            chunks.Add(dataChunk.Data);
-          }
-
-          if (dataChunk.TypeCase == DataChunk.TypeOneofCase.None)
-          {
-            throw new InvalidOperationException("Expected a Compute request type with a DataChunk Payload to continue the stream.");
-          }
-
-          if (dataChunk.TypeCase == DataChunk.TypeOneofCase.DataComplete)
-          {
-            break;
-          }
-        }
-
-        var size = chunks.Sum(s => s.Length);
-
-        var data = new byte[size];
-
-        var start = 0;
-
-        foreach (var chunk in chunks)
-        {
-          chunk.CopyTo(data,
-                       start);
-          start += chunk.Length;
-        }
-
-        dataDependencies[initData.Key] = data;
-      }
-    } while (!string.IsNullOrEmpty(initData.Key));
-
-    dataDependencies_ = dataDependencies;
-    isInitialized_    = true;
-  }
-
-  private Exception TaskHandlerException(string argumentName)
-    => isInitialized_
-         ? new InvalidOperationException($"Error in initalization: {argumentName} is null")
-         : new InvalidOperationException("");
 }


### PR DESCRIPTION
This PR changes the way data should be sent between Worker and Scheduling Agent to use files in a shared directory instead of gRPC streams.

Rationale:
Rework communications between scheduling agent and worker so that there is no streams and pass data through file in a shared volume. This will allow some nice optimisations such as:

- [ ] Less gRPC communications between scheduling agent and worker
- [ ] Simpler RPC methods between scheduling agent and worker
- [ ] Tasks that start faster: no need to receive the input payload and dependencies, they will be available in the shared volume at the start of the task due to prefetching
- [ ] Data can be consummed when needed during the task; not forcefully received at the start
- [ ] A node-wide caching system could be implemented through a volume shared between all the scheduling agents and workers that would allow the scheduling agent to know that some data are already there and reuse them to avoid unnecessary data download. This should be implemented in ArmoniK.Core and should not impact APIs and Worker behavior


What changed ?
- Worker `Process` RPC is now an Unitary Call (no streams) with a `data_location` folder in which Payload and Data Dependencies are located as file whose name is the ID of the input
- Agent Get*Data are now Unitary Calls too : The call returns when expected data are located in the `data_location` folder as file whose name is the ID of the required data
- Agent `UploadResultData` and `SendResult` became `NotifyResultData`. Results should be stored as a file whose name is the ID of the results in the `data_location` folder then the `NotifyResultData` method should be called to notify Agent that data were submitted.
