### PR TITLE
fix: Small change in create_results docstring

### DIFF
--- a/packages/python/src/armonik/client/results.py
+++ b/packages/python/src/armonik/client/results.py
@@ -165,15 +165,15 @@ class ArmoniKResults:
     def create_results(
         self, results_data: Dict[str, bytes], session_id: str, batch_size: int = 1
     ) -> Dict[str, Result]:
-        """Create one result with data included in the request.
+        """Create multiple results from a mapping of result names and its corresponding data.
 
         Args:
             results_data: A dictionnary mapping the result names to their actual data.
-            session_id: The ID of the session to which the results belongs.
+            session_id: The ID of the session to create the results in.
             batch_size: Batch size for querying.
 
         Return:
-            A dictionnary mappin each result name to its corresponding result summary.
+            A dictionnary mapping each result name to its corresponding result summary.
         """
         results = {}
         for results_names_batch in batched(results_data.keys(), batch_size):


### PR DESCRIPTION
# Motivation

`create_results` creates multiple results but the docstring implies otherwise.

# Description

Changed the docstring to reflect the fact that `create_results` creates multiple results.

# Testing

Not applicable.

# Impact

Not applicable.

# Additional Information

None.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
