### PR TITLE
feat: Draft: Session status notification stream

### DIFF
--- a/Protos/V1/events_common.proto
+++ b/Protos/V1/events_common.proto
@@ -6,6 +6,7 @@ import "result_status.proto";
 import "results_filters.proto";
 import "task_status.proto";
 import "tasks_filters.proto";
+import "session_status.proto";
 
 option csharp_namespace = "ArmoniK.Api.gRPC.V1.Events";
 option java_package = "fr.aneo.armonik.api.grpc.v1.events";
@@ -96,4 +97,15 @@ message EventSubscriptionResponse {
     NewTask new_task = 5; /** A new task in ArmoniK. **/
     NewResult new_result = 6; /** A new result in ArmoniK. **/
   }
+}
+
+message SessionEventSubscriptionRequest {
+  repeated session_status.SessionStatus returned_events = 1; // a list of events which will be reported by the stream
+}
+
+message SessionEventSubscriptionResponse {
+  string session_id = 1; // the session-id whose
+  session_status.SessionStatus new_status = 2; // the new status of the session
+  session_status.SessionStatus old_status = 3; // the old status of the session
+  bool created = 4; // true if the session was newly create
 }

--- a/Protos/V1/events_common.proto
+++ b/Protos/V1/events_common.proto
@@ -99,13 +99,16 @@ message EventSubscriptionResponse {
   }
 }
 
-message SessionEventSubscriptionRequest {
-  repeated session_status.SessionStatus returned_events = 1; // a list of events which will be reported by the stream
+message SessionEventSubscriptionRequest { }
+
+enum SessionUpdateType {
+  CREATED = 0;
+  UPDATED = 1;
+  DELETED = 2;
 }
 
 message SessionEventSubscriptionResponse {
   string session_id = 1; // the session-id whose
-  session_status.SessionStatus new_status = 2; // the new status of the session
-  session_status.SessionStatus old_status = 3; // the old status of the session
-  bool created = 4; // true if the session was newly create
+  session_status.SessionStatus status = 2; // the new status of the session
+  SessionUpdateType updateType = 3;
 }

--- a/Protos/V1/events_service.proto
+++ b/Protos/V1/events_service.proto
@@ -27,4 +27,9 @@ service Events {
    * Get events that represents updates of result and tasks data.
    */
   rpc GetEvents(EventSubscriptionRequest) returns (stream EventSubscriptionResponse);
+
+  /**
+   * Get an event stream that represents updates of sessions and session states.
+   */
+  rpc GetSessionEvent(SessionEventSubscriptionRequest) returns (SessionEventSubscriptionResponse);
 }

--- a/Protos/V1/events_service.proto
+++ b/Protos/V1/events_service.proto
@@ -31,5 +31,5 @@ service Events {
   /**
    * Get an event stream that represents updates of sessions and session states.
    */
-  rpc GetSessionEvent(SessionEventSubscriptionRequest) returns (SessionEventSubscriptionResponse);
+  rpc GetSessionEvent(SessionEventSubscriptionRequest) returns (stream SessionEventSubscriptionResponse);
 }

--- a/packages/csharp/ArmoniK.Api.Client.Test/ArmoniK.Api.Client.Tests.csproj
+++ b/packages/csharp/ArmoniK.Api.Client.Test/ArmoniK.Api.Client.Tests.csproj
@@ -9,8 +9,8 @@
     <Optimize>true</Optimize>
     <DebugType>Embedded</DebugType>
     <IncludeSymbols>true</IncludeSymbols>
-    <PackageVersion>3.28.0</PackageVersion>
-    <Version>3.28.0</Version>
+    <PackageVersion>3.29.0-rp</PackageVersion>
+    <Version>3.29.0-rp</Version>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/packages/csharp/ArmoniK.Api.Client.Test/ArmoniK.Api.Client.Tests.csproj
+++ b/packages/csharp/ArmoniK.Api.Client.Test/ArmoniK.Api.Client.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net4.7;net4.8;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Company>ANEO</Company>
     <Copyright>Copyright (C) ANEO, 2021-2024</Copyright>
     <IsPackable>false</IsPackable>

--- a/packages/csharp/ArmoniK.Api.Client/ArmoniK.Api.Client.csproj
+++ b/packages/csharp/ArmoniK.Api.Client/ArmoniK.Api.Client.csproj
@@ -14,8 +14,8 @@
     <Nullable>enable</Nullable>
     <AssemblyOriginatorKeyFile>../kp.snk</AssemblyOriginatorKeyFile>
     <Optimize>true</Optimize>
-    <PackageVersion>3.28.0</PackageVersion>
-    <Version>3.28.0</Version>
+    <PackageVersion>3.29.0-rp</PackageVersion>
+    <Version>3.29.0-rp</Version>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/packages/csharp/ArmoniK.Api.Client/ArmoniK.Api.Client.csproj
+++ b/packages/csharp/ArmoniK.Api.Client/ArmoniK.Api.Client.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Company>ANEO</Company>
     <Copyright>Copyright (C) ANEO, 2021-2022</Copyright>

--- a/packages/csharp/ArmoniK.Api.Common.Channel/ArmoniK.Api.Common.Channel.csproj
+++ b/packages/csharp/ArmoniK.Api.Common.Channel/ArmoniK.Api.Common.Channel.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageVersion>3.28.0</PackageVersion>

--- a/packages/csharp/ArmoniK.Api.Common.Channel/ArmoniK.Api.Common.Channel.csproj
+++ b/packages/csharp/ArmoniK.Api.Common.Channel/ArmoniK.Api.Common.Channel.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <PackageVersion>3.28.0</PackageVersion>
-    <Version>3.28.0</Version>
+    <PackageVersion>3.29.0-rp</PackageVersion>
+    <Version>3.29.0-rp</Version>
     <PackageOutputPath>../publish</PackageOutputPath>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/packages/csharp/ArmoniK.Api.Common/ArmoniK.Api.Common.csproj
+++ b/packages/csharp/ArmoniK.Api.Common/ArmoniK.Api.Common.csproj
@@ -14,8 +14,8 @@
     <Nullable>enable</Nullable>
     <AssemblyOriginatorKeyFile>../kp.snk</AssemblyOriginatorKeyFile>
     <Optimize>true</Optimize>
-    <PackageVersion>3.28.0</PackageVersion>
-    <Version>3.28.0</Version>
+    <PackageVersion>3.29.0-rp</PackageVersion>
+    <Version>3.29.0-rp</Version>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/packages/csharp/ArmoniK.Api.Common/ArmoniK.Api.Common.csproj
+++ b/packages/csharp/ArmoniK.Api.Common/ArmoniK.Api.Common.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Company>ANEO</Company>
     <Copyright>Copyright (C) ANEO, 2021-2022</Copyright>

--- a/packages/csharp/ArmoniK.Api.Common/Utils/Disposables.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Utils/Disposables.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace ArmoniK.Api.Common.Utils;
+
+/// Helper class for disposable's
+public static class Disposables
+{
+  private class NullDisposableInternal : IDisposable
+  {
+    public readonly static NullDisposableInternal Instance = new();
+
+    public void Dispose() { }
+  }
+
+
+  /// Gets a disposable instance which does nothing
+  public static IDisposable NullDisposable => NullDisposableInternal.Instance;
+}

--- a/packages/csharp/ArmoniK.Api.Common/Utils/LoggerExt.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Utils/LoggerExt.cs
@@ -1,5 +1,5 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
 //   W. Kirschenmann   <wkirschenmann@aneo.fr>
 //   J. Gurhem         <jgurhem@aneo.fr>
@@ -58,7 +58,7 @@ public static class LoggerExt
     var dictionary = properties.ToDictionary(p => p.Item1,
                                              p => p.Item2);
     dictionary[name + ".Scope"] = Guid.NewGuid();
-    return logger.BeginScope(dictionary);
+    return logger.BeginScope(dictionary) ?? Disposables.NullDisposable;
   }
 
   /// <summary>
@@ -75,7 +75,7 @@ public static class LoggerExt
   {
     var dictionary = properties.ToDictionary(p => p.Item1,
                                              p => p.Item2);
-    return logger.BeginScope(dictionary);
+    return logger.BeginScope(dictionary) ?? Disposables.NullDisposable;
   }
 
 

--- a/packages/csharp/ArmoniK.Api.Core/ArmoniK.Api.Core.csproj
+++ b/packages/csharp/ArmoniK.Api.Core/ArmoniK.Api.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Company>ANEO</Company>
     <Copyright>Copyright (C) ANEO, 2021-2022</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/packages/csharp/ArmoniK.Api.Core/ArmoniK.Api.Core.csproj
+++ b/packages/csharp/ArmoniK.Api.Core/ArmoniK.Api.Core.csproj
@@ -16,8 +16,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <AssemblyOriginatorKeyFile>../kp.snk</AssemblyOriginatorKeyFile>
-    <PackageVersion>3.28.0</PackageVersion>
-    <Version>3.28.0</Version>
+    <PackageVersion>3.29.0-rp</PackageVersion>
+    <Version>3.29.0-rp</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>

--- a/packages/csharp/ArmoniK.Api.Mock/ArmoniK.Api.Mock.csproj
+++ b/packages/csharp/ArmoniK.Api.Mock/ArmoniK.Api.Mock.csproj
@@ -14,8 +14,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <AssemblyOriginatorKeyFile>../kp.snk</AssemblyOriginatorKeyFile>
-    <PackageVersion>3.28.0</PackageVersion>
-    <Version>3.28.0</Version>
+    <PackageVersion>3.29.0-rp</PackageVersion>
+    <Version>3.29.0-rp</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/packages/csharp/ArmoniK.Api.Tests/ArmoniK.Api.Worker.Tests.csproj
+++ b/packages/csharp/ArmoniK.Api.Tests/ArmoniK.Api.Worker.Tests.csproj
@@ -9,8 +9,8 @@
     <Optimize>true</Optimize>
     <DebugType>Embedded</DebugType>
     <IncludeSymbols>true</IncludeSymbols>
-    <PackageVersion>3.28.0</PackageVersion>
-    <Version>3.28.0</Version>
+    <PackageVersion>3.29.0-rp</PackageVersion>
+    <Version>3.29.0-rp</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/packages/csharp/ArmoniK.Api.Tests/ArmoniK.Api.Worker.Tests.csproj
+++ b/packages/csharp/ArmoniK.Api.Tests/ArmoniK.Api.Worker.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Company>ANEO</Company>
     <Copyright>Copyright (C) ANEO, 2021-2022</Copyright>
     <IsPackable>false</IsPackable>

--- a/packages/csharp/ArmoniK.Api.Worker/ArmoniK.Api.Worker.csproj
+++ b/packages/csharp/ArmoniK.Api.Worker/ArmoniK.Api.Worker.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Company>ANEO</Company>
     <Copyright>Copyright (C) ANEO, 2021-2022</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/packages/csharp/ArmoniK.Api.Worker/ArmoniK.Api.Worker.csproj
+++ b/packages/csharp/ArmoniK.Api.Worker/ArmoniK.Api.Worker.csproj
@@ -16,8 +16,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <AssemblyOriginatorKeyFile>../kp.snk</AssemblyOriginatorKeyFile>
-    <PackageVersion>3.28.0</PackageVersion>
-    <Version>3.28.0</Version>
+    <PackageVersion>3.29.0-rp</PackageVersion>
+    <Version>3.29.0-rp</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+set -e
+
+APP=$0
+
+new_version=$1
+
+if [ -z "$new_version" ]
+then
+  echo "usage: $APP <new version>"
+  echo "example: $APP \"3.21.0\""
+  exit 1
+fi
+
+
+__update-csharp() {
+  projects=$(find ./ -name "*.csproj")
+  for prj in $projects
+  do
+    echo "updating $prj..."
+    sed -i "s/<PackageVersion>.*</<PackageVersion>$new_version</" $prj
+    sed -i "s/<Version>.*</<Version>$new_version</" $prj
+  done
+}
+
+
+__update-csharp


### PR DESCRIPTION
// DRAFT: also did some side modifications which i can undo before merge

# Motivation

Needed a better way to observe changes to sessions being opened/modified/deleted, other than polling the` ListSessions()` endpoint on the` SessionsService`.

# Description

Adds another endpoint on the `EventsService` to create a notification channel for session updates.

# Impact

Similiar idea to how the `ChangeStream` is implemented for `Results`. Btw, maybe it is time to rethink how these notifications work. Wouldn't MessageQueues be a better alternative for notifying changes/updates to the system overall? Also makes it independent to MongoDB (and for it being mandatory to be a replicaset!)