### PR TITLE
feat: option to turn off data deletion by armonik

### DIFF
--- a/Protos/V1/results_common.proto
+++ b/Protos/V1/results_common.proto
@@ -26,6 +26,7 @@ message ResultRaw {
   int64 size = 9; /** The size of the Result Data. */
   string created_by = 10; /** The ID of the Task that as submitted this result.*/
   bytes opaque_id = 11; /** ID of the data in the underlying object storage. */
+  bool manual_deletion = 12; /** If the user has to delete the data in the underlying object storage. */
 }
 
 /**
@@ -111,6 +112,7 @@ message CreateResultsMetaDataRequest {
   */
   message ResultCreate {
     string name = 1; /** The result name. Given by the client. */
+    bool manual_deletion = 2; /** If the user has to delete the data in the underlying object storage. */
   }
   repeated ResultCreate results = 1; /** The list of results to create. */
   string session_id = 2; /** The session in which create results. */
@@ -133,6 +135,7 @@ message CreateResultsRequest {
   message ResultCreate {
     string name = 1; /** The result name. Given by the client. */
     bytes data = 2; /** The actual data of the result. */
+    bool manual_deletion = 3; /** If the user has to delete the data in the underlying object storage. */
   }
   repeated ResultCreate results = 1; /** Results to create. */
   string session_id = 2; /** The session in which create results. */

--- a/Protos/V1/results_common.proto
+++ b/Protos/V1/results_common.proto
@@ -26,7 +26,7 @@ message ResultRaw {
   int64 size = 9; /** The size of the Result Data. */
   string created_by = 10; /** The ID of the Task that as submitted this result.*/
   bytes opaque_id = 11; /** ID of the data in the underlying object storage. */
-  bool manual_deletion = 12; /** If the user has to delete the data in the underlying object storage. */
+  bool manual_deletion = 12; /** If the user is responsible for the deletion of the data in the underlying object storage. */
 }
 
 /**
@@ -112,7 +112,7 @@ message CreateResultsMetaDataRequest {
   */
   message ResultCreate {
     string name = 1; /** The result name. Given by the client. */
-    bool manual_deletion = 2; /** If the user has to delete the data in the underlying object storage. */
+    bool manual_deletion = 2; /** If the user is responsible for the deletion of the data in the underlying object storage. */
   }
   repeated ResultCreate results = 1; /** The list of results to create. */
   string session_id = 2; /** The session in which create results. */
@@ -135,7 +135,7 @@ message CreateResultsRequest {
   message ResultCreate {
     string name = 1; /** The result name. Given by the client. */
     bytes data = 2; /** The actual data of the result. */
-    bool manual_deletion = 3; /** If the user has to delete the data in the underlying object storage. */
+    bool manual_deletion = 3; /** If the user is responsible for the deletion of the data in the underlying object storage. */
   }
   repeated ResultCreate results = 1; /** Results to create. */
   string session_id = 2; /** The session in which create results. */

--- a/Protos/V1/results_fields.proto
+++ b/Protos/V1/results_fields.proto
@@ -18,6 +18,8 @@ enum ResultRawEnumField {
   RESULT_RAW_ENUM_FIELD_RESULT_ID = 7; /** The result ID. */
   RESULT_RAW_ENUM_FIELD_SIZE = 8; /** The size of the result. */
   RESULT_RAW_ENUM_FIELD_CREATED_BY = 9; /** The size of the result. */
+  RESULT_RAW_ENUM_FIELD_OPAQUE_ID = 10; /** The ID of the data in the underlying object storage. */
+  RESULT_RAW_ENUM_FIELD_MANUAL_DELETION = 11; /** If the user is responsible for the deletion of the data in the underlying object storage. */
 }
 
 /**

--- a/packages/rust/armonik/src/objects/results/create.rs
+++ b/packages/rust/armonik/src/objects/results/create.rs
@@ -4,45 +4,42 @@ use super::Raw;
 
 use crate::api::v3;
 
+/// Result to create with data.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RequestItem {
+    /// The name of the result to create.
+    pub name: String,
+    /// The data associated to the result to create.
+    pub data: Vec<u8>,
+    /// The session in which create results.
+    pub manual_deletion: bool,
+}
+
+super::super::impl_convert!(
+  struct RequestItem = v3::results::create_results_request::ResultCreate {
+      name,
+      data,
+      manual_deletion,
+  }
+);
+
 /// Request for creating results with data.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Request {
     /// Results to create.
-    pub results: HashMap<String, Vec<u8>>,
+    pub results: Vec<RequestItem>,
     /// The session in which create results.
     pub session_id: String,
 }
 
-impl From<Request> for v3::results::CreateResultsRequest {
-    fn from(value: Request) -> Self {
-        Self {
-            results: value
-                .results
-                .into_iter()
-                .map(
-                    |(name, data)| v3::results::create_results_request::ResultCreate { name, data },
-                )
-                .collect(),
-            session_id: value.session_id,
-        }
-    }
-}
-
-impl From<v3::results::CreateResultsRequest> for Request {
-    fn from(value: v3::results::CreateResultsRequest) -> Self {
-        Self {
-            results: value
-                .results
-                .into_iter()
-                .map(|result| (result.name, result.data))
-                .collect(),
-            session_id: value.session_id,
-        }
-    }
-}
-
-super::super::impl_convert!(req Request : v3::results::CreateResultsRequest);
+super::super::impl_convert!(
+  struct Request = v3::results::CreateResultsRequest {
+      list results = list results,
+      session_id,
+  }
+);
 
 /// Response for creating results without data.
 #[derive(Debug, Clone, Default)]

--- a/packages/rust/armonik/src/objects/results/create_metadata.rs
+++ b/packages/rust/armonik/src/objects/results/create_metadata.rs
@@ -4,47 +4,39 @@ use super::Raw;
 
 use crate::api::v3;
 
+/// Result to create without data.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RequestItem {
+    /// The name of the result to create.
+    pub name: String,
+    /// The session in which create results.
+    pub manual_deletion: bool,
+}
+
+super::super::impl_convert!(
+  struct RequestItem = v3::results::create_results_meta_data_request::ResultCreate {
+      name,
+      manual_deletion,
+  }
+);
+
 /// Request for creating results without data.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Request {
-    /// The list of names for the results to create.
-    pub names: Vec<String>,
+    /// Results to create.
+    pub results: Vec<RequestItem>,
     /// The session in which create results.
     pub session_id: String,
 }
 
-impl From<Request> for v3::results::CreateResultsMetaDataRequest {
-    fn from(value: Request) -> Self {
-        Self {
-            results: value
-                .names
-                .into_iter()
-                .map(
-                    |result| v3::results::create_results_meta_data_request::ResultCreate {
-                        name: result,
-                    },
-                )
-                .collect(),
-            session_id: value.session_id,
-        }
-    }
-}
-
-impl From<v3::results::CreateResultsMetaDataRequest> for Request {
-    fn from(value: v3::results::CreateResultsMetaDataRequest) -> Self {
-        Self {
-            names: value
-                .results
-                .into_iter()
-                .map(|result| result.name)
-                .collect(),
-            session_id: value.session_id,
-        }
-    }
-}
-
-super::super::impl_convert!(req Request : v3::results::CreateResultsMetaDataRequest);
+super::super::impl_convert!(
+  struct Request = v3::results::CreateResultsMetaDataRequest {
+      list results = list results,
+      session_id,
+  }
+);
 
 /// Response for creating results without data.
 #[derive(Debug, Clone, Default)]

--- a/packages/rust/armonik/src/objects/results/field.rs
+++ b/packages/rust/armonik/src/objects/results/field.rs
@@ -26,6 +26,10 @@ pub enum Field {
     Size = 8,
     /// The ID of the Task that as submitted this result.
     CreatedBy = 9,
+    /// The ID of the data in the underlying object storage.
+    OpaqueId = 10,
+    /// If the user is responsible for the deletion of the data in the underlying object storage.
+    ManualDeletion = 11,
 }
 
 impl From<i32> for Field {
@@ -41,6 +45,8 @@ impl From<i32> for Field {
             7 => Self::ResultId,
             8 => Self::Size,
             9 => Self::CreatedBy,
+            10 => Self::OpaqueId,
+            11 => Self::ManualDeletion,
             _ => Self::Unspecified,
         }
     }

--- a/packages/rust/armonik/src/objects/results/raw.rs
+++ b/packages/rust/armonik/src/objects/results/raw.rs
@@ -34,6 +34,8 @@ pub struct Raw {
     pub created_by: String,
     /// ID of the data in the underlying object storage.
     pub opaque_id: Vec<u8>,
+    /// If the user has to delete the data in the underlying object storage
+    pub manual_deletion: bool,
 }
 
 super::super::impl_convert!(
@@ -48,5 +50,6 @@ super::super::impl_convert!(
         size,
         created_by,
         opaque_id,
+        manual_deletion,
     }
 );

--- a/packages/rust/armonik/src/objects/results/raw.rs
+++ b/packages/rust/armonik/src/objects/results/raw.rs
@@ -34,7 +34,7 @@ pub struct Raw {
     pub created_by: String,
     /// ID of the data in the underlying object storage.
     pub opaque_id: Vec<u8>,
-    /// If the user has to delete the data in the underlying object storage
+    /// If the user is responsible for the deletion of the data in the underlying object storage
     pub manual_deletion: bool,
 }
 


### PR DESCRIPTION
# Motivation

Allow users to specify data that will not be deleted by ArmoniK. Used in combination with import, it ensures data managed outside of ArmoniK to not be deleted by ArmoniK.

# Description

- Add `manual_deletion` option during results metadata creation
- Add missing fields for filtering
- Implement Rust client side

# Testing

- Rust unit tests were modified accordingly and are passing.

# Impact

- This option should be supported in ArmoniK.Core in the future
- This option has to be added into other programming languages

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
