### PR TITLE
fix: Remove async_trait from client code

### DIFF
--- a/packages/rust/armonik/Cargo.lock
+++ b/packages/rust/armonik/Cargo.lock
@@ -36,7 +36,6 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 name = "armonik"
 version = "3.24.0-beta-0"
 dependencies = [
- "async-trait",
  "eyre",
  "futures",
  "http-body-util",

--- a/packages/rust/armonik/Cargo.toml
+++ b/packages/rust/armonik/Cargo.toml
@@ -21,7 +21,6 @@ tonic = "0.12"
 prost = "0.13"
 prost-types = "0.13"
 futures = "0.3"
-async-trait = "0.1"
 snafu = "0.8"
 tracing = "0.1"
 hyper = { version = "1.5", features = ["client", "http1", "http2"] }

--- a/packages/rust/armonik/src/client/agent.rs
+++ b/packages/rust/armonik/src/client/agent.rs
@@ -208,7 +208,6 @@ super::impl_call! {
     }
 }
 
-#[async_trait::async_trait(?Send)]
 impl<T, S> GrpcCallStream<create_tasks::Request, S> for &'_ mut Agent<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,

--- a/packages/rust/armonik/src/client/events.rs
+++ b/packages/rust/armonik/src/client/events.rs
@@ -72,7 +72,6 @@ where
     }
 }
 
-#[async_trait::async_trait(?Send)]
 impl<T> GrpcCall<subscribe::Request> for &'_ mut Events<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,

--- a/packages/rust/armonik/src/client/mod.rs
+++ b/packages/rust/armonik/src/client/mod.rs
@@ -353,7 +353,7 @@ where
 }
 
 /// Perform a gRPC call from a raw request.
-#[async_trait::async_trait(?Send)]
+#[allow(async_fn_in_trait)]
 pub trait GrpcCall<Request> {
     type Response;
     type Error;
@@ -363,7 +363,7 @@ pub trait GrpcCall<Request> {
 }
 
 /// Perform a gRPC call from a raw request.
-#[async_trait::async_trait(?Send)]
+#[allow(async_fn_in_trait)]
 pub trait GrpcCallStream<Request, Stream>
 where
     Stream: futures::Stream<Item = Request> + Send + 'static,
@@ -375,7 +375,6 @@ where
     async fn call(self, request: Stream) -> Result<Self::Response, Self::Error>;
 }
 
-#[async_trait::async_trait(?Send)]
 impl<Stream, Request, T> GrpcCall<Stream> for T
 where
     Stream: futures::Stream<Item = Request> + Send + 'static,
@@ -449,7 +448,6 @@ macro_rules! impl_call {
         }
     };
     (@one $Client:ident($self:ident, $request:ident: $Request:ty) -> Result<$Response:ty, $Error:ty> $block:block) => {
-        #[async_trait::async_trait(?Send)]
         impl<T> $crate::client::GrpcCall<$Request> for &'_ mut $Client<T>
         where
             T: tonic::client::GrpcService<tonic::body::BoxBody>,

--- a/packages/rust/armonik/src/client/results.rs
+++ b/packages/rust/armonik/src/client/results.rs
@@ -278,7 +278,6 @@ super::impl_call! {
     }
 }
 
-#[async_trait::async_trait(?Send)]
 impl<T> GrpcCall<download::Request> for &'_ mut Results<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
@@ -302,7 +301,6 @@ where
     }
 }
 
-#[async_trait::async_trait(?Send)]
 impl<T, S> GrpcCallStream<upload::Request, S> for &'_ mut Results<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,

--- a/packages/rust/armonik/src/client/submitter.rs
+++ b/packages/rust/armonik/src/client/submitter.rs
@@ -385,7 +385,6 @@ super::impl_call! {
     }
 }
 
-#[async_trait::async_trait(?Send)]
 impl<T, S> GrpcCallStream<create_tasks::LargeRequest, S> for &'_ mut Submitter<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,


### PR DESCRIPTION
# Motivation

`async_trait` makes the method futures either all sends, or all not send.

# Description

Remove the async_trait and use async in trait feature of recent Rust versions.

# Testing

It has been tested in the load balancer.

# Impact

This is a breaking change, but as the rust package is still in beta, this is fine.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
