### PR TITLE
style: remove a deprecated configuration setting

### DIFF
--- a/packages/python/ruff.toml
+++ b/packages/python/ruff.toml
@@ -35,9 +35,6 @@ exclude = ["*.pyi"]
 # By default all rules are considered fixable.
 fixable = ["ALL"]
 
-# Avoid automatically removing unused imports in `__init__.py` files.
-ignore-init-module-imports = false
-
 [format]
 # Like Black, indent with spaces, rather than tabs.
 indent-style = "space"


### PR DESCRIPTION
# Motivation

Ruff, the Python linter, displays a warning message because of the use of a deprecated configuration setting.

# Description

This change removes the deprecated configuration setting from the ruff configuration.

# Testing

The linting style works properly with this change.

# Impact

This change has no impact.

# Additional Information

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
