### PR TITLE
docs: add search in readthedocs

### DIFF
--- a/.docs/conf.py
+++ b/.docs/conf.py
@@ -35,6 +35,7 @@ suppress_warnings = ["myst.header"]
 
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
+html_search = True
 
 # -- Options for source files ------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-source-files


### PR DESCRIPTION
# Motivation

To improve navigation and help users find relevant information more easily.

# Description

Enabling search functionality on ReadTheDocs by setting html_search = True in conf.py