### PR TITLE
ci: move test in test ci and allow nuget package publishing on renovate PRs

### DIFF
--- a/.github/workflows/publish-edge.yml
+++ b/.github/workflows/publish-edge.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   genversion:
-    if: github.actor != 'renovate[bot]' && github.repository_owner == 'aneoconsulting'
     runs-on: ubuntu-latest
     name: Version
     outputs:
@@ -40,43 +39,8 @@ jobs:
         id: outver
         run: echo "VERSION=${{ needs.genversion.outputs.version }}" >> "$GITHUB_OUTPUT"
 
-  tests:
-    if: github.actor != 'renovate[bot]' && github.repository_owner == 'aneoconsulting'
-    name: Tests
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        projects:
-          - packages/csharp/ArmoniK.Api.Tests
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          ref: ${{ github.head_ref }}
-          fetch-depth: 0
-
-      # Install the .NET Core workload
-      - name: Install .NET Core
-        uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4
-        with:
-          dotnet-version: 6.x
-
-      - name: Run tests
-        run: |
-          cd ${{ matrix.projects }}
-          dotnet test --logger "trx;LogFileName=test-results.trx"
-
-      - name: Test Report
-        uses: dorny/test-reporter@v1
-        if: success() || failure()
-        with:
-          name: Test - ${{ matrix.os }} ${{ matrix.projects }}
-          path: ${{ matrix.projects }}/TestResults/test-results.trx
-          reporter: dotnet-trx
-
   release-csharp-packages:
-    needs: [tests, version]
+    needs: [version]
     name: Release C# Packages
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -227,6 +191,7 @@ jobs:
 
   release-cpp-package:
     needs: [version]
+    if: github.actor != 'renovate[bot]' && github.repository_owner == 'aneoconsulting'
     strategy:
       fail-fast: false
       matrix:
@@ -253,6 +218,7 @@ jobs:
 
   release-java-package:
     needs: [version]
+    if: github.actor != 'renovate[bot]' && github.repository_owner == 'aneoconsulting'
     name: Release Java Package
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -337,3 +337,40 @@ jobs:
         with:
           name: code-coverage-report-xml
           path: packages/python/coverage.xml
+
+  csharp-api:
+    name: C# API Tests
+    strategy:
+      fail-fast: false
+      matrix:
+        projects:
+          - packages/csharp/ArmoniK.Api.Tests
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      # Install the .NET Core workload
+      - name: Install .NET Core
+        uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4
+        with:
+          dotnet-version: 6.x
+
+      - name: Run tests
+        run: |
+          cd ${{ matrix.projects }}
+          dotnet test --logger "trx;LogFileName=test-results.trx"
+
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: Test - ${{ matrix.os }} ${{ matrix.projects }}
+          path: ${{ matrix.projects }}/TestResults/test-results.trx
+          reporter: dotnet-trx

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,6 @@
   ],
   "rust-analyzer.cargo.features": [
     "serde"
-  ]
+  ],
+  "cmake.ignoreCMakeListsMissing": true
 }


### PR DESCRIPTION
# Motivation

Allow to publish nuget packages produced by updates from Renovate so that we can test if they are still compatible with other projects.

# Description

- Change pipeline job conditions so that nuget packages are published when Renovate opens PRs

# Testing

- Use the CI

# Impact

NA

# Additional Information

NA

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
