### PR TITLE
fix: Properly passing in task options in the worker's task handler

### DIFF
--- a/packages/python/src/armonik/worker/taskhandler.py
+++ b/packages/python/src/armonik/worker/taskhandler.py
@@ -103,10 +103,8 @@ class TaskHandler:
                 session_id=self.session_id,
                 communication_token=self.token,
                 task_creations=task_creations,
+                task_options=(default_task_options.to_message() if default_task_options else None),
             )
-
-            if default_task_options:
-                request.task_options = default_task_options.to_message()
 
             submitted_tasks.extend(
                 Task(


### PR DESCRIPTION
# Motivation

Encountered error when trying to set the task options of a task that's being instantiated from a Python worker (via sub-tasking). 

# Description

- Changed the SubmitTaskRequest to just take in the default_task_options on creation. (Another approach would be to still use the if statement and a `CopyFrom` ?)

# Testing

The unit tests in this repo are still passing

# Impact

Not Applicable.

# Additional Information

Not Applicable.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
