### PR TITLE
feat: Add import result data method for Python API

### DIFF
--- a/packages/python/src/armonik/common/filter/_filter_field.py
+++ b/packages/python/src/armonik/common/filter/_filter_field.py
@@ -338,6 +338,7 @@ class ResultFilter(FilterWrapper):
         "size": (FType.NUM, RESULT_RAW_ENUM_FIELD_SIZE),
         "created_by": (FType.STR, RESULT_RAW_ENUM_FIELD_CREATED_BY),
         "owner_task_id": (FType.STR, RESULT_RAW_ENUM_FIELD_OWNER_TASK_ID),
+        "opaque_id": (FType.NA, "opaque_id"),
     }
 
     def __init__(self):

--- a/packages/python/src/armonik/common/objects.py
+++ b/packages/python/src/armonik/common/objects.py
@@ -481,6 +481,7 @@ class Result:
     completed_at = FilterDescriptor(_resultFilter)
     result_id = FilterDescriptor(_resultFilter)
     size = FilterDescriptor(_resultFilter)
+    opaque_id = FilterDescriptor(_resultFilter)
 
     def __init__(
         self,
@@ -493,6 +494,7 @@ class Result:
         completed_at: Optional[datetime] = None,
         result_id: Optional[str] = None,
         size: Optional[int] = None,
+        opaque_id: Optional[bytes] = None,
     ):
         self.session_id = session_id
         self.name = name
@@ -503,6 +505,7 @@ class Result:
         self.completed_at = completed_at
         self.result_id = result_id
         self.size = size
+        self.opaque_id = opaque_id
 
     @classmethod
     def from_message(cls, result_raw: ResultRaw) -> "Result":
@@ -516,6 +519,7 @@ class Result:
             completed_at=timestamp_to_datetime(result_raw.completed_at),
             result_id=result_raw.result_id,
             size=result_raw.size,
+            opaque_id=result_raw.opaque_id,
         )
 
     @classmethod
@@ -537,6 +541,7 @@ class Result:
             and self.completed_at == other.completed_at
             and self.result_id == other.result_id
             and self.size == other.size
+            and self.opaque_id == other.opaque_id
         )
 
 

--- a/packages/python/tests/test_results.py
+++ b/packages/python/tests/test_results.py
@@ -21,6 +21,7 @@ class TestArmoniKResults:
         assert result.completed_at is None
         assert result.result_id == "result-id"
         assert result.size == 0
+        assert result.opaque_id == b"opaque-id"
 
     def test_get_owner_task_id(self):
         results_client: ArmoniKResults = get_client("Results")
@@ -111,6 +112,24 @@ class TestArmoniKResults:
             assert issubclass(w[-1].category, DeprecationWarning)
             assert rpc_called("Results", "CreateResultsMetaData", 2)
             assert results == {}
+
+    def test_import_result_data(self):
+        results_client: ArmoniKResults = get_client("Results")
+        result = results_client.import_data("session-id", [("result-id", b"opaque-id")])[
+            "result-id"
+        ]
+
+        assert rpc_called("Results", "ImportResultsData")
+        assert isinstance(result, Result)
+        assert result.session_id == "session-id"
+        assert result.name == "result-name"
+        assert result.owner_task_id == "owner-task-id"
+        assert result.status == 2
+        assert result.created_at is None
+        assert result.completed_at is None
+        assert result.result_id == "result-id"
+        assert result.size == 0
+        assert result.opaque_id == b"opaque-id"
 
     def test_service_fully_implemented(self):
         assert all_rpc_called("Results", missings=["WatchResults"])


### PR DESCRIPTION
# Motivation

The RPC for importing result data is not implemented in the Python API.

# Description

Updated the Result object to add the opaque_id field and implemented the import_data method on ArmoniKResults class.

# Testing

Added a new unit test.

# Impact

No impact.

# Additional Information

Not applicable.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
