### PR TITLE
ci: Add TLS support for Mock

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,185 @@
+name: Tests
+
+on:
+  pull_request:
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  certs:
+    name: Generate certificates
+    runs-on: ubuntu-latest
+    outputs:
+      client-ca_pem: ${{ steps.certs.outputs.client-ca_pem }}
+      client_key: ${{ steps.certs.outputs.client_key }}
+      client_pem: ${{ steps.certs.outputs.client_pem }}
+      server1-ca_pem: ${{ steps.certs.outputs.server1-ca_pem }}
+      server1_key: ${{ steps.certs.outputs.server1_key }}
+      server1_pem: ${{ steps.certs.outputs.server1_pem }}
+      server2-ca_pem: ${{ steps.certs.outputs.server2-ca_pem }}
+      server2_key: ${{ steps.certs.outputs.server2_key }}
+      server2_pem: ${{ steps.certs.outputs.server2_pem }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+      - name: Generate certificates
+        id: certs
+        run: |
+          mkdir certs
+          cd certs
+          ../scripts/certs.sh
+          for file in *; do
+            echo "${file//./_}<<EOF"
+            cat "$file"
+            echo "EOF"
+          done >> "$GITHUB_OUTPUT"
+
+  csharp:
+    name: Test C#
+    needs:
+      - certs
+    strategy:
+      fail-fast: false
+      matrix:
+        dotnet:
+          - version: ''
+            framework: net4.7
+          - version: ''
+            framework: net4.8
+          - version: 6.0
+            framework: net6.0
+          - version: 8.0
+            framework: net8.0
+        platform:
+          - os: ubuntu-latest
+            runtime: linux-x64
+          - os: windows-2019
+            runtime: windows-x64
+          - os: windows-2022
+            runtime: windows-x64
+        exclude:
+          - dotnet:
+              version: ''
+              framework: net4.7
+            platform:
+              os: ubuntu-latest
+              runtime: linux-x64
+          - dotnet:
+              version: ''
+              framework: net4.8
+            platform:
+              os: ubuntu-latest
+              runtime: linux-x64
+    runs-on: ${{ matrix.platform.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Install local certs
+        working-directory: packages/csharp/
+        shell: bash
+        run: |
+          mkdir certs
+          cd certs
+          cat > client-ca.pem <<EOF
+          ${{ needs.certs.outputs.client-ca_pem }}
+          EOF
+          cat > client.key <<EOF
+          ${{ needs.certs.outputs.client_key }}
+          EOF
+          cat > client.pem <<EOF
+          ${{ needs.certs.outputs.client_pem }}
+          EOF
+          cat > server1-ca.pem <<EOF
+          ${{ needs.certs.outputs.server1-ca_pem }}
+          EOF
+          cat > server1.key <<EOF
+          ${{ needs.certs.outputs.server1_key }}
+          EOF
+          cat > server1.pem <<EOF
+          ${{ needs.certs.outputs.server1_pem }}
+          EOF
+          cat > server2-ca.pem <<EOF
+          ${{ needs.certs.outputs.server2-ca_pem }}
+          EOF
+          cat > server2.key <<EOF
+          ${{ needs.certs.outputs.server2_key }}
+          EOF
+          cat > server2.pem <<EOF
+          ${{ needs.certs.outputs.server2_pem }}
+          EOF
+      - name: Install certs
+        if: ${{ matrix.platform.os == 'ubuntu-latest' }}
+        working-directory: packages/csharp/certs
+        run: |
+          sudo apt install ca-certificates
+          sudo mkdir -p /usr/local/share/ca-certificates/
+          sudo cp server2-ca.pem /usr/local/share/ca-certificates/ca.crt
+          sudo update-ca-certificates
+      - name: Install certs
+        if: ${{ contains(matrix.platform.os, 'windows') }}
+        working-directory: packages/csharp/certs
+        run: |
+          certutil -addstore -f "ROOT" server2-ca.pem
+
+      - name: Install .NET Core
+        uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4
+        if: ${{ matrix.dotnet.version }} != ""
+        with:
+          dotnet-version: ${{ matrix.dotnet.version }}
+
+      - name: Build Mock server
+        working-directory: packages/csharp/ArmoniK.Api.Mock
+        shell: bash
+        run: |
+          dotnet publish -o ../out
+          [ -e ../out/ArmoniK.Api.Mock.exe ] || ln -s ArmoniK.Api.Mock ../out/ArmoniK.Api.Mock.exe
+
+      - name: Test
+        working-directory: packages/csharp/
+        shell: bash
+        run: |
+          set +e
+          set -x
+          export CertFolder="$PWD/certs"
+          ./out/ArmoniK.Api.Mock.exe \
+            grpc:port=5000 http:port=4999 \
+            & notls_pid=$!
+          ./out/ArmoniK.Api.Mock.exe \
+            grpc:port=5001 http:port=5001 \
+            http:cert="$CertFolder/server1.pem" http:key="$CertFolder/server1.key" \
+            & tls_pid=$!
+          ./out/ArmoniK.Api.Mock.exe \
+            grpc:port=5002 http:port=5002 \
+            http:cert="$CertFolder/server2.pem" http:key="$CertFolder/server2.key" \
+            & tlsstore_pid=$!
+          ./out/ArmoniK.Api.Mock.exe \
+            grpc:port=5003 http:port=5003 \
+            http:cert="$CertFolder/server1.pem" http:key="$CertFolder/server1.key" http:clientcert="$CertFolder/client-ca.pem" \
+            & mtls_pid=$!
+          ./out/ArmoniK.Api.Mock.exe \
+            grpc:port=5004 http:port=5004 \
+            http:cert="$CertFolder/server2.pem" http:key="$CertFolder/server2.key" http:clientcert="$CertFolder/client-ca.pem" \
+            & mtlsstore_pid=$!
+          sleep 5
+
+          cd ArmoniK.Api.Client.Test
+          dotnet test --runtime ${{ matrix.platform.runtime }} -f ${{ matrix.dotnet.framework }} --logger "trx;LogFileName=test-results.trx"; ret=$?
+
+          kill $notls_pid $tls_pid $tlsstore_pid $mtls_pid $mtlsstore_pid
+          exit $ret
+
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: ConnectivityTests ${{ matrix.platform.runtime }} ${{ matrix.dotnet.framework }}
+          path: ./packages/csharp/ArmoniK.Api.Client.Test/TestResults/test-results.trx
+          reporter: dotnet-trx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,40 +8,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  certs:
-    name: Generate certificates
-    runs-on: ubuntu-latest
-    outputs:
-      client-ca_pem: ${{ steps.certs.outputs.client-ca_pem }}
-      client_key: ${{ steps.certs.outputs.client_key }}
-      client_pem: ${{ steps.certs.outputs.client_pem }}
-      server1-ca_pem: ${{ steps.certs.outputs.server1-ca_pem }}
-      server1_key: ${{ steps.certs.outputs.server1_key }}
-      server1_pem: ${{ steps.certs.outputs.server1_pem }}
-      server2-ca_pem: ${{ steps.certs.outputs.server2-ca_pem }}
-      server2_key: ${{ steps.certs.outputs.server2_key }}
-      server2_pem: ${{ steps.certs.outputs.server2_pem }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-        with:
-          fetch-depth: 0
-      - name: Generate certificates
-        id: certs
-        run: |
-          mkdir certs
-          cd certs
-          ../scripts/certs.sh
-          for file in *; do
-            echo "${file//./_}<<EOF"
-            cat "$file"
-            echo "EOF"
-          done >> "$GITHUB_OUTPUT"
-
   csharp:
     name: Test C#
-    needs:
-      - certs
     strategy:
       fail-fast: false
       matrix:
@@ -82,39 +50,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install local certs
+      - name: Generate certs
         working-directory: packages/csharp/
         shell: bash
         run: |
           mkdir certs
           cd certs
-          cat > client-ca.pem <<EOF
-          ${{ needs.certs.outputs.client-ca_pem }}
-          EOF
-          cat > client.key <<EOF
-          ${{ needs.certs.outputs.client_key }}
-          EOF
-          cat > client.pem <<EOF
-          ${{ needs.certs.outputs.client_pem }}
-          EOF
-          cat > server1-ca.pem <<EOF
-          ${{ needs.certs.outputs.server1-ca_pem }}
-          EOF
-          cat > server1.key <<EOF
-          ${{ needs.certs.outputs.server1_key }}
-          EOF
-          cat > server1.pem <<EOF
-          ${{ needs.certs.outputs.server1_pem }}
-          EOF
-          cat > server2-ca.pem <<EOF
-          ${{ needs.certs.outputs.server2-ca_pem }}
-          EOF
-          cat > server2.key <<EOF
-          ${{ needs.certs.outputs.server2_key }}
-          EOF
-          cat > server2.pem <<EOF
-          ${{ needs.certs.outputs.server2_pem }}
-          EOF
+          ../../../scripts/certs.sh
       - name: Install certs
         if: ${{ matrix.platform.os == 'ubuntu-latest' }}
         working-directory: packages/csharp/certs
@@ -180,6 +122,6 @@ jobs:
         uses: dorny/test-reporter@v1
         if: always()
         with:
-          name: ConnectivityTests ${{ matrix.platform.runtime }} ${{ matrix.dotnet.framework }}
+          name: ConnectivityTests ${{ matrix.platform.os }} ${{ matrix.dotnet.framework }}
           path: ./packages/csharp/ArmoniK.Api.Client.Test/TestResults/test-results.trx
           reporter: dotnet-trx

--- a/packages/csharp/ArmoniK.Api.Client.Test/ArmoniK.Api.Client.Tests.csproj
+++ b/packages/csharp/ArmoniK.Api.Client.Test/ArmoniK.Api.Client.Tests.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net4.7;net4.8;net6.0;net8.0</TargetFrameworks>
     <Company>ANEO</Company>
-    <Copyright>Copyright (C) ANEO, 2021-2022</Copyright>
+    <Copyright>Copyright (C) ANEO, 2021-2024</Copyright>
     <IsPackable>false</IsPackable>
     <LangVersion>10</LangVersion>
     <Optimize>true</Optimize>

--- a/packages/csharp/ArmoniK.Api.Client.Test/ArmoniK.Api.Client.Tests.csproj
+++ b/packages/csharp/ArmoniK.Api.Client.Test/ArmoniK.Api.Client.Tests.csproj
@@ -20,7 +20,6 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Core" Version="2.46.6" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />

--- a/packages/csharp/ArmoniK.Api.Client.Test/ArmoniK.Api.Client.Tests.csproj
+++ b/packages/csharp/ArmoniK.Api.Client.Test/ArmoniK.Api.Client.Tests.csproj
@@ -20,6 +20,7 @@
 
 
   <ItemGroup>
+    <PackageReference Include="Grpc.Core" Version="2.46.6" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />

--- a/packages/csharp/ArmoniK.Api.Client.Test/ConnectivityKind.cs
+++ b/packages/csharp/ArmoniK.Api.Client.Test/ConnectivityKind.cs
@@ -1,0 +1,120 @@
+﻿// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2021-2024. All rights reserved.
+//   W. Kirschenmann   <wkirschenmann@aneo.fr>
+//   J. Gurhem         <jgurhem@aneo.fr>
+//   D. Dubuc          <ddubuc@aneo.fr>
+//   L. Ziane Khodja   <lzianekhodja@aneo.fr>
+//   F. Lemaitre       <flemaitre@aneo.fr>
+//   S. Djebbar        <sdjebbar@aneo.fr>
+//   J. Fonseca        <jfonseca@aneo.fr>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.IO;
+
+using ArmoniK.Api.Client.Options;
+using ArmoniK.Api.Client.Submitter;
+
+using Grpc.Core;
+
+using NUnit.Framework;
+
+namespace ArmoniK.Api.Client.Tests;
+
+public enum ConnectivityKind
+{
+  Unencrypted,
+  TlsInsecure,
+  TlsCert,
+  TlsStore,
+  MTlsInsecure,
+  MTlsCert,
+  MTlsStore,
+}
+
+internal static class ConnectivityKindExt
+{
+  private const string CertFolder = "../../../../certs";
+
+  internal static bool IsTls(this ConnectivityKind kind)
+    => kind switch
+       {
+         ConnectivityKind.Unencrypted => false,
+         _                            => true,
+       };
+
+  internal static bool IsInsecure(this ConnectivityKind kind)
+    => kind switch
+       {
+         ConnectivityKind.Unencrypted or ConnectivityKind.TlsInsecure or ConnectivityKind.MTlsInsecure => true,
+         _                                                                                             => false,
+       };
+
+  internal static bool IsMTls(this ConnectivityKind kind)
+    => kind switch
+       {
+         ConnectivityKind.MTlsInsecure => true,
+         ConnectivityKind.MTlsCert     => true,
+         ConnectivityKind.MTlsStore    => true,
+         _                             => false,
+       };
+
+  internal static string? GetCaCertPath(this ConnectivityKind kind)
+    => kind switch
+       {
+         ConnectivityKind.TlsCert or ConnectivityKind.MTlsCert => Path.Combine(CertFolder,
+                                                                               "server-ca.pem"),
+         _ => null,
+       };
+
+  internal static (string?, string?) GetClientCertPath(this ConnectivityKind kind)
+    => kind.IsMTls()
+         ? (Path.Combine(CertFolder,
+                         "client.pem"), Path.Combine(CertFolder,
+                                                     "client.key"))
+         : (null, null);
+
+  internal static string GetEndpoint(this ConnectivityKind kind)
+    => kind switch
+       {
+         ConnectivityKind.Unencrypted  => "http://localhost:5000",
+         ConnectivityKind.TlsInsecure  => "https://localhost:5001",
+         ConnectivityKind.TlsCert      => "https://localhost:5001",
+         ConnectivityKind.TlsStore     => "https://localhost:5001",
+         ConnectivityKind.MTlsInsecure => "https://localhost:5002",
+         ConnectivityKind.MTlsCert     => "https://localhost:5002",
+         ConnectivityKind.MTlsStore    => "https://localhost:5002",
+         _                             => "http://localhost:5000",
+       };
+
+  internal static ChannelBase GetChannel(this ConnectivityKind kind)
+  {
+    var (certPath, keyPath) = kind.GetClientCertPath();
+
+    if (kind.GetCaCertPath() is not null && false)
+    {
+      Assert.Inconclusive("CA is not yet supported");
+    }
+
+    return GrpcChannelFactory.CreateChannel(new GrpcClient
+                                            {
+                                              Endpoint              = kind.GetEndpoint(),
+                                              AllowUnsafeConnection = kind.IsInsecure(),
+                                              CertPem               = certPath             ?? "",
+                                              KeyPem                = keyPath              ?? "",
+                                              CaCert                = kind.GetCaCertPath() ?? "",
+                                            });
+  }
+}

--- a/packages/csharp/ArmoniK.Api.Client.Test/ConnectivityTest.cs
+++ b/packages/csharp/ArmoniK.Api.Client.Test/ConnectivityTest.cs
@@ -1,0 +1,43 @@
+// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2021-2024. All rights reserved.
+//   W. Kirschenmann   <wkirschenmann@aneo.fr>
+//   J. Gurhem         <jgurhem@aneo.fr>
+//   D. Dubuc          <ddubuc@aneo.fr>
+//   L. Ziane Khodja   <lzianekhodja@aneo.fr>
+//   F. Lemaitre       <flemaitre@aneo.fr>
+//   S. Djebbar        <sdjebbar@aneo.fr>
+//   J. Fonseca        <jfonseca@aneo.fr>
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using ArmoniK.Api.gRPC.V1;
+using ArmoniK.Api.gRPC.V1.Results;
+
+using NUnit.Framework;
+
+namespace ArmoniK.Api.Client.Tests;
+
+[TestFixture]
+public class ConnectivityTests
+{
+  [Test]
+  public void ResultsGetServiceConfiguration([Values] ConnectivityKind connectivityKind)
+  {
+    var channel      = connectivityKind.GetChannel();
+    var resultClient = new Results.ResultsClient(channel);
+
+    Assert.That(() => resultClient.GetServiceConfiguration(new Empty()),
+                Throws.Nothing);
+  }
+}

--- a/packages/csharp/ArmoniK.Api.Mock/ArmoniK.Api.Mock.csproj
+++ b/packages/csharp/ArmoniK.Api.Mock/ArmoniK.Api.Mock.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Company>ANEO</Company>
     <Copyright>Copyright (C) ANEO, 2023</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -20,6 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="8.0.5" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.59.0" />
     <PackageReference Include="Grpc.AspNetCore.Web" Version="2.59.0" />
     <PackageReference Include="MethodDecorator.Fody" Version="1.1.1" />

--- a/scripts/certs.sh
+++ b/scripts/certs.sh
@@ -3,10 +3,10 @@
 set -ex
 
 chain() {
-  openssl req -x509 -newkey rsa:4096 -days 3650 -nodes -keyout "$1-ca.key" -out "$1-ca.pem" -subj "/C=FR/ST=France/L=/O=ArmoniK Ingress Root (NonTrusted)/OU=/CN=ArmoniK Ingress Root (NonTrusted) Private Certificate Authority/emailAddress="
+  openssl req -x509 -newkey rsa:4096 -days 3650 -nodes -keyout "$1-ca.key" -out "$1-ca.pem" -subj "/C=FR/ST=France/L=/O=ArmoniK Ingress Root (NonTrusted)/OU=$1/CN=ArmoniK Ingress Root (NonTrusted) Private Certificate Authority/emailAddress="
 
   openssl genrsa -out "$1.key" 4096
-  openssl req -new -key "$1".key -out "$1".csr -subj "/C=FR/ST=France/L=/O=ArmoniK Ingress Root (NonTrusted)/OU=/CN=${2:-ArmoniK Root (NonTrusted}/emailAddress="
+  openssl req -new -key "$1".key -out "$1".csr -subj "/C=FR/ST=France/L=/O=ArmoniK Ingress Root (NonTrusted)/OU=$1/CN=${2:-ArmoniK Root (NonTrusted}/emailAddress="
 
   cat > "$1.cnf" <<EOF
 ${2:+subjectAltName=DNS:$2}
@@ -15,5 +15,6 @@ EOF
   openssl x509 -req -in "$1.csr" -CA "$1-ca.pem" -CAkey "$1-ca.key" -CAcreateserial -out "$1.pem" -days 3650 -extfile "$1.cnf"
 }
 
-chain server localhost
+chain server1 localhost
+chain server2 localhost
 chain client

--- a/scripts/certs.sh
+++ b/scripts/certs.sh
@@ -1,0 +1,19 @@
+#! /bin/sh
+
+set -ex
+
+chain() {
+  openssl req -x509 -newkey rsa:4096 -days 3650 -nodes -keyout "$1-ca.key" -out "$1-ca.pem" -subj "/C=FR/ST=France/L=/O=ArmoniK Ingress Root (NonTrusted)/OU=/CN=ArmoniK Ingress Root (NonTrusted) Private Certificate Authority/emailAddress="
+
+  openssl genrsa -out "$1.key" 4096
+  openssl req -new -key "$1".key -out "$1".csr -subj "/C=FR/ST=France/L=/O=ArmoniK Ingress Root (NonTrusted)/OU=/CN=${2:-ArmoniK Root (NonTrusted}/emailAddress="
+
+  cat > "$1.cnf" <<EOF
+${2:+subjectAltName=DNS:$2}
+EOF
+
+  openssl x509 -req -in "$1.csr" -CA "$1-ca.pem" -CAkey "$1-ca.key" -CAcreateserial -out "$1.pem" -days 3650 -extfile "$1.cnf"
+}
+
+chain server localhost
+chain client


### PR DESCRIPTION
Add support for TLS for ArmoniK.Api.mock.

This enables to test within the Api repository the client channel creation for TLS/mTLS.