### PR TITLE
build(java): move logback to test scope

### DIFF
--- a/packages/java/armonik-client-api/pom.xml
+++ b/packages/java/armonik-client-api/pom.xml
@@ -49,7 +49,12 @@
       <version>1.78.1</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/packages/java/armonik-client-api/src/test/resources/logback-test.xml
+++ b/packages/java/armonik-client-api/src/test/resources/logback-test.xml
@@ -1,4 +1,4 @@
-<configuration debug="true">
+<configuration>
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>

--- a/packages/java/pom.xml
+++ b/packages/java/pom.xml
@@ -105,11 +105,6 @@
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <version>${logback.version}</version>
-    </dependency>
 
     <!-- Test dependencies -->
     <dependency>
@@ -206,7 +201,6 @@
             </execution>
           </executions>
           <configuration>
-            <stylesheet>java</stylesheet>
             <doclint>none</doclint>
           </configuration>
         </plugin>


### PR DESCRIPTION
# Motivation:
Including Logback as a main dependency and shipping a logback.xml in the library artifact forces consumers to use Logback and may override their own logging setup.
By limiting Logback to test scope and restricting configuration to tests only, the library:

- avoids imposing a logging backend on consumers
- prevents accidental conflicts with application-level logging
- still keeps predictable logging behavior during tests

# Changes:
- set logback-classic to test scope
- rename logback.xml → logback-test.xml
- move config to src/test/resources