### PR TITLE
ci: remove windows 2019 and fix protoc install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,9 @@ jobs:
         run: nci
 
       - name: Install Protoc
-        run: sudo apt install -y protobuf-compiler
+        uses: taiki-e/install-action@019e22100565643c6890fe3f00da0b63017c1672 # v2
+        with:
+          tool: protoc
 
       - name: Build protos
         run: nr proto:generate:linux
@@ -308,7 +310,9 @@ jobs:
         run: nci
 
       - name: Install Protoc
-        run: sudo apt install -y protobuf-compiler
+        uses: taiki-e/install-action@019e22100565643c6890fe3f00da0b63017c1672 # v2
+        with:
+          tool: protoc
 
       - name: Build protos
         run: nr proto:generate:linux

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,6 @@ jobs:
         plateform:
           - os: ubuntu-latest
           - os: windows-latest
-          - os: windows-2019
         exclude:
           - language:
               lang: Python
@@ -80,18 +79,6 @@ jobs:
               lang: C++
             plateform:
               os: windows-latest
-          - language:
-              lang: C++
-            plateform:
-              os: windows-2019
-          - language:
-              lang: Python
-            plateform:
-              os: windows-2019
-          - language:
-              lang: Rust
-            plateform:
-              os: windows-2019
           # FIXME: Rust should be working on Windows,
           # but we most likely encounter a port exhaustion issue
           - language:


### PR DESCRIPTION
# Motivation

Protoc install might fail when installed from apt.
Windows server 2019 has been deprecated from github runners.

# Description

Install protoc with taiki-e/install-action, and remove Windows server 2019 tests.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
