### PR TITLE
docs: Fix read the doc build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,12 +9,11 @@ build:
   os: ubuntu-24.04
   tools:
     python: '3.12'
+  apt_packages:
+    - dotnet-sdk-8.0
   jobs:
     post_install:
       - pip install --only-binary sphinx,sphinxcontrib-mermaid,sphinx-rtd-theme,myst_parser,grpcio,grpcio-tools --no-cache-dir sphinx sphinxcontrib-mermaid sphinx-rtd-theme myst_parser grpcio grpcio-tools
-      - curl -OfsSL https://dot.net/v1/dotnet-install.sh
-      - chmod +x dotnet-install.sh
-      - ./dotnet-install.sh
       # Install protobuf compiler manually
       - curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.0/protoc-21.0-linux-x86_64.zip
       - unzip protoc-21.0-linux-x86_64.zip -d $HOME/protoc
@@ -26,15 +25,13 @@ build:
       - $HOME/protoc/bin/protoc --version # Verify protoc version
 
     pre_build:
-
       - $HOME/protoc/bin/protoc -I Protos/V1 --plugin=$HOME/protoc-gen-doc/protoc-gen-doc --doc_out=.docs/content/api --doc_opt=markdown,tmp.md Protos/V1/*.proto # Generate docs
       - sh scripts/generate-proto-doc.sh
       # Process the generated markdown with sed to apply custom formatting
 
       - sphinx-apidoc -o .docs/content/api/python packages/python/src/armonik
       # Set up .NET environment
-      - DOTNET_ROOT="$HOME/.dotnet" PATH="$PATH":"$DOTNET_ROOT":"$DOTNET_ROOT/tools" env
-      - DOTNET_ROOT="$HOME/.dotnet" PATH="$PATH":"$DOTNET_ROOT":"$DOTNET_ROOT/tools" scripts/generate-csharp-doc.sh
+      - PATH="$PATH":"$HOME/.dotnet/tools" scripts/generate-csharp-doc.sh
 
 # Move anchors out of the titles
 # Build documentation in the ".docs/" directory with Sphinx

--- a/scripts/generate-csharp-doc.sh
+++ b/scripts/generate-csharp-doc.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 set -e
-dotnet tool update -g docfx
+dotnet tool install -g docfx
 dotnet build packages/csharp/ArmoniK.Api.sln
 docfx docfx.json
 sed -E -i 's/([#]+) <a id="([^"]+)"><\/a> (.+)/<a id="\2"><\/a>\n\1 \3/g' .docs/content/api/csharp/*.md


### PR DESCRIPTION
# Motivation

Reduce the failure rate of documentation builds.

# Description

Install dotnet with apt-get through readthedocs `apt_packages`  instead of using curl to download dotnet installer and execute it to install dotnet.  Curl step was failing a lot.

# Testing

Documentation is building properly.

# Impact

Decrease the burden of having a "green" pipeline.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
