### PR TITLE
fix: Add ReusePorts option

### DIFF
--- a/packages/csharp/ArmoniK.Api.Client/Options/GrpcClient.cs
+++ b/packages/csharp/ArmoniK.Api.Client/Options/GrpcClient.cs
@@ -154,5 +154,10 @@ namespace ArmoniK.Api.Client.Options
     ///   Password used for proxy authentication
     /// </summary>
     public string ProxyPassword { get; set; } = "";
+
+    /// <summary>
+    ///   Enable the option SO_REUSE_UNICASTPORT upon socket opening to limit port exhaustion
+    /// </summary>
+    public bool ReusePorts { get; set; } = true;
   }
 }

--- a/packages/csharp/ArmoniK.Api.Client/Submitter/GrpcChannelFactory.cs
+++ b/packages/csharp/ArmoniK.Api.Client/Submitter/GrpcChannelFactory.cs
@@ -274,6 +274,11 @@ namespace ArmoniK.Api.Client.Submitter
         throw new InvalidOperationException($"{nameof(optionsGrpcClient.Endpoint)} should not be null or empty");
       }
 
+      if (optionsGrpcClient.ReusePorts)
+      {
+        ServicePointManager.ReusePort = true;
+      }
+
       var serviceConfig = new ServiceConfig
                           {
                             MethodConfigs =

--- a/packages/csharp/ArmoniK.Api.Client/Submitter/GrpcChannelFactory.cs
+++ b/packages/csharp/ArmoniK.Api.Client/Submitter/GrpcChannelFactory.cs
@@ -394,6 +394,8 @@ namespace ArmoniK.Api.Client.Submitter
                                                  proxyType,
                                                  handlerType,
                                                  logger);
+      httpHandler = new Handler(httpHandler,
+                                logger);
 
       // Warn that RequestTimeout is not supported.
       // If required, it could be easily implemented with a DelegatingHandler and a cancellationToken delayed cancellation
@@ -629,6 +631,31 @@ namespace ArmoniK.Api.Client.Submitter
       ///   GrpcWebHandler(WinHttpHandler())
       /// </summary>
       Web,
+    }
+
+    private class Handler : DelegatingHandler
+    {
+      private readonly ILogger? logger_;
+
+      internal Handler(HttpMessageHandler inner,
+                       ILogger?           logger)
+        : base(inner)
+        => logger_ = logger;
+
+      protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+                                                                   CancellationToken  cancellationToken)
+      {
+        var response = await base.SendAsync(request,
+                                            cancellationToken)
+                                 .ConfigureAwait(false);
+
+        if (response.Headers.ConnectionClose is true)
+        {
+          logger_?.LogInformation("Connection closing has been requested, performance degradation is expected");
+        }
+
+        return response;
+      }
     }
   }
 }


### PR DESCRIPTION
On windows, a connection allocate a port that remains allocated 4 minutes after closing. When the server request connection closing after each request, we end up exhausting ports very quickly.

Adding the option to reuse ports enable to work around this limitation.