### PR TITLE
chore: add class attribute to mark classes whose doc should be extracted

### DIFF
--- a/packages/csharp/ArmoniK.Api.Client/Options/GrpcClient.cs
+++ b/packages/csharp/ArmoniK.Api.Client/Options/GrpcClient.cs
@@ -25,6 +25,7 @@ using System;
 using System.Threading;
 
 using ArmoniK.Api.Client.Submitter;
+using ArmoniK.Api.Common.Utils;
 
 using JetBrains.Annotations;
 
@@ -33,6 +34,7 @@ namespace ArmoniK.Api.Client.Options
   /// <summary>
   ///   Options for creating a gRPC Client with <see cref="GrpcChannelFactory" />
   /// </summary>
+  [ExtractDocumentation("Grpc Client Options")]
   [PublicAPI]
   public class GrpcClient
   {

--- a/packages/csharp/ArmoniK.Api.Common/Options/ComputePlane.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Options/ComputePlane.cs
@@ -23,6 +23,8 @@
 
 using System;
 
+using ArmoniK.Api.Common.Utils;
+
 using JetBrains.Annotations;
 
 namespace ArmoniK.Api.Common.Options;
@@ -30,6 +32,7 @@ namespace ArmoniK.Api.Common.Options;
 /// <summary>
 ///   Options to configure the connections between Worker and Agent
 /// </summary>
+[ExtractDocumentation("ComputePlane Options")]
 [PublicAPI]
 public class ComputePlane
 {

--- a/packages/csharp/ArmoniK.Api.Common/Options/GrpcChannel.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Options/GrpcChannel.cs
@@ -23,6 +23,8 @@
 
 using System;
 
+using ArmoniK.Api.Common.Utils;
+
 using JetBrains.Annotations;
 
 namespace ArmoniK.Api.Common.Options;
@@ -30,6 +32,7 @@ namespace ArmoniK.Api.Common.Options;
 /// <summary>
 ///   Options to configure a channel from gRPC
 /// </summary>
+[ExtractDocumentation("Grpc Channel Options")]
 [PublicAPI]
 public class GrpcChannel
 {

--- a/packages/csharp/ArmoniK.Api.Common/Utils/ExtractDocumentationAttribute.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Utils/ExtractDocumentationAttribute.cs
@@ -1,0 +1,49 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2025. All rights reserved.
+//   W. Kirschenmann   <wkirschenmann@aneo.fr>
+//   J. Gurhem         <jgurhem@aneo.fr>
+//   D. Dubuc          <ddubuc@aneo.fr>
+//   L. Ziane Khodja   <lzianekhodja@aneo.fr>
+//   F. Lemaitre       <flemaitre@aneo.fr>
+//   S. Djebbar        <sdjebbar@aneo.fr>
+//   J. Fonseca        <jfonseca@aneo.fr>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace ArmoniK.Api.Common.Utils;
+
+using System;
+
+/// <summary>
+/// Indicates that a class should have its property documentation collected.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class,
+                Inherited = false)]
+public class ExtractDocumentationAttribute : Attribute
+{
+  /// <summary>
+  /// Initializes a new instance of the <see cref="ExtractDocumentationAttribute"/> class.
+  /// </summary>
+  /// <param name="description">An optional description for the attribute, providing context about the class.</param>
+  public ExtractDocumentationAttribute(string description = "")
+  {
+    Description = description;
+  }
+
+  /// <summary>
+  /// Gets the description of the attribute.
+  /// </summary>
+  public string Description { get; }
+}

--- a/packages/csharp/ArmoniK.Api.Common/Utils/ExtractDocumentationAttribute.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Utils/ExtractDocumentationAttribute.cs
@@ -1,5 +1,5 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2025. All rights reserved.
 //   W. Kirschenmann   <wkirschenmann@aneo.fr>
 //   J. Gurhem         <jgurhem@aneo.fr>
@@ -22,28 +22,26 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace ArmoniK.Api.Common.Utils;
-
 using System;
 
+namespace ArmoniK.Api.Common.Utils;
+
 /// <summary>
-/// Indicates that a class should have its property documentation collected.
+///   Indicates that a class should have its property documentation collected.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class,
                 Inherited = false)]
 public class ExtractDocumentationAttribute : Attribute
 {
   /// <summary>
-  /// Initializes a new instance of the <see cref="ExtractDocumentationAttribute"/> class.
+  ///   Initializes a new instance of the <see cref="ExtractDocumentationAttribute" /> class.
   /// </summary>
   /// <param name="description">An optional description for the attribute, providing context about the class.</param>
   public ExtractDocumentationAttribute(string description = "")
-  {
-    Description = description;
-  }
+    => Description = description;
 
   /// <summary>
-  /// Gets the description of the attribute.
+  ///   Gets the description of the attribute.
   /// </summary>
   public string Description { get; }
 }


### PR DESCRIPTION
# Motivation

Improve documentation

# Description

PR adds  a class attribute `ExtractDocumentation` to mark classes whose doc should be extracted.

# Testing


# Impact

None

# Additional Information

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
