### PR TITLE
chore: remove pre-version package to be published on Pypi website

### DIFF
--- a/.github/workflows/publish-edge.yml
+++ b/.github/workflows/publish-edge.yml
@@ -225,14 +225,6 @@ jobs:
           packages-dir: packages/python/pkg/
           repository-url: https://test.pypi.org/legacy/
 
-      - name: Publish to PyPI
-        if: github.ref == 'refs/heads/main'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          print-hash: true
-          packages-dir: packages/python/pkg/
-
   release-cpp-package:
     needs: [version]
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,15 @@ jobs:
           name: python-packages
           path: packages/python/pkg/
 
+      - name: Publish to PyPITest
+        if: github.ref != 'refs/heads/main'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.DEV_PYPI_API_TOKEN }}
+          print-hash: true
+          packages-dir: packages/python/pkg/
+          repository-url: https://test.pypi.org/legacy/
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
The pre-version should be available only on https://test.pypi.org