### PR TITLE
fix: stream clear bug

### DIFF
--- a/packages/cpp/ArmoniK.Api.Worker/source/Worker/TaskHandler.cpp
+++ b/packages/cpp/ArmoniK.Api.Worker/source/Worker/TaskHandler.cpp
@@ -42,7 +42,6 @@ armonik::api::worker::TaskHandler::TaskHandler(Agent::Stub &client, const Proces
   string_stream
       << std::ifstream(armonik::api::common::utils::pathJoin(data_folder_, payload_id), std::fstream::binary).rdbuf();
   payload_ = string_stream.str();
-  // string_stream.clear();
   string_stream.str("");
   config_ = request_.configuration();
   expected_result_.assign(request_.expected_output_keys().begin(), request_.expected_output_keys().end());
@@ -52,7 +51,6 @@ armonik::api::worker::TaskHandler::TaskHandler(Agent::Stub &client, const Proces
     string_stream
         << std::ifstream(armonik::api::common::utils::pathJoin(data_folder_, dd), std::fstream::binary).rdbuf();
     data_dependencies_[dd] = string_stream.str();
-    // string_stream.clear();
     string_stream.str("");
   }
 }


### PR DESCRIPTION
# Motivation

When calling getDataDependencies(), we were copying the payload ID and also the payload itself into the dependency list. This created a recursive duplication because the buffer was not properly reset: the .clear() call did not clear the contents, only the flags.


# Description

Replaced the call to .clear() with .str("") to explicitly reset the buffer.

# Testing

The test is conclusive, no more recursive copying in the dependencies.

# Impact

Therefore, using the getDataDependencies() function in the C++ API is no longer a problem.
