### PR TITLE
fix: Abort immediately upon cancellation

### DIFF
--- a/packages/csharp/ArmoniK.Api.Common/Options/ComputePlane.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Options/ComputePlane.cs
@@ -56,5 +56,5 @@ public class ComputePlane
   /// <summary>
   ///   Time to wait upon cancellation before aborting the worker
   /// </summary>
-  public TimeSpan AbortAfter { get; set; } = TimeSpan.FromSeconds(1);
+  public TimeSpan AbortAfter { get; set; } = TimeSpan.Zero;
 }

--- a/packages/csharp/ArmoniK.Api.Worker/Worker/WorkerStreamWrapper.cs
+++ b/packages/csharp/ArmoniK.Api.Worker/Worker/WorkerStreamWrapper.cs
@@ -131,11 +131,14 @@ public class WorkerStreamWrapper : gRPC.V1.Worker.Worker.WorkerBase, IAsyncDispo
     {
       logger_.LogInformation("RPC request was aborted");
 
-      // Request has been cancelled
-      // Wait for process to be properly cancelled, or small delay
-      task = await Task.WhenAny(process,
-                                Task.Delay(computePlaneOptions_.AbortAfter))
-                       .ConfigureAwait(false);
+      if (computePlaneOptions_.AbortAfter > TimeSpan.Zero)
+      {
+        // Request has been cancelled
+        // Wait for process to be properly cancelled, or small delay
+        task = await Task.WhenAny(process,
+                                  Task.Delay(computePlaneOptions_.AbortAfter))
+                         .ConfigureAwait(false);
+      }
 
       // Check cancelled completion of process
       if (ReferenceEquals(task,


### PR DESCRIPTION
Change the default option and abort immediately upon cancellation.

This is to limit the edge case that a task cancellation that is not catched would make the next task to crash and being retried.