### PR TITLE
feat: turn enumwrappers into real python enumerators

### DIFF
--- a/packages/python/src/armonik/common/enumwrapper.py
+++ b/packages/python/src/armonik/common/enumwrapper.py
@@ -75,7 +75,7 @@ class TaskStatus(IntEnum):
     PAUSED = TASK_STATUS_PAUSED
 
 
-class EventTypes:
+class EventTypes(IntEnum):
     UNSPECIFIED = EVENTS_ENUM_UNSPECIFIED
     NEW_TASK = EVENTS_ENUM_NEW_TASK
     TASK_STATUS_UPDATE = EVENTS_ENUM_TASK_STATUS_UPDATE
@@ -88,7 +88,7 @@ class EventTypes:
         return getattr(cls, name.upper())
 
 
-class SessionStatus:
+class SessionStatus(IntEnum):
     @staticmethod
     def name_from_value(status: RawSessionStatus) -> str:
         return _SESSIONSTATUS.values_by_number[status].name
@@ -102,7 +102,7 @@ class SessionStatus:
     DELETED = SESSION_STATUS_DELETED
 
 
-class ResultStatus:
+class ResultStatus(IntEnum):
     @staticmethod
     def name_from_value(status: RawResultStatus) -> str:
         return _RESULTSTATUS.values_by_number[status].name
@@ -115,19 +115,19 @@ class ResultStatus:
     NOTFOUND = RESULT_STATUS_NOTFOUND
 
 
-class ServiceHealthCheckStatus:
+class ServiceHealthCheckStatus(IntEnum):
     UNSPECIFIED = HEALTH_STATUS_ENUM_UNSPECIFIED
     HEALTHY = HEALTH_STATUS_ENUM_HEALTHY
     DEGRADED = HEALTH_STATUS_ENUM_DEGRADED
     UNHEALTHY = HEALTH_STATUS_ENUM_UNHEALTHY
 
 
-class HealthCheckStatus:
+class HealthCheckStatus(IntEnum):
     UNKNOWN = HealthCheckReply.UNKNOWN
     SERVING = HealthCheckReply.SERVING
     NOT_SERVING = HealthCheckReply.NOT_SERVING
 
 
-class Direction:
+class Direction(IntEnum):
     ASC = SORT_DIRECTION_ASC
     DESC = SORT_DIRECTION_DESC

--- a/packages/python/src/armonik/common/objects.py
+++ b/packages/python/src/armonik/common/objects.py
@@ -64,7 +64,7 @@ class TaskOptions:
             application_namespace=task_options.application_namespace,
             application_service=task_options.application_service,
             engine_type=task_options.engine_type,
-            options=task_options.options,
+            options={k: v for k, v in task_options.options.items()},
         )
 
     def to_message(self) -> RawTaskOptions:


### PR DESCRIPTION
- feat: turn enumwrappers into real python enumerators
- fix: correctly convert TaskOptions option property into Python dictionnary

# Motivation

So far, the API wrappers for enumerators are not “real” Python enumerators. This makes it difficult to obtain the name associated with the value of enumerator elements.

# Description

This change fixes this problem by making each enumerator wrapper a “real” Python enumerator.

It also fixes a minor bug in the conversion of the TaskOptions option field to a native Python dictionary.

# Testing

A few manual tests in addition to unit tests.

# Impact

This changes should have no impact.

# Additional Information


# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
