### PR TITLE
chore: parametrize keep alive options

### DIFF
--- a/packages/csharp/ArmoniK.Api.Common/ArmoniK.Api.Common.csproj
+++ b/packages/csharp/ArmoniK.Api.Common/ArmoniK.Api.Common.csproj
@@ -28,6 +28,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/packages/csharp/ArmoniK.Api.Common/Options/ComputePlane.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Options/ComputePlane.cs
@@ -41,12 +41,12 @@ public class ComputePlane
   /// <summary>
   ///   Path to the section containing the worker channel values in configuration object
   /// </summary>
-  public const string WorkerChannelSection = "WorkerChannel";
+  public const string WorkerChannelSection = nameof(WorkerChannel);
 
   /// <summary>
   ///  Path to the section containing the agent channel values in configuration object
   /// </summary>
-  public const string AgentChannelSection = "AgentChannel";
+  public const string AgentChannelSection = nameof(AgentChannel);
 
   /// <summary>
   ///   Channel used by the Agent to send tasks to the Worker

--- a/packages/csharp/ArmoniK.Api.Common/Options/ComputePlane.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Options/ComputePlane.cs
@@ -44,7 +44,7 @@ public class ComputePlane
   public const string WorkerChannelSection = nameof(WorkerChannel);
 
   /// <summary>
-  ///  Path to the section containing the agent channel values in configuration object
+  ///   Path to the section containing the agent channel values in configuration object
   /// </summary>
   public const string AgentChannelSection = nameof(AgentChannel);
 

--- a/packages/csharp/ArmoniK.Api.Common/Options/ComputePlane.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Options/ComputePlane.cs
@@ -39,6 +39,16 @@ public class ComputePlane
   public const string SettingSection = nameof(ComputePlane);
 
   /// <summary>
+  ///   Path to the section containing the worker channel values in configuration object
+  /// </summary>
+  public const string WorkerChannelSection = "WorkerChannel";
+
+  /// <summary>
+  ///  Path to the section containing the agent channel values in configuration object
+  /// </summary>
+  public const string AgentChannelSection = "AgentChannel";
+
+  /// <summary>
   ///   Channel used by the Agent to send tasks to the Worker
   /// </summary>
   public GrpcChannel WorkerChannel { get; set; } = new();

--- a/packages/csharp/ArmoniK.Api.Common/Options/GrpcChannel.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Options/GrpcChannel.cs
@@ -46,10 +46,10 @@ public class GrpcChannel
   /// <summary>
   ///   Keep-alive ping timeout for http2 connections
   /// </summary>
-  public TimeSpan KeepAlivePingTimeOut { get; set; } = TimeSpan.FromSeconds(20);
+  public TimeSpan KeepAlivePingTimeOut { get; set; }
 
   /// <summary>
   ///   Keep-alive timeout
   /// </summary>
-  public TimeSpan KeepAliveTimeOut { get; set; } = TimeSpan.FromSeconds(130);
+  public TimeSpan KeepAliveTimeOut { get; set; }
 }

--- a/packages/csharp/ArmoniK.Api.Common/Options/GrpcChannel.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Options/GrpcChannel.cs
@@ -52,5 +52,4 @@ public class GrpcChannel
   ///   Keep-alive timeout
   /// </summary>
   public TimeSpan KeepAliveTimeOut { get; set; } = TimeSpan.MaxValue;
-
 }

--- a/packages/csharp/ArmoniK.Api.Common/Options/GrpcChannel.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Options/GrpcChannel.cs
@@ -21,6 +21,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+
 using JetBrains.Annotations;
 
 namespace ArmoniK.Api.Common.Options;
@@ -40,4 +42,15 @@ public class GrpcChannel
   ///   Type of gRPC Socket used
   /// </summary>
   public GrpcSocketType SocketType { get; set; } = GrpcSocketType.UnixDomainSocket;
+
+  /// <summary>
+  ///   Keep-alive ping timeout for http2 connections
+  /// </summary>
+  public TimeSpan KeepAlivePingTimeOut { get; set; } = TimeSpan.MaxValue;
+
+  /// <summary>
+  ///   Keep-alive timeout
+  /// </summary>
+  public TimeSpan KeepAliveTimeOut { get; set; } = TimeSpan.MaxValue;
+
 }

--- a/packages/csharp/ArmoniK.Api.Common/Options/GrpcChannel.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Options/GrpcChannel.cs
@@ -46,10 +46,10 @@ public class GrpcChannel
   /// <summary>
   ///   Keep-alive ping timeout for http2 connections
   /// </summary>
-  public TimeSpan KeepAlivePingTimeOut { get; set; } = TimeSpan.MaxValue;
+  public TimeSpan KeepAlivePingTimeOut { get; set; } = TimeSpan.FromSeconds(20);
 
   /// <summary>
   ///   Keep-alive timeout
   /// </summary>
-  public TimeSpan KeepAliveTimeOut { get; set; } = TimeSpan.MaxValue;
+  public TimeSpan KeepAliveTimeOut { get; set; } = TimeSpan.FromSeconds(130);
 }

--- a/packages/csharp/ArmoniK.Api.Common/Utils/ConfigurationExt.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Utils/ConfigurationExt.cs
@@ -40,16 +40,20 @@ public static class ConfigurationExt
                                       string              key)
     => configuration.GetRequiredSection(key)
                     .Get<T>() ?? throw new InvalidOperationException($"{key} not found");
-  
+
   /// <summary>
-  /// Retrieves a <see cref="TimeSpan"/> from the configuration, or returns the provided default value if not found or invalid.
-  /// If the configuration contains "MaxValue", it will return <see cref="TimeSpan.MaxValue"/>.
+  ///   Retrieves a <see cref="TimeSpan" /> from the configuration, or returns the provided default value if not found or
+  ///   invalid.
+  ///   If the configuration contains "MaxValue", it will return <see cref="TimeSpan.MaxValue" />.
   /// </summary>
-  /// <param name="configuration">The <see cref="IConfiguration"/> instance from which to retrieve the value.</param>
+  /// <param name="configuration">The <see cref="IConfiguration" /> instance from which to retrieve the value.</param>
   /// <param name="key">The key of the configuration value to retrieve.</param>
   /// <param name="defaultValue">The default value to return if the key is not found or the value is invalid.</param>
-  /// <returns>A <see cref="TimeSpan"/> representing the configuration value, or <paramref name="defaultValue"/> if invalid or missing.</returns>
-  /// <exception cref="FormatException">Thrown if the value is not a valid <see cref="TimeSpan"/> or "MaxValue".</exception>
+  /// <returns>
+  ///   A <see cref="TimeSpan" /> representing the configuration value, or <paramref name="defaultValue" /> if invalid
+  ///   or missing.
+  /// </returns>
+  /// <exception cref="FormatException">Thrown if the value is not a valid <see cref="TimeSpan" /> or "MaxValue".</exception>
   public static TimeSpan GetTimeSpanOrDefault(this IConfiguration configuration,
                                               string              key,
                                               TimeSpan            defaultValue)

--- a/packages/csharp/ArmoniK.Api.Common/Utils/ConfigurationExt.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Utils/ConfigurationExt.cs
@@ -1,0 +1,94 @@
+// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2021-2025. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+
+using Microsoft.Extensions.Configuration;
+
+namespace ArmoniK.Api.Common.Utils;
+
+/// <summary>
+///   Extends the functionality of the <see cref="IConfiguration" />
+/// </summary>
+public static class ConfigurationExt
+{
+  /// <summary>
+  ///   Configure an object with the given configuration.
+  /// </summary>
+  /// <typeparam name="T">Type of the options class</typeparam>
+  /// <param name="configuration">Configurations used to populate the class</param>
+  /// <param name="key">Path to the Object in the configuration</param>
+  /// <returns>
+  ///   The initialized object
+  /// </returns>
+  /// <exception cref="InvalidOperationException">the <paramref name="key" /> is not found in the configurations.</exception>
+  public static T GetRequiredValue<T>(this IConfiguration configuration,
+                                      string              key)
+    => configuration.GetRequiredSection(key)
+                    .Get<T>() ?? throw new InvalidOperationException($"{key} not found");
+
+  /// <summary>
+  ///   Configure an object with the given configuration.
+  ///   If the object is not found in the configuration, a new object in returned.
+  /// </summary>
+  /// <typeparam name="T">Type of the options class</typeparam>
+  /// <param name="configuration">Configurations used to populate the class</param>
+  /// <param name="key">Path to the Object in the configuration</param>
+  /// <returns>
+  ///   The initialized object
+  /// </returns>
+  public static T GetInitializedValue<T>(this IConfiguration configuration,
+                                         string              key)
+    where T : new()
+    => configuration.GetSection(key)
+                    .Get<T>() ?? new T();
+
+  /// <summary>
+  /// Retrieves a <see cref="TimeSpan"/> from the configuration, or returns the provided default value if not found or invalid.
+  /// If the configuration contains "MaxValue", it will return <see cref="TimeSpan.MaxValue"/>.
+  /// </summary>
+  /// <param name="configuration">The <see cref="IConfiguration"/> instance from which to retrieve the value.</param>
+  /// <param name="key">The key of the configuration value to retrieve.</param>
+  /// <param name="defaultValue">The default value to return if the key is not found or the value is invalid.</param>
+  /// <returns>A <see cref="TimeSpan"/> representing the configuration value, or <paramref name="defaultValue"/> if invalid or missing.</returns>
+  /// <exception cref="FormatException">Thrown if the value is not a valid <see cref="TimeSpan"/> or "MaxValue".</exception>
+  public static TimeSpan GetTimeSpanOrDefault(this IConfiguration configuration,
+                                              string              key,
+                                              TimeSpan            defaultValue)
+  {
+    try
+    {
+      return GetRequiredValue<TimeSpan>(configuration,
+                                        key);
+    }
+    catch (Exception)
+    {
+      var value = configuration.GetValue<string>(key);
+      if (string.IsNullOrEmpty(value))
+      {
+        return defaultValue;
+      }
+
+      if (value!.Equals("MaxValue"))
+      {
+        return TimeSpan.MaxValue;
+      }
+
+      throw new FormatException($"'{key}' must be a valid TimeSpan or 'MaxValue'.");
+    }
+  }
+}

--- a/packages/csharp/ArmoniK.Api.Common/Utils/ConfigurationExt.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Utils/ConfigurationExt.cs
@@ -40,23 +40,7 @@ public static class ConfigurationExt
                                       string              key)
     => configuration.GetRequiredSection(key)
                     .Get<T>() ?? throw new InvalidOperationException($"{key} not found");
-
-  /// <summary>
-  ///   Configure an object with the given configuration.
-  ///   If the object is not found in the configuration, a new object in returned.
-  /// </summary>
-  /// <typeparam name="T">Type of the options class</typeparam>
-  /// <param name="configuration">Configurations used to populate the class</param>
-  /// <param name="key">Path to the Object in the configuration</param>
-  /// <returns>
-  ///   The initialized object
-  /// </returns>
-  public static T GetInitializedValue<T>(this IConfiguration configuration,
-                                         string              key)
-    where T : new()
-    => configuration.GetSection(key)
-                    .Get<T>() ?? new T();
-
+  
   /// <summary>
   /// Retrieves a <see cref="TimeSpan"/> from the configuration, or returns the provided default value if not found or invalid.
   /// If the configuration contains "MaxValue", it will return <see cref="TimeSpan.MaxValue"/>.

--- a/packages/csharp/ArmoniK.Api.Tests/WorkerServerTest.cs
+++ b/packages/csharp/ArmoniK.Api.Tests/WorkerServerTest.cs
@@ -27,7 +27,6 @@ using System.Threading.Tasks;
 
 using ArmoniK.Api.Common.Channel.Utils;
 using ArmoniK.Api.Common.Options;
-using ArmoniK.Api.Common.Utils;
 using ArmoniK.Api.Worker.Utils;
 using ArmoniK.Api.Worker.Worker;
 
@@ -117,15 +116,17 @@ public class WorkerServerTest
                        new($"{nameof(ComputePlane)}:{nameof(ComputePlane.WorkerChannel)}:{nameof(ComputePlane.WorkerChannel.SocketType)}",
                            GrpcSocketType.Tcp.ToString()),
                        new($"{nameof(ComputePlane)}:{nameof(ComputePlane.WorkerChannel)}:{nameof(ComputePlane.WorkerChannel.KeepAliveTimeOut)}",
-                          "MaxValue"),
+                           "MaxValue"),
                        new($"{nameof(ComputePlane)}:{nameof(ComputePlane.WorkerChannel)}:{nameof(ComputePlane.WorkerChannel.KeepAlivePingTimeOut)}",
                            "MaxValue"),
                        new($"{nameof(ComputePlane)}:{nameof(ComputePlane.AgentChannel)}:{nameof(ComputePlane.AgentChannel.Address)}",
                            "http://localhost:10666"),
                        new($"{nameof(ComputePlane)}:{nameof(ComputePlane.AgentChannel)}:{nameof(ComputePlane.AgentChannel.KeepAliveTimeOut)}",
-                           TimeSpan.FromSeconds(100).ToString()),
+                           TimeSpan.FromSeconds(100)
+                                   .ToString()),
                        new($"{nameof(ComputePlane)}:{nameof(ComputePlane.AgentChannel)}:{nameof(ComputePlane.AgentChannel.KeepAlivePingTimeOut)}",
-                           TimeSpan.FromSeconds(5).ToString()),
+                           TimeSpan.FromSeconds(5)
+                                   .ToString()),
                        new($"{nameof(ComputePlane)}:{nameof(ComputePlane.AgentChannel)}:{nameof(ComputePlane.AgentChannel.SocketType)}",
                            GrpcSocketType.Tcp.ToString()),
                      };

--- a/packages/csharp/ArmoniK.Api.Tests/WorkerServerTest.cs
+++ b/packages/csharp/ArmoniK.Api.Tests/WorkerServerTest.cs
@@ -27,6 +27,7 @@ using System.Threading.Tasks;
 
 using ArmoniK.Api.Common.Channel.Utils;
 using ArmoniK.Api.Common.Options;
+using ArmoniK.Api.Common.Utils;
 using ArmoniK.Api.Worker.Utils;
 using ArmoniK.Api.Worker.Worker;
 
@@ -107,10 +108,59 @@ public class WorkerServerTest
   }
 
   [Test]
+  public Task BuildServerConfiguratorTcp()
+  {
+    var collection = new List<KeyValuePair<string, string>>
+                     {
+                       new($"{nameof(ComputePlane)}:{nameof(ComputePlane.WorkerChannel)}:{nameof(ComputePlane.WorkerChannel.Address)}",
+                           "http://localhost:10667"),
+                       new($"{nameof(ComputePlane)}:{nameof(ComputePlane.WorkerChannel)}:{nameof(ComputePlane.WorkerChannel.SocketType)}",
+                           GrpcSocketType.Tcp.ToString()),
+                       new($"{nameof(ComputePlane)}:{nameof(ComputePlane.WorkerChannel)}:{nameof(ComputePlane.WorkerChannel.KeepAliveTimeOut)}",
+                          "MaxValue"),
+                       new($"{nameof(ComputePlane)}:{nameof(ComputePlane.WorkerChannel)}:{nameof(ComputePlane.WorkerChannel.KeepAlivePingTimeOut)}",
+                           "MaxValue"),
+                       new($"{nameof(ComputePlane)}:{nameof(ComputePlane.AgentChannel)}:{nameof(ComputePlane.AgentChannel.Address)}",
+                           "http://localhost:10666"),
+                       new($"{nameof(ComputePlane)}:{nameof(ComputePlane.AgentChannel)}:{nameof(ComputePlane.AgentChannel.KeepAliveTimeOut)}",
+                           TimeSpan.FromSeconds(100).ToString()),
+                       new($"{nameof(ComputePlane)}:{nameof(ComputePlane.AgentChannel)}:{nameof(ComputePlane.AgentChannel.KeepAlivePingTimeOut)}",
+                           TimeSpan.FromSeconds(5).ToString()),
+                       new($"{nameof(ComputePlane)}:{nameof(ComputePlane.AgentChannel)}:{nameof(ComputePlane.AgentChannel.SocketType)}",
+                           GrpcSocketType.Tcp.ToString()),
+                     };
+
+    var app = WorkerServer.Create<TestService>((_,
+                                                configuration) =>
+                                               {
+                                                 foreach (var pair in collection)
+                                                 {
+                                                   configuration[pair.Key] = pair.Value;
+                                                 }
+                                               });
+
+    var computePlane = app.Services.GetRequiredService<ComputePlane>();
+
+    Assert.AreEqual(computePlane.WorkerChannel.KeepAliveTimeOut,
+                    TimeSpan.MaxValue);
+    Assert.AreEqual(computePlane.WorkerChannel.KeepAliveTimeOut,
+                    TimeSpan.MaxValue);
+
+    Assert.AreEqual(computePlane.AgentChannel.KeepAliveTimeOut,
+                    TimeSpan.FromSeconds(100));
+    Assert.AreEqual(computePlane.AgentChannel.KeepAlivePingTimeOut,
+                    TimeSpan.FromSeconds(5));
+
+    return Task.CompletedTask;
+  }
+
+  [Test]
   public Task BuildServerNoArgs()
   {
     Environment.SetEnvironmentVariable($"{nameof(ComputePlane)}__{nameof(ComputePlane.WorkerChannel)}__{nameof(ComputePlane.WorkerChannel.Address)}",
                                        "/tmp/worker.sock");
+    Environment.SetEnvironmentVariable($"{nameof(ComputePlane)}__{nameof(ComputePlane.AgentChannel)}__{nameof(ComputePlane.AgentChannel.Address)}",
+                                       "/tmp/agent.sock");
     var app = WorkerServer.Create<TestService>();
     return Task.CompletedTask;
   }
@@ -120,6 +170,8 @@ public class WorkerServerTest
   {
     Environment.SetEnvironmentVariable($"{nameof(ComputePlane)}__{nameof(ComputePlane.WorkerChannel)}__{nameof(ComputePlane.WorkerChannel.Address)}",
                                        "/tmp/worker.sock");
+    Environment.SetEnvironmentVariable($"{nameof(ComputePlane)}__{nameof(ComputePlane.AgentChannel)}__{nameof(ComputePlane.AgentChannel.Address)}",
+                                       "/tmp/agent.sock");
     var app = WorkerServer.Create<TestService>(serviceConfigurator: collection => collection.AddSingleton("test"));
     return Task.CompletedTask;
   }

--- a/packages/csharp/ArmoniK.Api.Worker/Utils/WorkerServer.cs
+++ b/packages/csharp/ArmoniK.Api.Worker/Utils/WorkerServer.cs
@@ -110,19 +110,38 @@ public static class WorkerServer
 
       builder.Host.UseSerilog(Log.Logger);
 
-
-      var computePlaneOptions = builder.Configuration.GetRequiredSection(ComputePlane.SettingSection)
-                                       .Get<ComputePlane>();
-
-      if (computePlaneOptions?.WorkerChannel is null)
-      {
-        throw new Exception($"{nameof(computePlaneOptions.WorkerChannel)} options should not be null");
-      }
+      var rawComputePlaneOptions = builder.Configuration.GetRequiredSection(ComputePlane.SettingSection);
+      var workerChannelOptions = rawComputePlaneOptions.
+                                         GetRequiredSection(ComputePlane.WorkerChannelSection);
+      var agentChannelOptions = rawComputePlaneOptions.GetRequiredSection(ComputePlane.WorkerChannelSection);
+      var parsedComputePlaneOptions = new ComputePlane
+                                      {
+                                        WorkerChannel = new GrpcChannel
+                                                        {
+                                                          Address = workerChannelOptions.GetRequiredValue<string>("Address"),
+                                                          SocketType = workerChannelOptions.GetValue("SocketType", GrpcSocketType.UnixDomainSocket),
+                                                          KeepAlivePingTimeOut = workerChannelOptions.GetTimeSpanOrDefault("KeepAlivePingTimeOut",
+                                                                                                                           TimeSpan.FromSeconds(20)),
+                                                          KeepAliveTimeOut = workerChannelOptions.GetTimeSpanOrDefault("KeepAliveTimeOut",
+                                                                                                                       TimeSpan.FromSeconds(130)),
+                                                        },
+                                        AgentChannel = new GrpcChannel
+                                                       {
+                                                          Address    = agentChannelOptions.GetRequiredValue<string>("Address"),
+                                                          SocketType = agentChannelOptions.GetValue("SocketType", GrpcSocketType.UnixDomainSocket),
+                                                          KeepAlivePingTimeOut = agentChannelOptions.GetTimeSpanOrDefault("KeepAlivePingTimeOut",
+                                                                                                                           TimeSpan.FromSeconds(20)),
+                                                          KeepAliveTimeOut = agentChannelOptions.GetTimeSpanOrDefault("KeepAliveTimeOut",
+                                                                                                                                      TimeSpan.FromSeconds(130)),
+                                                       },
+                                        MessageBatchSize = rawComputePlaneOptions.GetValue("MessageBatchSize", 1),
+                                        AbortAfter = rawComputePlaneOptions.GetValue("AbortAfter", TimeSpan.Zero),
+                                      };
 
       builder.WebHost.ConfigureKestrel((context, options) =>
                                        {
-                                         var address       = computePlaneOptions.WorkerChannel.Address;
-                                         switch (computePlaneOptions.WorkerChannel.SocketType)
+                                         var address       = parsedComputePlaneOptions.WorkerChannel.Address;
+                                         switch (parsedComputePlaneOptions.WorkerChannel.SocketType)
                                          {
                                            case GrpcSocketType.UnixDomainSocket:
                                              if (File.Exists(address))
@@ -134,12 +153,8 @@ public static class WorkerServer
                                                                       listenOptions => listenOptions.Protocols = HttpProtocols.Http2);
                                              break;
                                            case GrpcSocketType.Tcp:
-
-                                             var channelOptions = context.Configuration.GetRequiredSection(ComputePlane.SettingSection).
-                                                                          GetSection(ComputePlane.WorkerChannelSection);
-                                             options.Limits.KeepAliveTimeout = channelOptions.GetTimeSpanOrDefault("KeepAliveTimeOut",TimeSpan.FromSeconds(130));
-                                             options.Limits.Http2.KeepAlivePingTimeout = channelOptions.GetTimeSpanOrDefault("KeepAlivePingTimeOut",
-                                                                                                       TimeSpan.FromSeconds(20));
+                                             options.Limits.KeepAliveTimeout           = parsedComputePlaneOptions.WorkerChannel.KeepAliveTimeOut;
+                                             options.Limits.Http2.KeepAlivePingTimeout = parsedComputePlaneOptions.WorkerChannel.KeepAlivePingTimeOut;
                                              var uri = new Uri(address);
                                              options.ListenAnyIP(uri.Port,
                                                                  listenOptions => listenOptions.Protocols = HttpProtocols.Http2);
@@ -152,8 +167,8 @@ public static class WorkerServer
       builder.Services.AddSingleton<ApplicationLifeTimeManager>()
              .AddSingleton(_ => loggerFactory)
              .AddSingleton<GrpcChannelProvider>()
-             .AddSingleton(computePlaneOptions)
-             .AddSingleton(computePlaneOptions.AgentChannel)
+             .AddSingleton(parsedComputePlaneOptions)
+             .AddSingleton(parsedComputePlaneOptions.AgentChannel)
              .AddLogging()
              .AddGrpcReflection()
              .AddGrpc(options => options.MaxReceiveMessageSize = null);

--- a/packages/csharp/ArmoniK.Api.Worker/Utils/WorkerServer.cs
+++ b/packages/csharp/ArmoniK.Api.Worker/Utils/WorkerServer.cs
@@ -133,6 +133,8 @@ public static class WorkerServer
                                                                       listenOptions => listenOptions.Protocols = HttpProtocols.Http2);
                                              break;
                                            case GrpcSocketType.Tcp:
+                                             options.Limits.Http2.KeepAlivePingTimeout = computePlaneOptions.WorkerChannel.KeepAlivePingTimeOut;
+                                             options.Limits.KeepAliveTimeout           = computePlaneOptions.WorkerChannel.KeepAliveTimeOut;
                                              var uri = new Uri(address);
                                              options.ListenAnyIP(uri.Port,
                                                                  listenOptions => listenOptions.Protocols = HttpProtocols.Http2);

--- a/packages/csharp/ArmoniK.Api.Worker/Utils/WorkerServer.cs
+++ b/packages/csharp/ArmoniK.Api.Worker/Utils/WorkerServer.cs
@@ -26,6 +26,7 @@ using System.IO;
 
 using ArmoniK.Api.Common.Channel.Utils;
 using ArmoniK.Api.Common.Options;
+using ArmoniK.Api.Common.Utils;
 
 using JetBrains.Annotations;
 
@@ -136,40 +137,13 @@ public static class WorkerServer
 
                                              var channelOptions = context.Configuration.GetRequiredSection(ComputePlane.SettingSection).
                                                                           GetSection(ComputePlane.WorkerChannelSection);
-                                             options.Limits.Http2.KeepAlivePingTimeout = ParseTimeSpan(channelOptions["KeepAlivePingTimeout"],
+                                             options.Limits.KeepAliveTimeout = channelOptions.GetTimeSpanOrDefault("KeepAliveTimeOut",TimeSpan.FromSeconds(130));
+                                             options.Limits.Http2.KeepAlivePingTimeout = channelOptions.GetTimeSpanOrDefault("KeepAlivePingTimeOut",
                                                                                                        TimeSpan.FromSeconds(20));
-                                             options.Limits.KeepAliveTimeout           = ParseTimeSpan(channelOptions["KeepAliveTimeOut"],
-                                                                                                       TimeSpan.FromSeconds(130));
                                              var uri = new Uri(address);
                                              options.ListenAnyIP(uri.Port,
                                                                  listenOptions => listenOptions.Protocols = HttpProtocols.Http2);
                                              break;
-
-                                             /* Local function to parse the KeepAlive options from the configuration section.
-                                              If the section to parse does not exist returns the given defaultValue
-                                              If a valid Time.Span string has been provided it parses and returns it
-                                              Provide support to handle the case where the option has been set to "MaxValue". */
-                                             TimeSpan ParseTimeSpan(string?  toParse,
-                                                                    TimeSpan defaultValue)
-                                             {
-                                               if (string.IsNullOrEmpty(toParse))
-                                               {
-                                                 return defaultValue;
-                                               }
-
-                                               if (toParse.Equals("MaxValue"))
-                                               {
-                                                 return TimeSpan.MaxValue;
-                                               }
-
-                                               if (TimeSpan.TryParse(toParse,
-                                                                     out var result))
-                                               {
-                                                 return result;
-                                               }
-
-                                               throw new FormatException($"Provide a valid TimeSpan format: {toParse} or 'MaxValue'");
-                                             }
                                            default:
                                              throw new InvalidOperationException("Socket type unknown");
                                          }

--- a/packages/csharp/ArmoniK.Api.Worker/Utils/WorkerServer.cs
+++ b/packages/csharp/ArmoniK.Api.Worker/Utils/WorkerServer.cs
@@ -113,7 +113,7 @@ public static class WorkerServer
       var rawComputePlaneOptions = builder.Configuration.GetRequiredSection(ComputePlane.SettingSection);
       var workerChannelOptions = rawComputePlaneOptions.
                                          GetRequiredSection(ComputePlane.WorkerChannelSection);
-      var agentChannelOptions = rawComputePlaneOptions.GetRequiredSection(ComputePlane.WorkerChannelSection);
+      var agentChannelOptions = rawComputePlaneOptions.GetRequiredSection(ComputePlane.AgentChannelSection);
       var parsedComputePlaneOptions = new ComputePlane
                                       {
                                         WorkerChannel = new GrpcChannel
@@ -132,13 +132,13 @@ public static class WorkerServer
                                                           KeepAlivePingTimeOut = agentChannelOptions.GetTimeSpanOrDefault("KeepAlivePingTimeOut",
                                                                                                                            TimeSpan.FromSeconds(20)),
                                                           KeepAliveTimeOut = agentChannelOptions.GetTimeSpanOrDefault("KeepAliveTimeOut",
-                                                                                                                                      TimeSpan.FromSeconds(130)),
+                                                                                                                      TimeSpan.FromSeconds(130)),
                                                        },
                                         MessageBatchSize = rawComputePlaneOptions.GetValue("MessageBatchSize", 1),
                                         AbortAfter = rawComputePlaneOptions.GetValue("AbortAfter", TimeSpan.Zero),
                                       };
 
-      builder.WebHost.ConfigureKestrel((context, options) =>
+      builder.WebHost.ConfigureKestrel(options =>
                                        {
                                          var address       = parsedComputePlaneOptions.WorkerChannel.Address;
                                          switch (parsedComputePlaneOptions.WorkerChannel.SocketType)

--- a/packages/csharp/ArmoniK.Api.Worker/Utils/WorkerServer.cs
+++ b/packages/csharp/ArmoniK.Api.Worker/Utils/WorkerServer.cs
@@ -135,7 +135,7 @@ public static class WorkerServer
                                            case GrpcSocketType.Tcp:
 
                                              var channelOptions = context.Configuration.GetRequiredSection(ComputePlane.SettingSection).
-                                                                          GetSection(ComputePlane.AgentChannelSection);
+                                                                          GetSection(ComputePlane.WorkerChannelSection);
                                              options.Limits.Http2.KeepAlivePingTimeout = ParseTimeSpan(channelOptions["KeepAlivePingTimeout"],
                                                                                                        TimeSpan.FromSeconds(20));
                                              options.Limits.KeepAliveTimeout           = ParseTimeSpan(channelOptions["KeepAliveTimeOut"],
@@ -146,10 +146,9 @@ public static class WorkerServer
                                              break;
 
                                              /* Local function to parse the KeepAlive options from the configuration section.
-                                                If the section to parse does not exist returns the given defaultValue
-                                                If a valid Time.Span string has been provided it parses and returns it
-                                                Provide support to handle the case where the option has been set to "MaxValue".
-                                              */
+                                              If the section to parse does not exist returns the given defaultValue
+                                              If a valid Time.Span string has been provided it parses and returns it
+                                              Provide support to handle the case where the option has been set to "MaxValue". */
                                              TimeSpan ParseTimeSpan(string?  toParse,
                                                                     TimeSpan defaultValue)
                                              {
@@ -157,15 +156,18 @@ public static class WorkerServer
                                                {
                                                  return defaultValue;
                                                }
+
                                                if (toParse.Equals("MaxValue"))
                                                {
                                                  return TimeSpan.MaxValue;
                                                }
+
                                                if (TimeSpan.TryParse(toParse,
                                                                      out var result))
                                                {
                                                  return result;
                                                }
+
                                                throw new FormatException($"Provide a valid TimeSpan format: {toParse} or 'MaxValue'");
                                              }
                                            default:

--- a/packages/csharp/ArmoniK.Api.Worker/Utils/WorkerServer.cs
+++ b/packages/csharp/ArmoniK.Api.Worker/Utils/WorkerServer.cs
@@ -111,15 +111,15 @@ public static class WorkerServer
       builder.Host.UseSerilog(Log.Logger);
 
       var rawComputePlaneOptions = builder.Configuration.GetRequiredSection(ComputePlane.SettingSection);
-      var workerChannelOptions = rawComputePlaneOptions.
-                                         GetRequiredSection(ComputePlane.WorkerChannelSection);
-      var agentChannelOptions = rawComputePlaneOptions.GetRequiredSection(ComputePlane.AgentChannelSection);
+      var workerChannelOptions   = rawComputePlaneOptions.GetRequiredSection(ComputePlane.WorkerChannelSection);
+      var agentChannelOptions    = rawComputePlaneOptions.GetRequiredSection(ComputePlane.AgentChannelSection);
       var parsedComputePlaneOptions = new ComputePlane
                                       {
                                         WorkerChannel = new GrpcChannel
                                                         {
                                                           Address = workerChannelOptions.GetRequiredValue<string>("Address"),
-                                                          SocketType = workerChannelOptions.GetValue("SocketType", GrpcSocketType.UnixDomainSocket),
+                                                          SocketType = workerChannelOptions.GetValue("SocketType",
+                                                                                                     GrpcSocketType.UnixDomainSocket),
                                                           KeepAlivePingTimeOut = workerChannelOptions.GetTimeSpanOrDefault("KeepAlivePingTimeOut",
                                                                                                                            TimeSpan.FromSeconds(20)),
                                                           KeepAliveTimeOut = workerChannelOptions.GetTimeSpanOrDefault("KeepAliveTimeOut",
@@ -127,20 +127,23 @@ public static class WorkerServer
                                                         },
                                         AgentChannel = new GrpcChannel
                                                        {
-                                                          Address    = agentChannelOptions.GetRequiredValue<string>("Address"),
-                                                          SocketType = agentChannelOptions.GetValue("SocketType", GrpcSocketType.UnixDomainSocket),
-                                                          KeepAlivePingTimeOut = agentChannelOptions.GetTimeSpanOrDefault("KeepAlivePingTimeOut",
-                                                                                                                           TimeSpan.FromSeconds(20)),
-                                                          KeepAliveTimeOut = agentChannelOptions.GetTimeSpanOrDefault("KeepAliveTimeOut",
-                                                                                                                      TimeSpan.FromSeconds(130)),
+                                                         Address = agentChannelOptions.GetRequiredValue<string>("Address"),
+                                                         SocketType = agentChannelOptions.GetValue("SocketType",
+                                                                                                   GrpcSocketType.UnixDomainSocket),
+                                                         KeepAlivePingTimeOut = agentChannelOptions.GetTimeSpanOrDefault("KeepAlivePingTimeOut",
+                                                                                                                         TimeSpan.FromSeconds(20)),
+                                                         KeepAliveTimeOut = agentChannelOptions.GetTimeSpanOrDefault("KeepAliveTimeOut",
+                                                                                                                     TimeSpan.FromSeconds(130)),
                                                        },
-                                        MessageBatchSize = rawComputePlaneOptions.GetValue("MessageBatchSize", 1),
-                                        AbortAfter = rawComputePlaneOptions.GetValue("AbortAfter", TimeSpan.Zero),
+                                        MessageBatchSize = rawComputePlaneOptions.GetValue("MessageBatchSize",
+                                                                                           1),
+                                        AbortAfter = rawComputePlaneOptions.GetValue("AbortAfter",
+                                                                                     TimeSpan.Zero),
                                       };
 
       builder.WebHost.ConfigureKestrel(options =>
                                        {
-                                         var address       = parsedComputePlaneOptions.WorkerChannel.Address;
+                                         var address = parsedComputePlaneOptions.WorkerChannel.Address;
                                          switch (parsedComputePlaneOptions.WorkerChannel.SocketType)
                                          {
                                            case GrpcSocketType.UnixDomainSocket:


### PR DESCRIPTION
# Motivation

PR https://github.com/aneoconsulting/ArmoniK.Api/pull/583 added support to allow the usage of a tcp socket between the agent and the worker. There are still issues with connection (for Java grpc) which are solved deactivating some keep-alive options   . This PR exposes those options so they can be set via environmental variables during deployment. 

# Description

Added the two relevant Keep-alive options  as members of the `GrpcChannel` class, the options are deactivated by setting
them as `TimeSpan.MaxValue`. 

In order to allow the user to specify this in the corresponding environment variables, for example to disable the `KeepAlivePingTimeout` in the `WorkerChannel`,  we make use of the environment variable:

```hcl 

"ComputePlane__WorkerChannel__KeepAlivePingTimeout=MaxValue"

```
 
manually parse the `ComputePlane` configuration to account this and correctly parse the string "MaxValue" as `TimeSpan.MaxValue`  before registering the configuration in the dependency injection container. If the above mentioned
environment variable is not defined we take care to set a default value that matches the default value of the [documentation](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.http2limits.keepalivepingtimeout?view=aspnetcore-9.0&viewFallbackFrom=net-8.0) 

# Testing

A unit test has been added to verify that the configuration is properly read and values correctly parsed.

# Impact

In the case the user wants to have control over this options, it is necessary to define the following environment variables

```hcl
    "ComputePlane__WorkerChannel__KeepAlivePingTimeout=MaxValue",
    "ComputePlane__WorkerChannel__KeepAliveTimeout=MaxValue",
    "ComputePlane__AgentChannel__KeepAlivePingTimeout=00:01:00",
    "ComputePlane__AgentChannel__KeepAliveTimeout=00:00:20"
```

The chosen values are just an example, only a valid TimeSpan or the string "MaxValue" are accepted.
These are only used for tcp sockets. 

# Additional Information

None.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
