### PR TITLE
fix: node pipelines breaking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,8 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           fetch-depth: 0
-      - run: npm install -g pnpm@9.1.4
+
+      - run: npm install -g pnpm@10.4.1
       - run: corepack enable
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
         with:


### PR DESCRIPTION
# Motivation

Pipelines involving node have broken in two different ways:
- The pnpm integrity key is no longer accepted by npm on pipelines running on node@20.x.x. (for `ci.yml`)
- The pnpm cache does no longer exist, breaking the Doc pipelines.

# Description

In order to fix the first problem, i tried to update pnpm to its lastest version, after the breaking integrity key was introduced. If it does not work, the solution reside in [this comment](https://github.com/nodejs/corepack/issues/612#issuecomment-2631428482), which include adding a new step to the lint JS pipeline.

For the second problem, if it is not fixed by the first solution, the solution might reside in adding a new step to the docs pipelines whose role would be to install (and so cache) the dependencies, as sugested by [this comment](https://github.com/actions/setup-node/issues/801#issuecomment-2499789029) 

# Testing

[When applicable, detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]

# Impact

[Discuss the impact of your modifications on ArmoniK. This might include effects on performance, configuration, documentation, new dependencies, or changes in behaviour.]

# Additional Information

[Any additional information that reviewers should be aware of.]

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
