### PR TITLE
chore: Cleanup client interface for Rust API

### DIFF
--- a/packages/rust/armonik/Cargo.lock
+++ b/packages/rust/armonik/Cargo.lock
@@ -28,13 +28,13 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.92"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "armonik"
-version = "3.21.0-beta-0"
+version = "3.22.0-beta-0"
 dependencies = [
  "async-trait",
  "eyre",
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "1b1244b10dcd56c92219da4e14caa97e312079e185f04ba3eea25061561dc0a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -103,36 +103,34 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd82dba44d209fddb11c190e0a94b78651f95299598e472215667417a03ff1d"
+checksum = "f409eb70b561706bf8abba8ca9c112729c481595893fd06a2dd9af8ed8441148"
 dependencies = [
  "aws-lc-sys",
- "mirai-annotations",
  "paste",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7a4168111d7eb622a31b214057b8509c0a7e1794f44c546d742330dc793972"
+checksum = "923ded50f602b3007e5e63e3f094c479d9c8a9b42d7f4034e4afe456aa48bfd2"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "libc",
  "paste",
 ]
 
 [[package]]
 name = "axum"
-version = "0.7.7"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -149,8 +147,8 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper 1.0.1",
- "tower 0.5.1",
+ "sync_wrapper",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -170,7 +168,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -233,15 +231,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.1.35"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57c4b4da2a9d619dd035f27316d7a426305b75be93d09e92f2b9229c34feaf"
+checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
 dependencies = [
  "jobserver",
  "libc",
@@ -276,18 +274,18 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -319,12 +317,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -339,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fixedbitset"
@@ -469,15 +467,15 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -485,7 +483,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -500,9 +498,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -511,25 +509,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -573,9 +565,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.5.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -594,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
  "http",
@@ -661,12 +653,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -689,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jobserver"
@@ -716,15 +708,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libloading"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets",
@@ -787,30 +779,23 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "mirai-annotations"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "multimap"
@@ -840,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -907,7 +892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
 ]
 
 [[package]]
@@ -963,18 +948,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -982,11 +967,10 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
+checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
- "bytes",
  "heck",
  "itertools 0.13.0",
  "log",
@@ -1003,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",
@@ -1016,18 +1000,18 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
+checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1064,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags",
 ]
@@ -1079,7 +1063,7 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.8",
+ "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
 ]
 
@@ -1094,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1144,22 +1128,22 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.39"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375116bee2be9ed569afe2154ea6a99dfdffd257f533f187498c2a8f5feaf4ee"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -1173,31 +1157,21 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 
 [[package]]
 name = "rustls-webpki"
@@ -1213,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -1225,18 +1199,18 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "scc"
-version = "2.2.4"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d25269dd3a12467afe2e510f69fb0b46b698e5afb296b59f2145259deaf8e8"
+checksum = "28e1c91382686d21b5ac7959341fcb9780fa7c03773646995a87c950fa7be640"
 dependencies = [
  "sdd",
 ]
 
 [[package]]
 name = "schannel"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -1249,15 +1223,15 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdd"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c1eeaf4b6a87c7479688c6d52b9f1153cedd3c489300564f932b065c6eab95"
+checksum = "478f121bb72bbf63c52c93011ea1791dca40140dfe13f8336c4c5ac952c33aa9"
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "81d3f8c9bfcc3cbb6b0179eb57042d75b1582bdc65c3cb95f3fa999509c03cbc"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1268,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+checksum = "1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1278,18 +1252,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1298,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
 dependencies = [
  "itoa",
  "memchr",
@@ -1310,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.1.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
 dependencies = [
  "futures",
  "log",
@@ -1324,9 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.1.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1386,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1408,9 +1382,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "987bc0be1cdea8b10216bd06e2ca407d40b9543468fafd3ddfb02f36e77f71f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1419,24 +1393,19 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -1454,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1481,20 +1450,19 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls",
- "rustls-pki-types",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1503,9 +1471,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1580,14 +1548,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 0.1.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -1606,9 +1574,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -1617,9 +1585,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1628,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1649,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -1673,9 +1641,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "untrusted"

--- a/packages/rust/armonik/Cargo.lock
+++ b/packages/rust/armonik/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "armonik"
-version = "3.22.0-beta-0"
+version = "3.24.0-beta-0"
 dependencies = [
  "async-trait",
  "eyre",

--- a/packages/rust/armonik/Cargo.toml
+++ b/packages/rust/armonik/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 readme = "README.md"
 name = "armonik"
 repository = "https://github.com/aneoconsulting/ArmoniK.Api"
-version = "3.21.0-beta-0"
+version = "3.22.0-beta-0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -29,8 +29,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 hyper-util = { version = "0.1", features = ["client", "http1"] }
 http-body-util = "0.1"
 serde_json = "1.0"
-serial_test = "3.1"
-tokio = { version = "1.41", features = [
+serial_test = "3.2"
+tokio = { version = "1.42", features = [
   "rt-multi-thread",
   "macros",
   "sync",

--- a/packages/rust/armonik/Cargo.toml
+++ b/packages/rust/armonik/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 readme = "README.md"
 name = "armonik"
 repository = "https://github.com/aneoconsulting/ArmoniK.Api"
-version = "3.22.0-beta-0"
+version = "3.24.0-beta-0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/rust/armonik/build.rs
+++ b/packages/rust/armonik/build.rs
@@ -16,6 +16,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "protos/V1/events_service.proto",
                 "protos/V1/filters_common.proto",
                 "protos/V1/objects.proto",
+                "protos/V1/health_checks_common.proto",
+                "protos/V1/health_checks_service.proto",
                 "protos/V1/partitions_common.proto",
                 "protos/V1/partitions_fields.proto",
                 "protos/V1/partitions_filters.proto",

--- a/packages/rust/armonik/src/api/v3.rs
+++ b/packages/rust/armonik/src/api/v3.rs
@@ -14,6 +14,9 @@ pub mod auth {
 pub mod events {
     tonic::include_proto!("armonik.api.grpc.v1.events");
 }
+pub mod health_checks {
+    tonic::include_proto!("armonik.api.grpc.v1.health_checks");
+}
 pub mod partitions {
     tonic::include_proto!("armonik.api.grpc.v1.partitions");
 }

--- a/packages/rust/armonik/src/client/agent.rs
+++ b/packages/rust/armonik/src/client/agent.rs
@@ -15,11 +15,11 @@ use super::{GrpcCall, GrpcCallStream};
 
 /// The ResultsService provides methods for interacting with results.
 #[derive(Clone)]
-pub struct AgentClient<T> {
+pub struct Agent<T> {
     inner: v3::agent::agent_client::AgentClient<T>,
 }
 
-impl<T> AgentClient<T>
+impl<T> Agent<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::Error: Into<tonic::codegen::StdError>,
@@ -138,7 +138,7 @@ where
 }
 
 super::impl_call! {
-    AgentClient {
+    Agent {
         async fn call(self, request: create_results_metadata::Request) -> Result<create_results_metadata::Response> {
             Ok(self
                 .inner
@@ -209,7 +209,7 @@ super::impl_call! {
 }
 
 #[async_trait::async_trait(?Send)]
-impl<T, S> GrpcCallStream<create_tasks::Request, S> for &'_ mut AgentClient<T>
+impl<T, S> GrpcCallStream<create_tasks::Request, S> for &'_ mut Agent<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::Error: Into<tonic::codegen::StdError>,
@@ -243,7 +243,7 @@ mod tests {
     #[tokio::test]
     async fn create_results_metadata() {
         let before = Client::get_nb_request("Agent", "CreateResultsMetaData").await;
-        let mut client = Client::new().await.unwrap().agent();
+        let mut client = Client::new().await.unwrap().into_agent();
         client
             .create_results_metadata("token", "session-id", ["result1", "result2"])
             .await
@@ -255,7 +255,7 @@ mod tests {
     #[tokio::test]
     async fn create_results() {
         let before = Client::get_nb_request("Agent", "CreateResults").await;
-        let mut client = Client::new().await.unwrap().agent();
+        let mut client = Client::new().await.unwrap().into_agent();
         client
             .create_results("token", "session-id", [("result1", "payload")])
             .await
@@ -267,7 +267,7 @@ mod tests {
     #[tokio::test]
     async fn notify_result_data() {
         let before = Client::get_nb_request("Agent", "NotifyResultData").await;
-        let mut client = Client::new().await.unwrap().agent();
+        let mut client = Client::new().await.unwrap().into_agent();
         client
             .notify_result_data("token", "session-id", ["result1", "result2"])
             .await
@@ -279,7 +279,7 @@ mod tests {
     #[tokio::test]
     async fn submit() {
         let before = Client::get_nb_request("Agent", "SubmitTasks").await;
-        let mut client = Client::new().await.unwrap().agent();
+        let mut client = Client::new().await.unwrap().into_agent();
         client
             .submit_tasks("token", "session-id", None, [])
             .await
@@ -291,7 +291,7 @@ mod tests {
     #[tokio::test]
     async fn create_tasks() {
         let before = Client::get_nb_request("Agent", "CreateTask").await;
-        let mut client = Client::new().await.unwrap().agent();
+        let mut client = Client::new().await.unwrap().into_agent();
 
         client
             .create_tasks(futures::stream::iter([
@@ -308,7 +308,7 @@ mod tests {
     #[tokio::test]
     async fn create_results_metadata_call() {
         let before = Client::get_nb_request("Agent", "CreateResultsMetaData").await;
-        let mut client = Client::new().await.unwrap().agent();
+        let mut client = Client::new().await.unwrap().into_agent();
         client
             .call(crate::agent::create_results_metadata::Request {
                 communication_token: String::from("token"),
@@ -324,7 +324,7 @@ mod tests {
     #[tokio::test]
     async fn create_results_call() {
         let before = Client::get_nb_request("Agent", "CreateResults").await;
-        let mut client = Client::new().await.unwrap().agent();
+        let mut client = Client::new().await.unwrap().into_agent();
         client
             .call(crate::agent::create_results::Request {
                 communication_token: String::from("token"),
@@ -340,7 +340,7 @@ mod tests {
     #[tokio::test]
     async fn notify_result_data_call() {
         let before = Client::get_nb_request("Agent", "NotifyResultData").await;
-        let mut client = Client::new().await.unwrap().agent();
+        let mut client = Client::new().await.unwrap().into_agent();
         client
             .call(crate::agent::notify_result_data::Request {
                 communication_token: String::from("token"),
@@ -356,7 +356,7 @@ mod tests {
     #[tokio::test]
     async fn submit_tasks_call() {
         let before = Client::get_nb_request("Agent", "SubmitTasks").await;
-        let mut client = Client::new().await.unwrap().agent();
+        let mut client = Client::new().await.unwrap().into_agent();
         client
             .call(crate::agent::submit_tasks::Request {
                 communication_token: String::from("token"),
@@ -373,7 +373,7 @@ mod tests {
     #[tokio::test]
     async fn get_resource_data_call() {
         let before = Client::get_nb_request("Agent", "GetResourceData").await;
-        let mut client = Client::new().await.unwrap().agent();
+        let mut client = Client::new().await.unwrap().into_agent();
         client
             .call(crate::agent::get_resource_data::Request {
                 communication_token: String::from("token"),
@@ -388,7 +388,7 @@ mod tests {
     #[tokio::test]
     async fn get_common_data_call() {
         let before = Client::get_nb_request("Agent", "GetCommonData").await;
-        let mut client = Client::new().await.unwrap().agent();
+        let mut client = Client::new().await.unwrap().into_agent();
         client
             .call(crate::agent::get_common_data::Request {
                 communication_token: String::from("token"),
@@ -403,7 +403,7 @@ mod tests {
     #[tokio::test]
     async fn get_direct_data_call() {
         let before = Client::get_nb_request("Agent", "GetDirectData").await;
-        let mut client = Client::new().await.unwrap().agent();
+        let mut client = Client::new().await.unwrap().into_agent();
         client
             .call(crate::agent::get_direct_data::Request {
                 communication_token: String::from("token"),
@@ -418,7 +418,7 @@ mod tests {
     #[tokio::test]
     async fn create_tasks_call() {
         let before = Client::get_nb_request("Agent", "CreateTask").await;
-        let mut client = Client::new().await.unwrap().agent();
+        let mut client = Client::new().await.unwrap().into_agent();
 
         client
             .call(futures::stream::iter([

--- a/packages/rust/armonik/src/client/applications.rs
+++ b/packages/rust/armonik/src/client/applications.rs
@@ -7,11 +7,11 @@ use crate::utils::IntoCollection;
 use super::GrpcCall;
 
 #[derive(Clone)]
-pub struct ApplicationsClient<T> {
+pub struct Applications<T> {
     inner: v3::applications::applications_client::ApplicationsClient<T>,
 }
 
-impl<T> ApplicationsClient<T>
+impl<T> Applications<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::Error: Into<tonic::codegen::StdError>,
@@ -57,7 +57,7 @@ where
 }
 
 super::impl_call! {
-    ApplicationsClient {
+    Applications {
         async fn call(self, request: list::Request) -> Result<list::Response> {
             Ok(self
                 .inner
@@ -80,7 +80,7 @@ mod tests {
     #[tokio::test]
     async fn list() {
         let before = Client::get_nb_request("Applications", "ListApplications").await;
-        let mut client = Client::new().await.unwrap().applications();
+        let mut client = Client::new().await.unwrap().into_applications();
         client
             .list(
                 crate::applications::filter::Or {
@@ -101,7 +101,7 @@ mod tests {
     #[tokio::test]
     async fn list_call() {
         let before = Client::get_nb_request("Applications", "ListApplications").await;
-        let mut client = Client::new().await.unwrap().applications();
+        let mut client = Client::new().await.unwrap().into_applications();
         client
             .call(crate::applications::list::Request {
                 page_size: 10,

--- a/packages/rust/armonik/src/client/auth.rs
+++ b/packages/rust/armonik/src/client/auth.rs
@@ -7,11 +7,11 @@ use super::GrpcCall;
 
 /// Service for authentication management.
 #[derive(Clone)]
-pub struct AuthClient<T> {
+pub struct Auth<T> {
     inner: v3::auth::authentication_client::AuthenticationClient<T>,
 }
 
-impl<T> AuthClient<T>
+impl<T> Auth<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::Error: Into<tonic::codegen::StdError>,
@@ -43,7 +43,7 @@ where
 }
 
 super::impl_call! {
-    AuthClient {
+    Auth {
         async fn call(self, request: current_user::Request) -> Result<current_user::Response> {
             Ok(self
                 .inner
@@ -66,7 +66,7 @@ mod tests {
     #[tokio::test]
     async fn current_user() {
         let before = Client::get_nb_request("Authentication", "GetCurrentUser").await;
-        let mut client = Client::new().await.unwrap().auth();
+        let mut client = Client::new().await.unwrap().into_auth();
         client.current_user().await.unwrap();
         let after = Client::get_nb_request("Authentication", "GetCurrentUser").await;
         assert_eq!(after - before, 1);
@@ -77,7 +77,7 @@ mod tests {
     #[tokio::test]
     async fn current_user_call() {
         let before = Client::get_nb_request("Authentication", "GetCurrentUser").await;
-        let mut client = Client::new().await.unwrap().auth();
+        let mut client = Client::new().await.unwrap().into_auth();
         client
             .call(crate::auth::current_user::Request {})
             .await

--- a/packages/rust/armonik/src/client/events.rs
+++ b/packages/rust/armonik/src/client/events.rs
@@ -9,11 +9,11 @@ use super::GrpcCall;
 
 /// Service for authentication management.
 #[derive(Clone)]
-pub struct EventsClient<T> {
+pub struct Events<T> {
     inner: v3::events::events_client::EventsClient<T>,
 }
 
-impl<T> EventsClient<T>
+impl<T> Events<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::Error: Into<tonic::codegen::StdError>,
@@ -73,7 +73,7 @@ where
 }
 
 #[async_trait::async_trait(?Send)]
-impl<T> GrpcCall<subscribe::Request> for &'_ mut EventsClient<T>
+impl<T> GrpcCall<subscribe::Request> for &'_ mut Events<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::Error: Into<tonic::codegen::StdError>,
@@ -108,7 +108,7 @@ mod tests {
     #[tokio::test]
     async fn subscribe() {
         let before = Client::get_nb_request("Events", "GetEvents").await;
-        let mut client = Client::new().await.unwrap().events();
+        let mut client = Client::new().await.unwrap().into_events();
         client
             .subscribe(
                 "session-id",
@@ -129,7 +129,7 @@ mod tests {
     #[tokio::test]
     async fn subscribe_call() {
         let before = Client::get_nb_request("Events", "GetEvents").await;
-        let mut client = Client::new().await.unwrap().events();
+        let mut client = Client::new().await.unwrap().into_events();
         client
             .call(crate::events::subscribe::Request {
                 session_id: String::from("session-id"),

--- a/packages/rust/armonik/src/client/health_checks.rs
+++ b/packages/rust/armonik/src/client/health_checks.rs
@@ -1,0 +1,91 @@
+use snafu::ResultExt;
+
+use crate::api::v3;
+use crate::health_checks::check;
+
+use super::GrpcCall;
+
+/// Service for authentication management.
+#[derive(Clone)]
+pub struct HealthChecksClient<T> {
+    inner: v3::health_checks::health_checks_service_client::HealthChecksServiceClient<T>,
+}
+
+impl<T> HealthChecksClient<T>
+where
+    T: tonic::client::GrpcService<tonic::body::BoxBody>,
+    T::Error: Into<tonic::codegen::StdError>,
+    T::ResponseBody: tonic::codegen::Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    <T::ResponseBody as tonic::codegen::Body>::Error: Into<tonic::codegen::StdError> + Send,
+{
+    /// Build a client from a gRPC channel
+    pub fn with_channel(channel: T) -> Self {
+        Self {
+            inner: v3::health_checks::health_checks_service_client::HealthChecksServiceClient::new(
+                channel,
+            ),
+        }
+    }
+
+    /// Checks the health of the cluster. This can be used to verify that the cluster is up and running.
+    pub async fn check(
+        &mut self,
+    ) -> Result<Vec<crate::health_checks::ServiceHealth>, super::RequestError> {
+        Ok(self.call(check::Request {}).await?.services)
+    }
+
+    /// Perform a gRPC call from a raw request.
+    pub async fn call<Request>(
+        &mut self,
+        request: Request,
+    ) -> Result<<&mut Self as GrpcCall<Request>>::Response, <&mut Self as GrpcCall<Request>>::Error>
+    where
+        for<'a> &'a mut Self: GrpcCall<Request>,
+    {
+        <&mut Self as GrpcCall<Request>>::call(self, request).await
+    }
+}
+
+super::impl_call! {
+    HealthChecksClient {
+        async fn call(self, request: check::Request) -> Result<check::Response> {
+            Ok(self
+                .inner
+                .check_health(request)
+                .await
+                .context(super::GrpcSnafu {})?
+                .into_inner()
+                .into())
+        }
+    }
+}
+
+#[cfg(test)]
+#[serial_test::serial(auth)]
+mod tests {
+    use crate::Client;
+
+    // Named methods
+
+    #[tokio::test]
+    async fn check() {
+        let before = Client::get_nb_request("HealthChecksService", "CheckHealth").await;
+        let mut client = Client::new().await.unwrap().health_checks();
+        client.check().await.unwrap();
+        let after = Client::get_nb_request("HealthChecksService", "CheckHealth").await;
+        assert_eq!(after - before, 1);
+    }
+    // Explicit call request
+
+    #[tokio::test]
+    async fn check_call() {
+        let before = Client::get_nb_request("HealthChecksService", "CheckHealth").await;
+        let mut client = Client::new().await.unwrap().health_checks();
+        client
+            .call(crate::health_checks::check::Request {})
+            .await
+            .unwrap();
+        let after = Client::get_nb_request("HealthChecksService", "CheckHealth").await;
+        assert_eq!(after - before, 1);
+    }
+}

--- a/packages/rust/armonik/src/client/health_checks.rs
+++ b/packages/rust/armonik/src/client/health_checks.rs
@@ -7,11 +7,11 @@ use super::GrpcCall;
 
 /// Service for authentication management.
 #[derive(Clone)]
-pub struct HealthChecksClient<T> {
+pub struct HealthChecks<T> {
     inner: v3::health_checks::health_checks_service_client::HealthChecksServiceClient<T>,
 }
 
-impl<T> HealthChecksClient<T>
+impl<T> HealthChecks<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::Error: Into<tonic::codegen::StdError>,
@@ -47,7 +47,7 @@ where
 }
 
 super::impl_call! {
-    HealthChecksClient {
+    HealthChecks {
         async fn call(self, request: check::Request) -> Result<check::Response> {
             Ok(self
                 .inner
@@ -70,7 +70,7 @@ mod tests {
     #[tokio::test]
     async fn check() {
         let before = Client::get_nb_request("HealthChecksService", "CheckHealth").await;
-        let mut client = Client::new().await.unwrap().health_checks();
+        let mut client = Client::new().await.unwrap().into_health_checks();
         client.check().await.unwrap();
         let after = Client::get_nb_request("HealthChecksService", "CheckHealth").await;
         assert_eq!(after - before, 1);
@@ -80,7 +80,7 @@ mod tests {
     #[tokio::test]
     async fn check_call() {
         let before = Client::get_nb_request("HealthChecksService", "CheckHealth").await;
-        let mut client = Client::new().await.unwrap().health_checks();
+        let mut client = Client::new().await.unwrap().into_health_checks();
         client
             .call(crate::health_checks::check::Request {})
             .await

--- a/packages/rust/armonik/src/client/health_checks.rs
+++ b/packages/rust/armonik/src/client/health_checks.rs
@@ -61,7 +61,7 @@ super::impl_call! {
 }
 
 #[cfg(test)]
-#[serial_test::serial(auth)]
+#[serial_test::serial(health_checks)]
 mod tests {
     use crate::Client;
 
@@ -69,23 +69,23 @@ mod tests {
 
     #[tokio::test]
     async fn check() {
-        let before = Client::get_nb_request("HealthChecksService", "CheckHealth").await;
+        let before = Client::get_nb_request("HealthChecks", "CheckHealth").await;
         let mut client = Client::new().await.unwrap().into_health_checks();
         client.check().await.unwrap();
-        let after = Client::get_nb_request("HealthChecksService", "CheckHealth").await;
+        let after = Client::get_nb_request("HealthChecks", "CheckHealth").await;
         assert_eq!(after - before, 1);
     }
     // Explicit call request
 
     #[tokio::test]
     async fn check_call() {
-        let before = Client::get_nb_request("HealthChecksService", "CheckHealth").await;
+        let before = Client::get_nb_request("HealthChecks", "CheckHealth").await;
         let mut client = Client::new().await.unwrap().into_health_checks();
         client
             .call(crate::health_checks::check::Request {})
             .await
             .unwrap();
-        let after = Client::get_nb_request("HealthChecksService", "CheckHealth").await;
+        let after = Client::get_nb_request("HealthChecks", "CheckHealth").await;
         assert_eq!(after - before, 1);
     }
 }

--- a/packages/rust/armonik/src/client/mod.rs
+++ b/packages/rust/armonik/src/client/mod.rs
@@ -22,20 +22,20 @@ mod versions;
 mod worker;
 
 pub use crate::utils::ReadEnvError;
-pub use agent::AgentClient;
-pub use applications::ApplicationsClient;
-pub use auth::AuthClient;
+pub use agent::Agent;
+pub use applications::Applications;
+pub use auth::Auth;
 pub use config::{ClientConfig, ClientConfigArgs, ConfigError};
-pub use events::EventsClient;
-pub use health_checks::HealthChecksClient;
-pub use partitions::PartitionsClient;
-pub use results::ResultsClient;
-pub use sessions::SessionsClient;
+pub use events::Events;
+pub use health_checks::HealthChecks;
+pub use partitions::Partitions;
+pub use results::Results;
+pub use sessions::Sessions;
 #[allow(deprecated)]
-pub use submitter::SubmitterClient;
-pub use tasks::TasksClient;
-pub use versions::VersionsClient;
-pub use worker::WorkerClient;
+pub use submitter::Submitter;
+pub use tasks::Tasks;
+pub use versions::Versions;
+pub use worker::Worker;
 
 /// ArmoniK Client
 #[derive(Clone)]
@@ -193,116 +193,162 @@ where
         Self { channel }
     }
 
-    /// Create an [`AgentClient`]
-    pub fn agent(&self) -> AgentClient<T> {
-        AgentClient::with_channel(self.channel.clone())
+    /// Create a borrowed [`Agent`]
+    pub fn agent(&mut self) -> Agent<&mut Self> {
+        Agent::with_channel(self)
     }
-    /// Create an [`AgentClient`]
-    pub fn into_agent(self) -> AgentClient<T> {
-        AgentClient::with_channel(self.channel)
-    }
-
-    /// Create an [`ApplicationsClient`]
-    pub fn applications(&self) -> ApplicationsClient<T> {
-        ApplicationsClient::with_channel(self.channel.clone())
-    }
-    /// Create an [`ApplicationsClient`]
-    pub fn into_applications(self) -> ApplicationsClient<T> {
-        ApplicationsClient::with_channel(self.channel)
+    /// Create an owned [`Agent`]
+    pub fn into_agent(self) -> Agent<Self> {
+        Agent::with_channel(self)
     }
 
-    /// Create an [`AuthClient`]
-    pub fn auth(&self) -> AuthClient<T> {
-        AuthClient::with_channel(self.channel.clone())
+    /// Create a borrowed [`Applications`]
+    pub fn applications(&mut self) -> Applications<&mut Self> {
+        Applications::with_channel(self)
     }
-    /// Create an [`AuthClient`]
-    pub fn into_auth(self) -> AuthClient<T> {
-        AuthClient::with_channel(self.channel)
-    }
-
-    /// Create an [`EventsClient`]
-    pub fn events(&self) -> EventsClient<T> {
-        EventsClient::with_channel(self.channel.clone())
-    }
-    /// Create an [`EventsClient`]
-    pub fn into_events(self) -> EventsClient<T> {
-        EventsClient::with_channel(self.channel)
+    /// Create an owned [`Applications`]
+    pub fn into_applications(self) -> Applications<Self> {
+        Applications::with_channel(self)
     }
 
-    /// Create a [`HealthChecksClient`]
-    pub fn health_checks(&self) -> HealthChecksClient<T> {
-        HealthChecksClient::with_channel(self.channel.clone())
+    /// Create a borrowed [`Auth`]
+    pub fn auth(&mut self) -> Auth<&mut Self> {
+        Auth::with_channel(self)
     }
-    /// Create a [`HealthChecksClient`]
-    pub fn into_health_checks(self) -> HealthChecksClient<T> {
-        HealthChecksClient::with_channel(self.channel)
-    }
-
-    /// Create a [`PartitionsClient`]
-    pub fn partitions(&self) -> PartitionsClient<T> {
-        PartitionsClient::with_channel(self.channel.clone())
-    }
-    /// Create a [`PartitionsClient`]
-    pub fn into_partitions(self) -> PartitionsClient<T> {
-        PartitionsClient::with_channel(self.channel)
+    /// Create an owned [`Auth`]
+    pub fn into_auth(self) -> Auth<Self> {
+        Auth::with_channel(self)
     }
 
-    /// Create a [`ResultsClient`]
-    pub fn results(&self) -> ResultsClient<T> {
-        ResultsClient::with_channel(self.channel.clone())
+    /// Create a borrowed [`Events`]
+    pub fn events(&mut self) -> Events<&mut Self> {
+        Events::with_channel(self)
     }
-    /// Create a [`ResultsClient`]
-    pub fn into_results(self) -> ResultsClient<T> {
-        ResultsClient::with_channel(self.channel)
-    }
-
-    /// Create a [`SessionsClient`]
-    pub fn sessions(&self) -> SessionsClient<T> {
-        SessionsClient::with_channel(self.channel.clone())
-    }
-    /// Create a [`SessionsClient`]
-    pub fn into_sessions(self) -> SessionsClient<T> {
-        SessionsClient::with_channel(self.channel)
+    /// Create an owned [`Events`]
+    pub fn into_events(self) -> Events<Self> {
+        Events::with_channel(self)
     }
 
-    /// Create a [`SubmitterClient`]
+    /// Create a borrowed [`HealthChecks`]
+    pub fn health_checks(&mut self) -> HealthChecks<&mut Self> {
+        HealthChecks::with_channel(self)
+    }
+    /// Create an owned [`HealthChecks`]
+    pub fn into_health_checks(self) -> HealthChecks<Self> {
+        HealthChecks::with_channel(self)
+    }
+
+    /// Create a borrowed [`Partitions`]
+    pub fn partitions(&mut self) -> Partitions<&mut Self> {
+        Partitions::with_channel(self)
+    }
+    /// Create an owned [`Partitions`]
+    pub fn into_partitions(self) -> Partitions<Self> {
+        Partitions::with_channel(self)
+    }
+
+    /// Create a borrowed [`Results`]
+    pub fn results(&mut self) -> Results<&mut Self> {
+        Results::with_channel(self)
+    }
+    /// Create an owned [`Results`]
+    pub fn into_results(self) -> Results<Self> {
+        Results::with_channel(self)
+    }
+
+    /// Create a borrowed [`Sessions`]
+    pub fn sessions(&mut self) -> Sessions<&mut Self> {
+        Sessions::with_channel(self)
+    }
+    /// Create an owned [`Sessions`]
+    pub fn into_sessions(self) -> Sessions<Self> {
+        Sessions::with_channel(self)
+    }
+
+    /// Create a borrowed [`Submitter`]
     #[deprecated]
     #[allow(deprecated)]
-    pub fn submitter(&self) -> SubmitterClient<T> {
-        SubmitterClient::with_channel(self.channel.clone())
+    pub fn submitter(&mut self) -> Submitter<&mut Self> {
+        Submitter::with_channel(self)
     }
     #[deprecated]
     #[allow(deprecated)]
-    /// Create a [`SubmitterClient`]
-    pub fn into_submitter(self) -> SubmitterClient<T> {
-        SubmitterClient::with_channel(self.channel)
+    /// Create an owned [`Submitter`]
+    pub fn into_submitter(self) -> Submitter<Self> {
+        Submitter::with_channel(self)
     }
 
-    /// Create a [`TasksClient`]
-    pub fn tasks(&self) -> TasksClient<T> {
-        TasksClient::with_channel(self.channel.clone())
+    /// Create a borrowed [`Tasks`]
+    pub fn tasks(&mut self) -> Tasks<&mut Self> {
+        Tasks::with_channel(self)
     }
-    /// Create a [`TasksClient`]
-    pub fn into_tasks(self) -> TasksClient<T> {
-        TasksClient::with_channel(self.channel)
-    }
-
-    /// Create a [`VersionsClient`]
-    pub fn versions(&self) -> VersionsClient<T> {
-        VersionsClient::with_channel(self.channel.clone())
-    }
-    /// Create a [`VersionsClient`]
-    pub fn into_versions(self) -> VersionsClient<T> {
-        VersionsClient::with_channel(self.channel)
+    /// Create an owned [`Tasks`]
+    pub fn into_tasks(self) -> Tasks<Self> {
+        Tasks::with_channel(self)
     }
 
-    /// Create a [`WorkerClient`]
-    pub fn worker(&self) -> WorkerClient<T> {
-        WorkerClient::with_channel(self.channel.clone())
+    /// Create a borrowed [`Versions`]
+    pub fn versions(&mut self) -> Versions<&mut Self> {
+        Versions::with_channel(self)
     }
-    /// Create a [`WorkerClient`]
-    pub fn into_worker(self) -> WorkerClient<T> {
-        WorkerClient::with_channel(self.channel)
+    /// Create an owned [`Versions`]
+    pub fn into_versions(self) -> Versions<Self> {
+        Versions::with_channel(self)
+    }
+
+    /// Create a borrowed [`Worker`]
+    pub fn worker(&mut self) -> Worker<&mut Self> {
+        Worker::with_channel(self)
+    }
+    /// Create an owned [`Worker`]
+    pub fn into_worker(self) -> Worker<Self> {
+        Worker::with_channel(self)
+    }
+}
+
+impl<T> tonic::client::GrpcService<tonic::body::BoxBody> for Client<T>
+where
+    T: tonic::client::GrpcService<tonic::body::BoxBody>,
+    T::Error: Into<tonic::codegen::StdError>,
+    T::ResponseBody: tonic::codegen::Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    <T::ResponseBody as tonic::codegen::Body>::Error: Into<tonic::codegen::StdError> + Send,
+{
+    type ResponseBody = T::ResponseBody;
+    type Error = T::Error;
+    type Future = T::Future;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.channel.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: hyper::http::Request<tonic::body::BoxBody>) -> Self::Future {
+        self.channel.call(request)
+    }
+}
+
+impl<T> tonic::client::GrpcService<tonic::body::BoxBody> for &'_ mut Client<T>
+where
+    T: tonic::client::GrpcService<tonic::body::BoxBody>,
+    T::Error: Into<tonic::codegen::StdError>,
+    T::ResponseBody: tonic::codegen::Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    <T::ResponseBody as tonic::codegen::Body>::Error: Into<tonic::codegen::StdError> + Send,
+{
+    type ResponseBody = T::ResponseBody;
+    type Error = T::Error;
+    type Future = T::Future;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.channel.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: hyper::http::Request<tonic::body::BoxBody>) -> Self::Future {
+        self.channel.call(request)
     }
 }
 

--- a/packages/rust/armonik/src/client/mod.rs
+++ b/packages/rust/armonik/src/client/mod.rs
@@ -12,6 +12,7 @@ mod applications;
 mod auth;
 mod config;
 mod events;
+mod health_checks;
 mod partitions;
 mod results;
 mod sessions;
@@ -26,6 +27,7 @@ pub use applications::ApplicationsClient;
 pub use auth::AuthClient;
 pub use config::{ClientConfig, ClientConfigArgs, ConfigError};
 pub use events::EventsClient;
+pub use health_checks::HealthChecksClient;
 pub use partitions::PartitionsClient;
 pub use results::ResultsClient;
 pub use sessions::SessionsClient;
@@ -195,7 +197,6 @@ where
     pub fn agent(&self) -> AgentClient<T> {
         AgentClient::with_channel(self.channel.clone())
     }
-    #[cfg(feature = "worker")]
     /// Create an [`AgentClient`]
     pub fn into_agent(self) -> AgentClient<T> {
         AgentClient::with_channel(self.channel)
@@ -205,7 +206,6 @@ where
     pub fn applications(&self) -> ApplicationsClient<T> {
         ApplicationsClient::with_channel(self.channel.clone())
     }
-    #[cfg(feature = "client")]
     /// Create an [`ApplicationsClient`]
     pub fn into_applications(self) -> ApplicationsClient<T> {
         ApplicationsClient::with_channel(self.channel)
@@ -215,7 +215,6 @@ where
     pub fn auth(&self) -> AuthClient<T> {
         AuthClient::with_channel(self.channel.clone())
     }
-    #[cfg(feature = "client")]
     /// Create an [`AuthClient`]
     pub fn into_auth(self) -> AuthClient<T> {
         AuthClient::with_channel(self.channel)
@@ -225,17 +224,24 @@ where
     pub fn events(&self) -> EventsClient<T> {
         EventsClient::with_channel(self.channel.clone())
     }
-    #[cfg(feature = "client")]
     /// Create an [`EventsClient`]
     pub fn into_events(self) -> EventsClient<T> {
         EventsClient::with_channel(self.channel)
+    }
+
+    /// Create a [`HealthChecksClient`]
+    pub fn health_checks(&self) -> HealthChecksClient<T> {
+        HealthChecksClient::with_channel(self.channel.clone())
+    }
+    /// Create a [`HealthChecksClient`]
+    pub fn into_health_checks(self) -> HealthChecksClient<T> {
+        HealthChecksClient::with_channel(self.channel)
     }
 
     /// Create a [`PartitionsClient`]
     pub fn partitions(&self) -> PartitionsClient<T> {
         PartitionsClient::with_channel(self.channel.clone())
     }
-    #[cfg(feature = "client")]
     /// Create a [`PartitionsClient`]
     pub fn into_partitions(self) -> PartitionsClient<T> {
         PartitionsClient::with_channel(self.channel)
@@ -245,7 +251,6 @@ where
     pub fn results(&self) -> ResultsClient<T> {
         ResultsClient::with_channel(self.channel.clone())
     }
-    #[cfg(feature = "client")]
     /// Create a [`ResultsClient`]
     pub fn into_results(self) -> ResultsClient<T> {
         ResultsClient::with_channel(self.channel)
@@ -255,7 +260,6 @@ where
     pub fn sessions(&self) -> SessionsClient<T> {
         SessionsClient::with_channel(self.channel.clone())
     }
-    #[cfg(feature = "client")]
     /// Create a [`SessionsClient`]
     pub fn into_sessions(self) -> SessionsClient<T> {
         SessionsClient::with_channel(self.channel)
@@ -267,7 +271,6 @@ where
     pub fn submitter(&self) -> SubmitterClient<T> {
         SubmitterClient::with_channel(self.channel.clone())
     }
-    #[cfg(feature = "client")]
     #[deprecated]
     #[allow(deprecated)]
     /// Create a [`SubmitterClient`]
@@ -279,7 +282,6 @@ where
     pub fn tasks(&self) -> TasksClient<T> {
         TasksClient::with_channel(self.channel.clone())
     }
-    #[cfg(feature = "client")]
     /// Create a [`TasksClient`]
     pub fn into_tasks(self) -> TasksClient<T> {
         TasksClient::with_channel(self.channel)
@@ -289,7 +291,6 @@ where
     pub fn versions(&self) -> VersionsClient<T> {
         VersionsClient::with_channel(self.channel.clone())
     }
-    #[cfg(feature = "client")]
     /// Create a [`VersionsClient`]
     pub fn into_versions(self) -> VersionsClient<T> {
         VersionsClient::with_channel(self.channel)
@@ -299,7 +300,6 @@ where
     pub fn worker(&self) -> WorkerClient<T> {
         WorkerClient::with_channel(self.channel.clone())
     }
-    #[cfg(feature = "agent")]
     /// Create a [`WorkerClient`]
     pub fn into_worker(self) -> WorkerClient<T> {
         WorkerClient::with_channel(self.channel)

--- a/packages/rust/armonik/src/client/mod.rs
+++ b/packages/rust/armonik/src/client/mod.rs
@@ -195,35 +195,70 @@ where
     pub fn agent(&self) -> AgentClient<T> {
         AgentClient::with_channel(self.channel.clone())
     }
+    #[cfg(feature = "worker")]
+    /// Create an [`AgentClient`]
+    pub fn into_agent(self) -> AgentClient<T> {
+        AgentClient::with_channel(self.channel)
+    }
 
     /// Create an [`ApplicationsClient`]
     pub fn applications(&self) -> ApplicationsClient<T> {
         ApplicationsClient::with_channel(self.channel.clone())
+    }
+    #[cfg(feature = "client")]
+    /// Create an [`ApplicationsClient`]
+    pub fn into_applications(self) -> ApplicationsClient<T> {
+        ApplicationsClient::with_channel(self.channel)
     }
 
     /// Create an [`AuthClient`]
     pub fn auth(&self) -> AuthClient<T> {
         AuthClient::with_channel(self.channel.clone())
     }
+    #[cfg(feature = "client")]
+    /// Create an [`AuthClient`]
+    pub fn into_auth(self) -> AuthClient<T> {
+        AuthClient::with_channel(self.channel)
+    }
 
     /// Create an [`EventsClient`]
     pub fn events(&self) -> EventsClient<T> {
         EventsClient::with_channel(self.channel.clone())
+    }
+    #[cfg(feature = "client")]
+    /// Create an [`EventsClient`]
+    pub fn into_events(self) -> EventsClient<T> {
+        EventsClient::with_channel(self.channel)
     }
 
     /// Create a [`PartitionsClient`]
     pub fn partitions(&self) -> PartitionsClient<T> {
         PartitionsClient::with_channel(self.channel.clone())
     }
+    #[cfg(feature = "client")]
+    /// Create a [`PartitionsClient`]
+    pub fn into_partitions(self) -> PartitionsClient<T> {
+        PartitionsClient::with_channel(self.channel)
+    }
 
     /// Create a [`ResultsClient`]
     pub fn results(&self) -> ResultsClient<T> {
         ResultsClient::with_channel(self.channel.clone())
     }
+    #[cfg(feature = "client")]
+    /// Create a [`ResultsClient`]
+    pub fn into_results(self) -> ResultsClient<T> {
+        ResultsClient::with_channel(self.channel)
+    }
 
     /// Create a [`SessionsClient`]
     pub fn sessions(&self) -> SessionsClient<T> {
         SessionsClient::with_channel(self.channel.clone())
+    }
+    #[cfg(feature = "client")]
+    /// Create a [`SessionsClient`]
+    pub fn into_sessions(self) -> SessionsClient<T> {
+        SessionsClient::with_channel(self.channel)
     }
 
     /// Create a [`SubmitterClient`]
@@ -232,20 +267,42 @@ where
     pub fn submitter(&self) -> SubmitterClient<T> {
         SubmitterClient::with_channel(self.channel.clone())
     }
+    #[cfg(feature = "client")]
+    #[deprecated]
+    #[allow(deprecated)]
+    /// Create a [`SubmitterClient`]
+    pub fn into_submitter(self) -> SubmitterClient<T> {
+        SubmitterClient::with_channel(self.channel)
+    }
 
     /// Create a [`TasksClient`]
     pub fn tasks(&self) -> TasksClient<T> {
         TasksClient::with_channel(self.channel.clone())
+    }
+    #[cfg(feature = "client")]
+    /// Create a [`TasksClient`]
+    pub fn into_tasks(self) -> TasksClient<T> {
+        TasksClient::with_channel(self.channel)
     }
 
     /// Create a [`VersionsClient`]
     pub fn versions(&self) -> VersionsClient<T> {
         VersionsClient::with_channel(self.channel.clone())
     }
+    #[cfg(feature = "client")]
+    /// Create a [`VersionsClient`]
+    pub fn into_versions(self) -> VersionsClient<T> {
+        VersionsClient::with_channel(self.channel)
+    }
 
     /// Create a [`WorkerClient`]
     pub fn worker(&self) -> WorkerClient<T> {
         WorkerClient::with_channel(self.channel.clone())
+    }
+    #[cfg(feature = "agent")]
+    /// Create a [`WorkerClient`]
+    pub fn into_worker(self) -> WorkerClient<T> {
+        WorkerClient::with_channel(self.channel)
     }
 }
 

--- a/packages/rust/armonik/src/client/partitions.rs
+++ b/packages/rust/armonik/src/client/partitions.rs
@@ -7,11 +7,11 @@ use crate::utils::IntoCollection;
 use super::GrpcCall;
 
 #[derive(Clone)]
-pub struct PartitionsClient<T> {
+pub struct Partitions<T> {
     inner: v3::partitions::partitions_client::PartitionsClient<T>,
 }
 
-impl<T> PartitionsClient<T>
+impl<T> Partitions<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::Error: Into<tonic::codegen::StdError>,
@@ -69,7 +69,7 @@ where
 }
 
 super::impl_call! {
-    PartitionsClient {
+    Partitions {
         async fn call(self, request: list::Request) -> Result<list::Response> {
             Ok(self
                 .inner
@@ -102,7 +102,7 @@ mod tests {
     #[tokio::test]
     async fn list() {
         let before = Client::get_nb_request("Partitions", "ListPartitions").await;
-        let mut client = Client::new().await.unwrap().partitions();
+        let mut client = Client::new().await.unwrap().into_partitions();
         client
             .list(
                 crate::partitions::filter::Or {
@@ -121,7 +121,7 @@ mod tests {
     #[tokio::test]
     async fn get() {
         let before = Client::get_nb_request("Partitions", "GetPartition").await;
-        let mut client = Client::new().await.unwrap().partitions();
+        let mut client = Client::new().await.unwrap().into_partitions();
         client.get("part1").await.unwrap();
         let after = Client::get_nb_request("Partitions", "GetPartition").await;
         assert_eq!(after - before, 1);
@@ -132,7 +132,7 @@ mod tests {
     #[tokio::test]
     async fn list_call() {
         let before = Client::get_nb_request("Partitions", "ListPartitions").await;
-        let mut client = Client::new().await.unwrap().partitions();
+        let mut client = Client::new().await.unwrap().into_partitions();
         client
             .call(crate::partitions::list::Request {
                 page_size: 10,
@@ -147,7 +147,7 @@ mod tests {
     #[tokio::test]
     async fn get_call() {
         let before = Client::get_nb_request("Partitions", "GetPartition").await;
-        let mut client = Client::new().await.unwrap().partitions();
+        let mut client = Client::new().await.unwrap().into_partitions();
         client
             .call(crate::partitions::get::Request {
                 partition_id: String::from("part1"),

--- a/packages/rust/armonik/src/client/results.rs
+++ b/packages/rust/armonik/src/client/results.rs
@@ -14,11 +14,11 @@ use super::{GrpcCall, GrpcCallStream};
 
 /// The ResultsService provides methods for interacting with results.
 #[derive(Clone)]
-pub struct ResultsClient<T> {
+pub struct Results<T> {
     inner: v3::results::results_client::ResultsClient<T>,
 }
 
-impl<T> ResultsClient<T>
+impl<T> Results<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::Error: Into<tonic::codegen::StdError>,
@@ -205,7 +205,7 @@ where
 }
 
 super::impl_call! {
-    ResultsClient {
+    Results {
         async fn call(self, request: list::Request) -> Result<list::Response> {
             Ok(self
                 .inner
@@ -279,7 +279,7 @@ super::impl_call! {
 }
 
 #[async_trait::async_trait(?Send)]
-impl<T> GrpcCall<download::Request> for &'_ mut ResultsClient<T>
+impl<T> GrpcCall<download::Request> for &'_ mut Results<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::Error: Into<tonic::codegen::StdError>,
@@ -303,7 +303,7 @@ where
 }
 
 #[async_trait::async_trait(?Send)]
-impl<T, S> GrpcCallStream<upload::Request, S> for &'_ mut ResultsClient<T>
+impl<T, S> GrpcCallStream<upload::Request, S> for &'_ mut Results<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::Error: Into<tonic::codegen::StdError>,
@@ -338,7 +338,7 @@ mod tests {
     #[tokio::test]
     async fn list() {
         let before = Client::get_nb_request("Results", "ListResults").await;
-        let mut client = Client::new().await.unwrap().results();
+        let mut client = Client::new().await.unwrap().into_results();
         client
             .list(
                 crate::results::filter::Or {
@@ -357,7 +357,7 @@ mod tests {
     #[tokio::test]
     async fn get() {
         let before = Client::get_nb_request("Results", "GetResult").await;
-        let mut client = Client::new().await.unwrap().results();
+        let mut client = Client::new().await.unwrap().into_results();
         client.get("result-id").await.unwrap();
         let after = Client::get_nb_request("Results", "GetResult").await;
         assert_eq!(after - before, 1);
@@ -366,7 +366,7 @@ mod tests {
     #[tokio::test]
     async fn get_owner_task_id() {
         let before = Client::get_nb_request("Results", "GetOwnerTaskId").await;
-        let mut client = Client::new().await.unwrap().results();
+        let mut client = Client::new().await.unwrap().into_results();
         client
             .get_owner_task_id("session-id", ["result1", "result2"])
             .await
@@ -378,7 +378,7 @@ mod tests {
     #[tokio::test]
     async fn create_metadata() {
         let before = Client::get_nb_request("Results", "CreateResultsMetaData").await;
-        let mut client = Client::new().await.unwrap().results();
+        let mut client = Client::new().await.unwrap().into_results();
         client
             .create_metadata("session-id", ["result1", "result2"])
             .await
@@ -390,7 +390,7 @@ mod tests {
     #[tokio::test]
     async fn create() {
         let before = Client::get_nb_request("Results", "CreateResults").await;
-        let mut client = Client::new().await.unwrap().results();
+        let mut client = Client::new().await.unwrap().into_results();
         client
             .create(
                 "session-id",
@@ -405,7 +405,7 @@ mod tests {
     #[tokio::test]
     async fn upload() {
         let before = Client::get_nb_request("Results", "UploadResultData").await;
-        let mut client = Client::new().await.unwrap().results();
+        let mut client = Client::new().await.unwrap().into_results();
         client
             .upload("session-id", "result-id", futures::stream::iter([b""]))
             .await
@@ -417,7 +417,7 @@ mod tests {
     #[tokio::test]
     async fn download() {
         let before = Client::get_nb_request("Results", "DownloadResultData").await;
-        let mut client = Client::new().await.unwrap().results();
+        let mut client = Client::new().await.unwrap().into_results();
         client
             .download("session-id", "result-id")
             .await
@@ -432,7 +432,7 @@ mod tests {
     #[tokio::test]
     async fn delete_data() {
         let before = Client::get_nb_request("Results", "DeleteResultsData").await;
-        let mut client = Client::new().await.unwrap().results();
+        let mut client = Client::new().await.unwrap().into_results();
         client
             .delete_data("session-id", ["result1", "result2"])
             .await
@@ -444,7 +444,7 @@ mod tests {
     #[tokio::test]
     async fn get_service_configuration() {
         let before = Client::get_nb_request("Results", "GetServiceConfiguration").await;
-        let mut client = Client::new().await.unwrap().results();
+        let mut client = Client::new().await.unwrap().into_results();
         client.get_service_configuration().await.unwrap();
         let after = Client::get_nb_request("Results", "GetServiceConfiguration").await;
         assert_eq!(after - before, 1);
@@ -455,7 +455,7 @@ mod tests {
     #[tokio::test]
     async fn list_call() {
         let before = Client::get_nb_request("Results", "ListResults").await;
-        let mut client = Client::new().await.unwrap().results();
+        let mut client = Client::new().await.unwrap().into_results();
         client
             .call(crate::results::list::Request {
                 page_size: 10,
@@ -470,7 +470,7 @@ mod tests {
     #[tokio::test]
     async fn get_call() {
         let before = Client::get_nb_request("Results", "GetResult").await;
-        let mut client = Client::new().await.unwrap().results();
+        let mut client = Client::new().await.unwrap().into_results();
         client
             .call(crate::results::get::Request {
                 id: String::from("result-id"),
@@ -484,7 +484,7 @@ mod tests {
     #[tokio::test]
     async fn get_owner_task_id_call() {
         let before = Client::get_nb_request("Results", "GetOwnerTaskId").await;
-        let mut client = Client::new().await.unwrap().results();
+        let mut client = Client::new().await.unwrap().into_results();
         client
             .call(crate::results::get_owner_task_id::Request {
                 session_id: String::from("session-id"),
@@ -499,7 +499,7 @@ mod tests {
     #[tokio::test]
     async fn create_metadata_call() {
         let before = Client::get_nb_request("Results", "CreateResultsMetaData").await;
-        let mut client = Client::new().await.unwrap().results();
+        let mut client = Client::new().await.unwrap().into_results();
         client
             .call(crate::results::create_metadata::Request {
                 session_id: String::from("session-id"),
@@ -514,7 +514,7 @@ mod tests {
     #[tokio::test]
     async fn create_call() {
         let before = Client::get_nb_request("Results", "CreateResults").await;
-        let mut client = Client::new().await.unwrap().results();
+        let mut client = Client::new().await.unwrap().into_results();
         client
             .call(crate::results::create::Request {
                 session_id: String::from("session-id"),
@@ -529,7 +529,7 @@ mod tests {
     #[tokio::test]
     async fn delete_data_call() {
         let before = Client::get_nb_request("Results", "DeleteResultsData").await;
-        let mut client = Client::new().await.unwrap().results();
+        let mut client = Client::new().await.unwrap().into_results();
         client
             .call(crate::results::delete_data::Request {
                 session_id: String::from("session-id"),
@@ -544,7 +544,7 @@ mod tests {
     #[tokio::test]
     async fn get_service_configuration_call() {
         let before = Client::get_nb_request("Results", "GetServiceConfiguration").await;
-        let mut client = Client::new().await.unwrap().results();
+        let mut client = Client::new().await.unwrap().into_results();
         client
             .call(crate::results::get_service_configuration::Request {})
             .await
@@ -556,7 +556,7 @@ mod tests {
     #[tokio::test]
     async fn download_call() {
         let before = Client::get_nb_request("Results", "DownloadResultData").await;
-        let mut client = Client::new().await.unwrap().results();
+        let mut client = Client::new().await.unwrap().into_results();
         client
             .call(crate::results::download::Request {
                 session_id: String::from("session-id"),
@@ -574,7 +574,7 @@ mod tests {
     #[tokio::test]
     async fn upload_call() {
         let before = Client::get_nb_request("Results", "UploadResultData").await;
-        let mut client = Client::new().await.unwrap().results();
+        let mut client = Client::new().await.unwrap().into_results();
         client
             .call(Box::pin(futures::stream::iter([
                 crate::results::upload::Request::Identifier {

--- a/packages/rust/armonik/src/client/sessions.rs
+++ b/packages/rust/armonik/src/client/sessions.rs
@@ -12,11 +12,11 @@ use super::GrpcCall;
 
 /// Service for handling sessions
 #[derive(Clone)]
-pub struct SessionsClient<T> {
+pub struct Sessions<T> {
     inner: v3::sessions::sessions_client::SessionsClient<T>,
 }
 
-impl<T> SessionsClient<T>
+impl<T> Sessions<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::Error: Into<tonic::codegen::StdError>,
@@ -185,7 +185,7 @@ where
 }
 
 super::impl_call! {
-    SessionsClient {
+    Sessions {
         async fn call(self, request: list::Request) -> Result<list::Response> {
             Ok(self
                 .inner
@@ -299,7 +299,7 @@ mod tests {
     #[tokio::test]
     async fn list() {
         let before = Client::get_nb_request("Sessions", "ListSessions").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client
             .list(
                 crate::sessions::filter::Or {
@@ -319,7 +319,7 @@ mod tests {
     #[tokio::test]
     async fn get() {
         let before = Client::get_nb_request("Sessions", "GetSession").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client.get("session-id").await.unwrap();
         let after = Client::get_nb_request("Sessions", "GetSession").await;
         assert_eq!(after - before, 1);
@@ -328,7 +328,7 @@ mod tests {
     #[tokio::test]
     async fn cancel() {
         let before = Client::get_nb_request("Sessions", "CancelSession").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client.cancel("session-id").await.unwrap();
         let after = Client::get_nb_request("Sessions", "CancelSession").await;
         assert_eq!(after - before, 1);
@@ -337,7 +337,7 @@ mod tests {
     #[tokio::test]
     async fn create() {
         let before = Client::get_nb_request("Sessions", "CreateSession").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client
             .create(
                 ["part1", "part2"],
@@ -355,7 +355,7 @@ mod tests {
     #[tokio::test]
     async fn pause() {
         let before = Client::get_nb_request("Sessions", "PauseSession").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client.pause("session-id").await.unwrap();
         let after = Client::get_nb_request("Sessions", "PauseSession").await;
         assert_eq!(after - before, 1);
@@ -364,7 +364,7 @@ mod tests {
     #[tokio::test]
     async fn resume() {
         let before = Client::get_nb_request("Sessions", "ResumeSession").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client.resume("session-id").await.unwrap();
         let after = Client::get_nb_request("Sessions", "ResumeSession").await;
         assert_eq!(after - before, 1);
@@ -373,7 +373,7 @@ mod tests {
     #[tokio::test]
     async fn close() {
         let before = Client::get_nb_request("Sessions", "CloseSession").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client.close("session-id").await.unwrap();
         let after = Client::get_nb_request("Sessions", "CloseSession").await;
         assert_eq!(after - before, 1);
@@ -382,7 +382,7 @@ mod tests {
     #[tokio::test]
     async fn purge() {
         let before = Client::get_nb_request("Sessions", "PurgeSession").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client.purge("session-id").await.unwrap();
         let after = Client::get_nb_request("Sessions", "PurgeSession").await;
         assert_eq!(after - before, 1);
@@ -391,7 +391,7 @@ mod tests {
     #[tokio::test]
     async fn delete() {
         let before = Client::get_nb_request("Sessions", "DeleteSession").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client.delete("session-id").await.unwrap();
         let after = Client::get_nb_request("Sessions", "DeleteSession").await;
         assert_eq!(after - before, 1);
@@ -400,7 +400,7 @@ mod tests {
     #[tokio::test]
     async fn stop_submission() {
         let before = Client::get_nb_request("Sessions", "StopSubmission").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client
             .stop_submission("session-id", true, true)
             .await
@@ -414,7 +414,7 @@ mod tests {
     #[tokio::test]
     async fn list_call() {
         let before = Client::get_nb_request("Sessions", "ListSessions").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client
             .call(crate::sessions::list::Request {
                 page_size: 10,
@@ -429,7 +429,7 @@ mod tests {
     #[tokio::test]
     async fn get_call() {
         let before = Client::get_nb_request("Sessions", "GetSession").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client
             .call(crate::sessions::get::Request {
                 session_id: String::from("session-id"),
@@ -443,7 +443,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_call() {
         let before = Client::get_nb_request("Sessions", "CancelSession").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client
             .call(crate::sessions::cancel::Request {
                 session_id: String::from("session-id"),
@@ -457,7 +457,7 @@ mod tests {
     #[tokio::test]
     async fn create_call() {
         let before = Client::get_nb_request("Sessions", "CreateSession").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client
             .call(crate::sessions::create::Request {
                 default_task_options: TaskOptions {
@@ -475,7 +475,7 @@ mod tests {
     #[tokio::test]
     async fn pause_call() {
         let before = Client::get_nb_request("Sessions", "PauseSession").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client
             .call(crate::sessions::pause::Request {
                 session_id: String::from("session-id"),
@@ -489,7 +489,7 @@ mod tests {
     #[tokio::test]
     async fn resume_call() {
         let before = Client::get_nb_request("Sessions", "ResumeSession").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client
             .call(crate::sessions::resume::Request {
                 session_id: String::from("session-id"),
@@ -503,7 +503,7 @@ mod tests {
     #[tokio::test]
     async fn close_call() {
         let before = Client::get_nb_request("Sessions", "CloseSession").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client
             .call(crate::sessions::close::Request {
                 session_id: String::from("session-id"),
@@ -517,7 +517,7 @@ mod tests {
     #[tokio::test]
     async fn purge_call() {
         let before = Client::get_nb_request("Sessions", "PurgeSession").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client
             .call(crate::sessions::purge::Request {
                 session_id: String::from("session-id"),
@@ -531,7 +531,7 @@ mod tests {
     #[tokio::test]
     async fn delete_call() {
         let before = Client::get_nb_request("Sessions", "DeleteSession").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client
             .call(crate::sessions::delete::Request {
                 session_id: String::from("session-id"),
@@ -545,7 +545,7 @@ mod tests {
     #[tokio::test]
     async fn stop_submission_call() {
         let before = Client::get_nb_request("Sessions", "StopSubmission").await;
-        let mut client = Client::new().await.unwrap().sessions();
+        let mut client = Client::new().await.unwrap().into_sessions();
         client
             .call(crate::sessions::stop_submission::Request {
                 session_id: String::from("session-id"),

--- a/packages/rust/armonik/src/client/submitter.rs
+++ b/packages/rust/armonik/src/client/submitter.rs
@@ -20,12 +20,12 @@ use super::{GrpcCall, GrpcCallStream};
 
 #[derive(Clone)]
 #[deprecated]
-pub struct SubmitterClient<T> {
+pub struct Submitter<T> {
     inner: v3::submitter::submitter_client::SubmitterClient<T>,
 }
 
 #[allow(deprecated)]
-impl<T> SubmitterClient<T>
+impl<T> Submitter<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::Error: Into<tonic::codegen::StdError>,
@@ -242,7 +242,7 @@ where
 }
 
 super::impl_call! {
-    SubmitterClient {
+    Submitter {
         async fn call(self, request: get_service_configuration::Request) -> Result<get_service_configuration::Response> {
             Ok(self
                 .inner
@@ -386,7 +386,7 @@ super::impl_call! {
 }
 
 #[async_trait::async_trait(?Send)]
-impl<T, S> GrpcCallStream<create_tasks::LargeRequest, S> for &'_ mut SubmitterClient<T>
+impl<T, S> GrpcCallStream<create_tasks::LargeRequest, S> for &'_ mut Submitter<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::Error: Into<tonic::codegen::StdError>,
@@ -420,7 +420,7 @@ mod tests {
     #[tokio::test]
     async fn get_service_configuration() {
         let before = Client::get_nb_request("Submitter", "GetServiceConfiguration").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client.get_service_configuration().await.unwrap();
         let after = Client::get_nb_request("Submitter", "GetServiceConfiguration").await;
         assert_eq!(after - before, 1);
@@ -429,7 +429,7 @@ mod tests {
     #[tokio::test]
     async fn create_session() {
         let before = Client::get_nb_request("Submitter", "CreateSession").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .create_session(
                 ["part1", "part2"],
@@ -447,7 +447,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_session() {
         let before = Client::get_nb_request("Submitter", "CancelSession").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client.cancel_session("session-id").await.unwrap();
         let after = Client::get_nb_request("Submitter", "CancelSession").await;
         assert_eq!(after - before, 1);
@@ -456,7 +456,7 @@ mod tests {
     #[tokio::test]
     async fn create_small_tasks() {
         let before = Client::get_nb_request("Submitter", "CreateSmallTasks").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         match client.create_small_tasks("session-id", None, []).await {
             Ok(_) => (),
             Err(crate::client::RequestError::Grpc { source, .. }) => {
@@ -472,7 +472,7 @@ mod tests {
     #[tokio::test]
     async fn create_large_tasks() {
         let before = Client::get_nb_request("Submitter", "CreateLargeTasks").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         match client
             .create_large_tasks(futures::stream::iter([
                 crate::submitter::create_tasks::LargeRequest::Invalid,
@@ -493,7 +493,7 @@ mod tests {
     #[tokio::test]
     async fn list_tasks() {
         let before = Client::get_nb_request("Submitter", "ListTasks").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .list_tasks(crate::submitter::TaskFilter {
                 ids: crate::submitter::TaskFilterIds::Sessions(vec![String::from("session-id")]),
@@ -508,7 +508,7 @@ mod tests {
     #[tokio::test]
     async fn list_sessions() {
         let before = Client::get_nb_request("Submitter", "ListSessions").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .list_sessions(crate::submitter::SessionFilter {
                 ids: vec![String::from("session-id")],
@@ -523,7 +523,7 @@ mod tests {
     #[tokio::test]
     async fn count_tasks() {
         let before = Client::get_nb_request("Submitter", "CountTasks").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .count_tasks(crate::submitter::TaskFilter {
                 ids: crate::submitter::TaskFilterIds::Sessions(vec![String::from("session-id")]),
@@ -538,7 +538,7 @@ mod tests {
     #[tokio::test]
     async fn try_get_result() {
         let before = Client::get_nb_request("Submitter", "TryGetResultStream").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .try_get_result("session-id", "result-id")
             .await
@@ -553,7 +553,7 @@ mod tests {
     #[tokio::test]
     async fn try_get_task_output() {
         let before = Client::get_nb_request("Submitter", "TryGetTaskOutput").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .try_get_task_output("session-id", "task_id")
             .await
@@ -565,7 +565,7 @@ mod tests {
     #[tokio::test]
     async fn wait_for_availability() {
         let before = Client::get_nb_request("Submitter", "WaitForAvailability").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .wait_for_availability("session-id", "result-id")
             .await
@@ -577,7 +577,7 @@ mod tests {
     #[tokio::test]
     async fn wait_for_completion() {
         let before = Client::get_nb_request("Submitter", "WaitForCompletion").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .wait_for_completion(
                 crate::submitter::TaskFilter {
@@ -598,7 +598,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_tasks() {
         let before = Client::get_nb_request("Submitter", "CancelTasks").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .cancel_tasks(crate::submitter::TaskFilter {
                 ids: crate::submitter::TaskFilterIds::Sessions(vec![String::from("session-id")]),
@@ -613,7 +613,7 @@ mod tests {
     #[tokio::test]
     async fn task_status() {
         let before = Client::get_nb_request("Submitter", "GetTaskStatus").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client.task_status(["task1", "task2"]).await.unwrap();
         let after = Client::get_nb_request("Submitter", "GetTaskStatus").await;
         assert_eq!(after - before, 1);
@@ -622,7 +622,7 @@ mod tests {
     #[tokio::test]
     async fn result_status() {
         let before = Client::get_nb_request("Submitter", "GetResultStatus").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .result_status("session-id", ["result1", "result2"])
             .await
@@ -636,7 +636,7 @@ mod tests {
     #[tokio::test]
     async fn get_service_configuration_call() {
         let before = Client::get_nb_request("Submitter", "GetServiceConfiguration").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .call(crate::submitter::get_service_configuration::Request {})
             .await
@@ -648,7 +648,7 @@ mod tests {
     #[tokio::test]
     async fn create_session_call() {
         let before = Client::get_nb_request("Submitter", "CreateSession").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .call(crate::submitter::create_session::Request {
                 partition_ids: vec![String::from("part1"), String::from("part2")],
@@ -666,7 +666,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_session_call() {
         let before = Client::get_nb_request("Submitter", "CancelSession").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .call(crate::submitter::cancel_session::Request {
                 session_id: String::from("session-id"),
@@ -680,7 +680,7 @@ mod tests {
     #[tokio::test]
     async fn create_small_tasks_call() {
         let before = Client::get_nb_request("Submitter", "CreateSmallTasks").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         match client
             .call(crate::submitter::create_tasks::SmallRequest {
                 session_id: String::from("session-id"),
@@ -703,7 +703,7 @@ mod tests {
     #[tokio::test]
     async fn create_large_tasks_call() {
         let before = Client::get_nb_request("Submitter", "CreateLargeTasks").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         match client
             .call(futures::stream::iter([
                 crate::submitter::create_tasks::LargeRequest::Invalid,
@@ -724,7 +724,7 @@ mod tests {
     #[tokio::test]
     async fn list_tasks_call() {
         let before = Client::get_nb_request("Submitter", "ListTasks").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .call(crate::submitter::list_tasks::Request {
                 filter: crate::submitter::TaskFilter {
@@ -743,7 +743,7 @@ mod tests {
     #[tokio::test]
     async fn list_sessions_call() {
         let before = Client::get_nb_request("Submitter", "ListSessions").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .call(crate::submitter::list_sessions::Request {
                 filter: crate::submitter::SessionFilter {
@@ -760,7 +760,7 @@ mod tests {
     #[tokio::test]
     async fn count_tasks_call() {
         let before = Client::get_nb_request("Submitter", "CountTasks").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .call(crate::submitter::count_tasks::Request {
                 filter: crate::submitter::TaskFilter {
@@ -779,7 +779,7 @@ mod tests {
     #[tokio::test]
     async fn try_get_result_call() {
         let before = Client::get_nb_request("Submitter", "TryGetResultStream").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .call(crate::submitter::try_get_result::Request {
                 session_id: String::from("session-id"),
@@ -797,7 +797,7 @@ mod tests {
     #[tokio::test]
     async fn try_get_task_output_call() {
         let before = Client::get_nb_request("Submitter", "TryGetTaskOutput").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .call(crate::submitter::try_get_task_output::Request {
                 session_id: String::from("session-id"),
@@ -812,7 +812,7 @@ mod tests {
     #[tokio::test]
     async fn wait_for_availability_call() {
         let before = Client::get_nb_request("Submitter", "WaitForAvailability").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .call(crate::submitter::wait_for_availability::Request {
                 session_id: String::from("session-id"),
@@ -827,7 +827,7 @@ mod tests {
     #[tokio::test]
     async fn wait_for_completion_call() {
         let before = Client::get_nb_request("Submitter", "WaitForCompletion").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .call(crate::submitter::wait_for_completion::Request {
                 filter: crate::submitter::TaskFilter {
@@ -848,7 +848,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_tasks_call() {
         let before = Client::get_nb_request("Submitter", "CancelTasks").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .call(crate::submitter::cancel_tasks::Request {
                 filter: crate::submitter::TaskFilter {
@@ -867,7 +867,7 @@ mod tests {
     #[tokio::test]
     async fn task_status_call() {
         let before = Client::get_nb_request("Submitter", "GetTaskStatus").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .call(crate::submitter::task_status::Request {
                 task_ids: Vec::new(),
@@ -881,7 +881,7 @@ mod tests {
     #[tokio::test]
     async fn result_status_call() {
         let before = Client::get_nb_request("Submitter", "GetResultStatus").await;
-        let mut client = Client::new().await.unwrap().submitter();
+        let mut client = Client::new().await.unwrap().into_submitter();
         client
             .call(crate::submitter::result_status::Request {
                 session_id: String::from("session-id"),

--- a/packages/rust/armonik/src/client/tasks.rs
+++ b/packages/rust/armonik/src/client/tasks.rs
@@ -14,11 +14,11 @@ use super::GrpcCall;
 
 /// Service for handling tasks.
 #[derive(Clone)]
-pub struct TasksClient<T> {
+pub struct Tasks<T> {
     inner: v3::tasks::tasks_client::TasksClient<T>,
 }
 
-impl<T> TasksClient<T>
+impl<T> Tasks<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::Error: Into<tonic::codegen::StdError>,
@@ -150,7 +150,7 @@ where
 }
 
 super::impl_call! {
-    TasksClient {
+    Tasks {
         async fn call(self, request: list::Request) -> Result<list::Response> {
             Ok(self
                 .inner
@@ -233,7 +233,7 @@ mod tests {
     #[tokio::test]
     async fn list() {
         let before = Client::get_nb_request("Tasks", "ListTasks").await;
-        let mut client = Client::new().await.unwrap().tasks();
+        let mut client = Client::new().await.unwrap().into_tasks();
         client
             .list(
                 crate::tasks::filter::Or {
@@ -253,7 +253,7 @@ mod tests {
     #[tokio::test]
     async fn list_detailed() {
         let before = Client::get_nb_request("Tasks", "ListTasksDetailed").await;
-        let mut client = Client::new().await.unwrap().tasks();
+        let mut client = Client::new().await.unwrap().into_tasks();
         client
             .list_detailed(
                 crate::tasks::filter::Or {
@@ -273,7 +273,7 @@ mod tests {
     #[tokio::test]
     async fn get() {
         let before = Client::get_nb_request("Tasks", "GetTask").await;
-        let mut client = Client::new().await.unwrap().tasks();
+        let mut client = Client::new().await.unwrap().into_tasks();
         client.get("task-id").await.unwrap();
         let after = Client::get_nb_request("Tasks", "GetTask").await;
         assert_eq!(after - before, 1);
@@ -282,7 +282,7 @@ mod tests {
     #[tokio::test]
     async fn cancel() {
         let before = Client::get_nb_request("Tasks", "CancelTasks").await;
-        let mut client = Client::new().await.unwrap().tasks();
+        let mut client = Client::new().await.unwrap().into_tasks();
         client.cancel(["task1", "task2"]).await.unwrap();
         let after = Client::get_nb_request("Tasks", "CancelTasks").await;
         assert_eq!(after - before, 1);
@@ -291,7 +291,7 @@ mod tests {
     #[tokio::test]
     async fn get_result_ids() {
         let before = Client::get_nb_request("Tasks", "GetResultIds").await;
-        let mut client = Client::new().await.unwrap().tasks();
+        let mut client = Client::new().await.unwrap().into_tasks();
         client.get_result_ids(["task1", "task2"]).await.unwrap();
         let after = Client::get_nb_request("Tasks", "GetResultIds").await;
         assert_eq!(after - before, 1);
@@ -300,7 +300,7 @@ mod tests {
     #[tokio::test]
     async fn count_status() {
         let before = Client::get_nb_request("Tasks", "CountTasksByStatus").await;
-        let mut client = Client::new().await.unwrap().tasks();
+        let mut client = Client::new().await.unwrap().into_tasks();
         client
             .count_status(crate::tasks::filter::Or {
                 or: vec![crate::tasks::filter::And { and: vec![] }],
@@ -314,7 +314,7 @@ mod tests {
     #[tokio::test]
     async fn submit() {
         let before = Client::get_nb_request("Tasks", "SubmitTasks").await;
-        let mut client = Client::new().await.unwrap().tasks();
+        let mut client = Client::new().await.unwrap().into_tasks();
         client.submit("session-id", None, []).await.unwrap();
         let after = Client::get_nb_request("Tasks", "SubmitTasks").await;
         assert_eq!(after - before, 1);
@@ -325,7 +325,7 @@ mod tests {
     #[tokio::test]
     async fn list_call() {
         let before = Client::get_nb_request("Tasks", "ListTasks").await;
-        let mut client = Client::new().await.unwrap().tasks();
+        let mut client = Client::new().await.unwrap().into_tasks();
         client
             .call(crate::tasks::list::Request {
                 page_size: 10,
@@ -340,7 +340,7 @@ mod tests {
     #[tokio::test]
     async fn list_detailed_call() {
         let before = Client::get_nb_request("Tasks", "ListTasksDetailed").await;
-        let mut client = Client::new().await.unwrap().tasks();
+        let mut client = Client::new().await.unwrap().into_tasks();
         client
             .call(crate::tasks::list_detailed::Request {
                 page_size: 10,
@@ -355,7 +355,7 @@ mod tests {
     #[tokio::test]
     async fn get_call() {
         let before = Client::get_nb_request("Tasks", "GetTask").await;
-        let mut client = Client::new().await.unwrap().tasks();
+        let mut client = Client::new().await.unwrap().into_tasks();
         client
             .call(crate::tasks::get::Request {
                 task_id: String::from("task-id"),
@@ -369,7 +369,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_call() {
         let before = Client::get_nb_request("Tasks", "CancelTasks").await;
-        let mut client = Client::new().await.unwrap().tasks();
+        let mut client = Client::new().await.unwrap().into_tasks();
         client
             .call(crate::tasks::cancel::Request {
                 task_ids: vec![String::from("task1"), String::from("task2")],
@@ -383,7 +383,7 @@ mod tests {
     #[tokio::test]
     async fn get_result_ids_call() {
         let before = Client::get_nb_request("Tasks", "GetResultIds").await;
-        let mut client = Client::new().await.unwrap().tasks();
+        let mut client = Client::new().await.unwrap().into_tasks();
         client
             .call(crate::tasks::get_result_ids::Request {
                 task_ids: vec![String::from("task1"), String::from("task2")],
@@ -397,7 +397,7 @@ mod tests {
     #[tokio::test]
     async fn count_status_call() {
         let before = Client::get_nb_request("Tasks", "CountTasksByStatus").await;
-        let mut client = Client::new().await.unwrap().tasks();
+        let mut client = Client::new().await.unwrap().into_tasks();
         client
             .call(crate::tasks::count_status::Request {
                 filters: crate::tasks::filter::Or {
@@ -413,7 +413,7 @@ mod tests {
     #[tokio::test]
     async fn submit_call() {
         let before = Client::get_nb_request("Tasks", "SubmitTasks").await;
-        let mut client = Client::new().await.unwrap().tasks();
+        let mut client = Client::new().await.unwrap().into_tasks();
         client
             .call(crate::tasks::submit::Request {
                 session_id: String::from("session-id"),

--- a/packages/rust/armonik/src/client/versions.rs
+++ b/packages/rust/armonik/src/client/versions.rs
@@ -6,13 +6,12 @@ use crate::versions::list;
 use super::GrpcCall;
 
 #[derive(Clone)]
-pub struct VersionsClient<T> {
+pub struct Versions<T> {
     inner: v3::versions::versions_client::VersionsClient<T>,
 }
 
-impl<T> VersionsClient<T>
+impl<T> Versions<T>
 where
-    T: Clone,
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::Error: Into<tonic::codegen::StdError>,
     T::ResponseBody: tonic::codegen::Body<Data = tonic::codegen::Bytes> + Send + 'static,
@@ -42,7 +41,7 @@ where
 }
 
 super::impl_call! {
-    VersionsClient {
+    Versions {
         async fn call(self, request: list::Request) -> Result<list::Response> {
             Ok(self
                 .inner
@@ -65,7 +64,7 @@ mod tests {
     #[tokio::test]
     async fn list() {
         let before = Client::get_nb_request("Versions", "ListVersions").await;
-        let mut client = Client::new().await.unwrap().versions();
+        let mut client = Client::new().await.unwrap().into_versions();
         client.list().await.unwrap();
         let after = Client::get_nb_request("Versions", "ListVersions").await;
         assert_eq!(after - before, 1);
@@ -76,7 +75,7 @@ mod tests {
     #[tokio::test]
     async fn list_call() {
         let before = Client::get_nb_request("Versions", "ListVersions").await;
-        let mut client = Client::new().await.unwrap().versions();
+        let mut client = Client::new().await.unwrap().into_versions();
         client
             .call(crate::versions::list::Request {})
             .await

--- a/packages/rust/armonik/src/client/worker.rs
+++ b/packages/rust/armonik/src/client/worker.rs
@@ -7,11 +7,11 @@ use crate::Output;
 use super::GrpcCall;
 
 #[derive(Clone)]
-pub struct WorkerClient<T> {
+pub struct Worker<T> {
     inner: v3::worker::worker_client::WorkerClient<T>,
 }
 
-impl<T> WorkerClient<T>
+impl<T> Worker<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::Error: Into<tonic::codegen::StdError>,
@@ -49,7 +49,7 @@ where
 }
 
 super::impl_call! {
-    WorkerClient {
+    Worker {
         async fn call(self, request: health_check::Request) -> Result<health_check::Response> {
             Ok(self
                 .inner

--- a/packages/rust/armonik/src/objects/health_checks/check.rs
+++ b/packages/rust/armonik/src/objects/health_checks/check.rs
@@ -1,0 +1,24 @@
+use crate::api::v3;
+
+use super::ServiceHealth;
+
+/// Request to check if all services are healthy.
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Request {}
+
+super::super::impl_convert!(
+    struct Request = v3::health_checks::CheckHealthRequest {
+    }
+);
+
+/// Response to check if all services are healthy.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Response {
+    pub services: Vec<ServiceHealth>,
+}
+
+super::super::impl_convert!(
+    struct Response = v3::health_checks::CheckHealthResponse {
+        list services,
+    }
+);

--- a/packages/rust/armonik/src/objects/health_checks/mod.rs
+++ b/packages/rust/armonik/src/objects/health_checks/mod.rs
@@ -1,0 +1,9 @@
+//! ArmoniK objects related to the Health Checks service
+
+mod service_health;
+mod status;
+
+pub mod check;
+
+pub use service_health::ServiceHealth;
+pub use status::Status;

--- a/packages/rust/armonik/src/objects/health_checks/service_health.rs
+++ b/packages/rust/armonik/src/objects/health_checks/service_health.rs
@@ -1,0 +1,21 @@
+use crate::api::v3;
+
+use super::Status;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ServiceHealth {
+    /// Name of the service (e.g. "control_plane", "database", "redis").
+    pub name: String,
+    /// Message.
+    pub message: String,
+    /// Health status.
+    pub health: Status,
+}
+
+super::super::impl_convert!(
+    struct ServiceHealth = v3::health_checks::check_health_response::ServiceHealth {
+        name,
+        message,
+        health = enum healthy,
+    }
+);

--- a/packages/rust/armonik/src/objects/health_checks/status.rs
+++ b/packages/rust/armonik/src/objects/health_checks/status.rs
@@ -1,0 +1,51 @@
+use crate::api::v3;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(i32)]
+pub enum Status {
+    /// Unspecified.
+    #[default]
+    Unspecified = 0,
+    /// Service is working without issues.
+    Healthy = 1,
+    /// Service has issues but still works.
+    Degraded = 2,
+    /// Service does not work.
+    Unhealthy = 3,
+}
+
+impl From<i32> for Status {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Healthy,
+            2 => Self::Degraded,
+            3 => Self::Unhealthy,
+            _ => Default::default(),
+        }
+    }
+}
+
+impl From<Status> for v3::health_checks::HealthStatusEnum {
+    fn from(value: Status) -> Self {
+        match value {
+            Status::Unspecified => Self::Unspecified,
+            Status::Healthy => Self::Healthy,
+            Status::Degraded => Self::Degraded,
+            Status::Unhealthy => Self::Unhealthy,
+        }
+    }
+}
+
+impl From<v3::health_checks::HealthStatusEnum> for Status {
+    fn from(value: v3::health_checks::HealthStatusEnum) -> Self {
+        match value {
+            v3::health_checks::HealthStatusEnum::Unspecified => Self::Unspecified,
+            v3::health_checks::HealthStatusEnum::Healthy => Self::Healthy,
+            v3::health_checks::HealthStatusEnum::Degraded => Self::Degraded,
+            v3::health_checks::HealthStatusEnum::Unhealthy => Self::Unhealthy,
+        }
+    }
+}
+
+super::super::impl_convert!(req Status : v3::health_checks::HealthStatusEnum);

--- a/packages/rust/armonik/src/objects/mod.rs
+++ b/packages/rust/armonik/src/objects/mod.rs
@@ -55,6 +55,7 @@ pub mod agent;
 pub mod applications;
 pub mod auth;
 pub mod events;
+pub mod health_checks;
 pub mod partitions;
 pub mod results;
 pub mod sessions;

--- a/packages/rust/armonik/src/objects/tasks/mod.rs
+++ b/packages/rust/armonik/src/objects/tasks/mod.rs
@@ -14,7 +14,7 @@ mod output;
 mod raw;
 mod summary;
 
-pub use field::Field;
+pub use field::{Field, SummaryField};
 pub use output::Output;
 pub use raw::{Raw, Raw as Task};
 pub use summary::Summary;


### PR DESCRIPTION
# Motivation

HealthCheck service was missing, and the interface to get a typed client was messy.

# Description

Implement the missing HealthCheck service.
Cleanup the client interface.

# Impact

This is a breaking change relative to the Rust API, but as the rust package is still on beta, this is fine.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
