### PR TITLE
ci: Fix alpine version

### DIFF
--- a/packages/cpp/tools/Dockerfile.worker
+++ b/packages/cpp/tools/Dockerfile.worker
@@ -1,5 +1,5 @@
 # Start with the latest Alpine base image for the build stage
-FROM alpine AS builder
+FROM alpine:3.21 AS builder
 ARG GRPC_VERSION=v1.54.0
 
 # Install all the necessary dependencies required for the build process
@@ -51,7 +51,7 @@ RUN cmake -DCMAKE_INSTALL_PREFIX="/app/install" -DPROTO_FILES_DIR="/app/proto" -
 RUN make -j $(nproc) install
 
 # Start with the latest Alpine base image for the final stage
-FROM alpine
+FROM alpine:3.21
 # Install all the necessary dependencies required for the build process
 # These include tools and libraries for building and compiling the source code
 RUN apk update && apk add --no-cache \
@@ -72,7 +72,7 @@ RUN apk update && apk add --no-cache \
     libprotobuf \
     grpc \ 
     grpc-cpp
-	
+
 # Create a non-root user and group for running the application
 # This is a security best practice to avoid running applications as the root user
 RUN addgroup -g 5000 -S armonikuser && adduser -D -h /home/armonikuser  -u 5000 -G armonikuser --shell /bin/sh armonikuser && mkdir /cache && chown armonikuser: /cache

--- a/packages/cpp/tools/packaging/tgz_alpine.Dockerfile
+++ b/packages/cpp/tools/packaging/tgz_alpine.Dockerfile
@@ -1,5 +1,5 @@
 # Start with the latest Alpine base image for the build stage
-FROM alpine AS builder
+FROM alpine:3.21 AS builder
 ARG GRPC_VERSION=v1.54.0
 
 # Install all the necessary dependencies required for the build process
@@ -45,7 +45,7 @@ COPY packages/cpp/Dependencies.cmake .
 # Build the application using the copied source files and protobuf definitions
 WORKDIR /app/libarmonik/build
 RUN cmake -DCMAKE_INSTALL_PREFIX="/app/install" -DPROTO_FILES_DIR="/app/proto" -DBUILD_TEST=OFF \
-          -DBUILD_CLIENT=ON -DBUILD_WORKER=OFF -DPROTO_FILES_DIR=/app/libarmonik/Protos \ 
-          -DCPACK_GENERATOR=TGZ /app/libarmonik && \
+    -DBUILD_CLIENT=ON -DBUILD_WORKER=OFF -DPROTO_FILES_DIR=/app/libarmonik/Protos \ 
+    -DCPACK_GENERATOR=TGZ /app/libarmonik && \
     make -j $(nproc) && \
     make package -j


### PR DESCRIPTION
# Motivation

In the latest Alpine version, gRPC and protobuf versions have been upgraded, which make fail pipelines.

# Description

Force the previous Alpine version.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
