### PR TITLE
ci: Fix pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,9 @@ jobs:
       - name: Install .NET Core
         uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4
         with:
-          dotnet-version: 6.x
+          dotnet-version: |
+            6.x
+            8.x
 
       - name: Install ReSharper
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,12 @@ jobs:
               lang: Rust
             plateform:
               os: windows-2019
+          # FIXME: Rust should be working on Windows,
+          # but we most likely encounter a port exhaustion issue
+          - language:
+              lang: Rust
+            plateform:
+              os: windows-latest
           - language:
               lang: C#
               dotnet: ''

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,9 +135,10 @@ jobs:
 
       - name: Install .NET Core
         uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4
-        if: ${{ matrix.language.dotnet }} != ""
         with:
-          dotnet-version: ${{ matrix.language.dotnet }}
+          dotnet-version: |
+            6.x
+            8.x
 
       - name: Print language
         run: |

--- a/packages/cpp/ArmoniK.Api.Client/header/submitter/SubmitterClient.h
+++ b/packages/cpp/ArmoniK.Api.Client/header/submitter/SubmitterClient.h
@@ -68,8 +68,8 @@ public:
    * @param chunk_max_size The maximum chunk size.
    * @return A future large task request object.
    */
-  static std::future<std::vector<armonik::api::grpc::v1::submitter::CreateLargeTaskRequest>> task_chunk_stream(
-      const armonik::api::grpc::v1::TaskRequest &task_request, bool is_last, size_t chunk_max_size);
+  static std::future<std::vector<armonik::api::grpc::v1::submitter::CreateLargeTaskRequest>>
+  task_chunk_stream(const armonik::api::grpc::v1::TaskRequest &task_request, bool is_last, size_t chunk_max_size);
 
   /**
    * @brief Creates tasks asynchronously with the specified options and requests.
@@ -78,9 +78,9 @@ public:
    * @param task_requests The vector of task requests.
    * @return A future create task reply object.
    */
-  std::future<armonik::api::grpc::v1::submitter::CreateTaskReply> create_tasks_async(
-      std::string session_id, armonik::api::grpc::v1::TaskOptions task_options,
-      const std::vector<armonik::api::grpc::v1::TaskRequest> &task_requests);
+  std::future<armonik::api::grpc::v1::submitter::CreateTaskReply>
+  create_tasks_async(std::string session_id, armonik::api::grpc::v1::TaskOptions task_options,
+                     const std::vector<armonik::api::grpc::v1::TaskRequest> &task_requests);
 
   /**
    * @brief Submits tasks with dependencies to the session context.
@@ -90,9 +90,9 @@ public:
    * @param max_retries The maximum number of retries for submitting tasks.
    * @return A vector of submitted task IDs.
    */
-  std::pair<std::vector<std::string>, std::vector<std::string>> submit_tasks_with_dependencies(
-      std::string session_id, armonik::api::grpc::v1::TaskOptions task_options,
-      const std::vector<payload_data> &payloads_with_dependencies, int max_retries);
+  std::pair<std::vector<std::string>, std::vector<std::string>>
+  submit_tasks_with_dependencies(std::string session_id, armonik::api::grpc::v1::TaskOptions task_options,
+                                 const std::vector<payload_data> &payloads_with_dependencies, int max_retries);
 
   /**
    * @brief Get result without streaming.
@@ -101,8 +101,8 @@ public:
    */
   std::future<std::string> get_result_async(const armonik::api::grpc::v1::ResultRequest &result_request);
 
-  std::map<std::string, armonik::api::grpc::v1::result_status::ResultStatus> get_result_status(
-      const std::string &session_id, const std::vector<std::string> &result_ids);
+  std::map<std::string, armonik::api::grpc::v1::result_status::ResultStatus>
+  get_result_status(const std::string &session_id, const std::vector<std::string> &result_ids);
 };
 
 } // namespace client

--- a/packages/cpp/ArmoniK.Api.Common/source/utils/ChannelArguments.cpp
+++ b/packages/cpp/ArmoniK.Api.Common/source/utils/ChannelArguments.cpp
@@ -30,14 +30,10 @@ armonik::api::common::utils::getServiceConfigJson(const armonik::api::common::op
   if (!status.ok()) {
     throw std::invalid_argument("Timeout is invalid" + status.ToString());
   }
-  ss << R"({ "methodConfig": [{ "name": [{}], )"
-     << R"("timeout" : )" << timeout << ',' << R"("retryPolicy" : {)"
+  ss << R"({ "methodConfig": [{ "name": [{}], )" << R"("timeout" : )" << timeout << ',' << R"("retryPolicy" : {)"
      << R"("backoffMultiplier": )" << config.getBackoffMultiplier() << ',' << R"("initialBackoff":)" << initialBackoff
-     << ","
-     << R"("maxBackoff":)" << maxBackoff << ","
-     << R"("maxAttempts":)" << config.getMaxAttempts() << ','
-     << R"("retryableStatusCodes": [ "UNAVAILABLE", "ABORTED", "UNKNOWN" ])"
-     << "}}]}";
+     << "," << R"("maxBackoff":)" << maxBackoff << "," << R"("maxAttempts":)" << config.getMaxAttempts() << ','
+     << R"("retryableStatusCodes": [ "UNAVAILABLE", "ABORTED", "UNKNOWN" ])" << "}}]}";
   return ss.str();
 }
 


### PR DESCRIPTION
# Motivation

There are multiple errors in the pipelines currently:
- Windows tests for Rust fail with the following error: "No connection could be made because the target machine actively refused it."
- The formatting rules in C++ have changed due to the image upgrade from ubuntu-22.04 to ubuntu-24.04
- Dotnet installation has changed due to the image upgrade from ubuntu-22.04 to ubuntu-24.04

# Description

Disable the windows tests for Rust while waiting for a proper fix.
Update the C++ code to adhere to the new formatting rules.
Force the installation of both dotnet 6 and dotnet 8 in all circumstances

# Impact

The proper fix for Rust would be to enable port reuse, but this would require to reimplement a bunch of code to create a new channel.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
