### PR TITLE
feat: Add configurable gRPC retry policies to worker channels

### DIFF
--- a/packages/csharp/ArmoniK.Api.Common.Channel/Utils/GrpcChannelProvider.cs
+++ b/packages/csharp/ArmoniK.Api.Common.Channel/Utils/GrpcChannelProvider.cs
@@ -1,13 +1,13 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,7 @@ using ArmoniK.Api.Common.Utils;
 
 using Grpc.Core;
 using Grpc.Net.Client;
+using Grpc.Net.Client.Configuration;
 
 using JetBrains.Annotations;
 
@@ -70,11 +71,63 @@ public sealed class GrpcChannelProvider : IAsyncDisposable
     }
   }
 
-  private static ChannelBase BuildWebGrpcChannel(string  address,
-                                                 ILogger logger)
+  /// <summary>
+  ///   Creates the gRPC <see cref="ServiceConfig" /> with a retry policy for transient failures,
+  ///   using values from the <see cref="GrpcChannel" /> options.
+  ///   Retries on transient/recoverable status codes with exponential backoff.
+  ///   See: https://learn.microsoft.com/en-us/aspnet/core/grpc/retries
+  ///   See: https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+  /// </summary>
+  private ServiceConfig BuildServiceConfig()
+  {
+    if (options_.RetryPolicy.MaxAttempts <= 1)
+    {
+      logger_.LogDebug("gRPC native retry policy is disabled (RetryMaxAttempts={maxAttempts})",
+                       options_.RetryPolicy.MaxAttempts);
+      return new ServiceConfig();
+    }
+
+    logger_.LogInformation("gRPC native retry policy enabled: MaxAttempts={maxAttempts}, InitialBackoff={initialBackoff}, MaxBackoff={maxBackoff}, Multiplier={multiplier}",
+                           options_.RetryPolicy.MaxAttempts,
+                           options_.RetryPolicy.InitialBackoff,
+                           options_.RetryPolicy.MaxBackoff,
+                           options_.RetryPolicy.BackoffMultiplier);
+
+    return new ServiceConfig
+           {
+             MethodConfigs =
+             {
+               new MethodConfig
+               {
+                 Names       = { MethodName.Default },
+                 RetryPolicy = new RetryPolicy
+                               {
+                                 MaxAttempts       = options_.RetryPolicy.MaxAttempts,
+                                 InitialBackoff    = options_.RetryPolicy.InitialBackoff,
+                                 MaxBackoff        = options_.RetryPolicy.MaxBackoff,
+                                 BackoffMultiplier = options_.RetryPolicy.BackoffMultiplier,
+                                 RetryableStatusCodes =
+                                 {
+                                   StatusCode.Unavailable,
+                                   StatusCode.Internal,
+                                   StatusCode.Aborted,
+                                   StatusCode.ResourceExhausted,
+                                 },
+                               },
+               },
+             },
+           };
+  }
+
+  private ChannelBase BuildWebGrpcChannel(string  address,
+                                                ILogger logger)
   {
     using var _ = logger.LogFunction();
-    return Grpc.Net.Client.GrpcChannel.ForAddress(address);
+    return Grpc.Net.Client.GrpcChannel.ForAddress(address,
+                                                  new GrpcChannelOptions
+                                                  {
+                                                    ServiceConfig = BuildServiceConfig(),
+                                                  });
   }
 
   private ChannelBase BuildUnixSocketGrpcChannel(string  address,
@@ -117,7 +170,8 @@ public sealed class GrpcChannelProvider : IAsyncDisposable
     return Grpc.Net.Client.GrpcChannel.ForAddress("http://localhost",
                                                   new GrpcChannelOptions
                                                   {
-                                                    HttpHandler = socketsHttpHandler,
+                                                    HttpHandler   = socketsHttpHandler,
+                                                    ServiceConfig = BuildServiceConfig(),
                                                   });
   }
 

--- a/packages/csharp/ArmoniK.Api.Common/Options/GrpcChannel.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Options/GrpcChannel.cs
@@ -1,13 +1,13 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -48,4 +48,20 @@ public class GrpcChannel
   ///   Keep-alive timeout
   /// </summary>
   public TimeSpan KeepAliveTimeOut { get; set; }
+
+  /// <summary>
+  ///   Retry policy options for this gRPC channel.
+  /// </summary>
+  public GrpcChannelRetryPolicy RetryPolicy { get; set; } = new();
+
+  /// <summary>
+  ///   Returns a new <see cref="GrpcChannel" /> with the given <see cref="GrpcChannelRetryPolicy" /> applied.
+  /// </summary>
+  /// <param name="retryPolicy">The retry policy to apply.</param>
+  /// <returns>A new <see cref="GrpcChannel" /> instance with the updated retry policy.</returns>
+  public GrpcChannel WithRetryPolicy(GrpcChannelRetryPolicy retryPolicy)
+  {
+    RetryPolicy = retryPolicy;
+    return this;
+  }
 }

--- a/packages/csharp/ArmoniK.Api.Common/Options/GrpcChannelExt.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Options/GrpcChannelExt.cs
@@ -1,0 +1,53 @@
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using ArmoniK.Api.Common.Utils;
+
+using JetBrains.Annotations;
+
+using Microsoft.Extensions.Configuration;
+
+namespace ArmoniK.Api.Common.Options;
+
+/// <summary>
+///   Extension methods for <see cref="GrpcChannel" />.
+/// </summary>
+[PublicAPI]
+public static class GrpcChannelExt
+{
+  /// <summary>
+  ///   Returns a copy of the <see cref="GrpcChannel" /> with its <see cref="GrpcChannel.RetryPolicy" />
+  ///   populated from the given <see cref="IConfigurationSection" />.
+  ///   Any values not present in the configuration retain the defaults defined on <see cref="GrpcChannelRetryPolicy" />.
+  /// </summary>
+  /// <param name="channel">The source channel options.</param>
+  /// <param name="configuration">The configuration section that contains the channel settings.</param>
+  /// <returns>A new <see cref="GrpcChannel" /> instance with the retry policy bound from configuration.</returns>
+  public static GrpcChannel BuildWithRetryPolicy(this GrpcChannel      channel,
+                                      IConfigurationSection configuration)
+  {
+    var retrySection = configuration.GetSection("RetryPolicy");
+    var defaults     = new GrpcChannelRetryPolicy();
+
+    var retryPolicy = new GrpcChannelRetryPolicy
+                      {
+                        MaxAttempts       = retrySection.GetValue("MaxAttempts",       defaults.MaxAttempts),
+                        InitialBackoff    = retrySection.GetTimeSpanOrDefault("InitialBackoff",    defaults.InitialBackoff),
+                        MaxBackoff        = retrySection.GetTimeSpanOrDefault("MaxBackoff",        defaults.MaxBackoff),
+                        BackoffMultiplier = retrySection.GetValue("BackoffMultiplier", defaults.BackoffMultiplier),
+                      };
+
+    return channel.WithRetryPolicy(retryPolicy);
+  }
+}

--- a/packages/csharp/ArmoniK.Api.Common/Options/GrpcChannelRetryPolicy.cs
+++ b/packages/csharp/ArmoniK.Api.Common/Options/GrpcChannelRetryPolicy.cs
@@ -1,0 +1,95 @@
+// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+using JetBrains.Annotations;
+
+namespace ArmoniK.Api.Common.Options;
+
+/// <summary>
+///   Retry policy options for a gRPC channel.
+///   Use the fluent <c>With*</c> methods to override individual values at runtime.
+/// </summary>
+[PublicAPI]
+public sealed class GrpcChannelRetryPolicy
+{
+  /// <summary>
+  ///   Maximum number of gRPC retry attempts for transient failures.
+  ///   Set to 0 or 1 to disable native gRPC retries.
+  ///   See: https://learn.microsoft.com/en-us/aspnet/core/grpc/retries
+  /// </summary>
+  public int MaxAttempts { get; set; } = 5;
+
+  /// <summary>
+  ///   Initial backoff delay before the first retry attempt.
+  /// </summary>
+  public TimeSpan InitialBackoff { get; set; } = TimeSpan.FromSeconds(1);
+
+  /// <summary>
+  ///   Maximum backoff delay between retry attempts.
+  /// </summary>
+  public TimeSpan MaxBackoff { get; set; } = TimeSpan.FromSeconds(10);
+
+  /// <summary>
+  ///   Multiplier applied to the backoff after each retry attempt.
+  /// </summary>
+  public double BackoffMultiplier { get; set; } = 2.0;
+
+  /// <summary>
+  ///   Sets the maximum number of gRPC retry attempts.
+  /// </summary>
+  /// <param name="value">Maximum retry attempts.</param>
+  /// <returns>The same instance.</returns>
+  public GrpcChannelRetryPolicy WithMaxAttempts(int value)
+  {
+    MaxAttempts = value;
+    return this;
+  }
+
+  /// <summary>
+  ///   Sets the initial backoff delay before the first retry attempt.
+  /// </summary>
+  /// <param name="value">Initial backoff duration.</param>
+  /// <returns>The same instance.</returns>
+  public GrpcChannelRetryPolicy WithInitialBackoff(TimeSpan value)
+  {
+    InitialBackoff = value;
+    return this;
+  }
+
+  /// <summary>
+  ///   Sets the maximum backoff delay between retry attempts.
+  /// </summary>
+  /// <param name="value">Maximum backoff duration.</param>
+  /// <returns>The same instance.</returns>
+  public GrpcChannelRetryPolicy WithMaxBackoff(TimeSpan value)
+  {
+    MaxBackoff = value;
+    return this;
+  }
+
+  /// <summary>
+  ///   Sets the multiplier applied to the backoff after each retry attempt.
+  /// </summary>
+  /// <param name="value">Backoff multiplier.</param>
+  /// <returns>The same instance.</returns>
+  public GrpcChannelRetryPolicy WithBackoffMultiplier(double value)
+  {
+    BackoffMultiplier = value;
+    return this;
+  }
+}

--- a/packages/csharp/ArmoniK.Api.Tests/WorkerServerTest.cs
+++ b/packages/csharp/ArmoniK.Api.Tests/WorkerServerTest.cs
@@ -1,13 +1,13 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -156,6 +156,118 @@ public class WorkerServerTest
     Environment.SetEnvironmentVariable($"{nameof(ComputePlane)}__{nameof(ComputePlane.AgentChannel)}__{nameof(ComputePlane.AgentChannel.Address)}",
                                        "/tmp/agent.sock");
     var app = WorkerServer.Create<TestService>();
+    return Task.CompletedTask;
+  }
+
+  [Test]
+  public Task BuildServerRetryDefaultsShouldApplyWhenNotConfigured()
+  {
+    var collection = new List<KeyValuePair<string, string>>
+                     {
+                       new($"{nameof(ComputePlane)}:{nameof(ComputePlane.WorkerChannel)}:{nameof(ComputePlane.WorkerChannel.Address)}",
+                           "/tmp/worker.sock"),
+                       new($"{nameof(ComputePlane)}:{nameof(ComputePlane.WorkerChannel)}:{nameof(ComputePlane.WorkerChannel.SocketType)}",
+                           GrpcSocketType.UnixDomainSocket.ToString()),
+                       new($"{nameof(ComputePlane)}:{nameof(ComputePlane.AgentChannel)}:{nameof(ComputePlane.AgentChannel.Address)}",
+                           "/tmp/agent.sock"),
+                       new($"{nameof(ComputePlane)}:{nameof(ComputePlane.AgentChannel)}:{nameof(ComputePlane.AgentChannel.SocketType)}",
+                           GrpcSocketType.UnixDomainSocket.ToString()),
+                     };
+
+    var app = WorkerServer.Create<TestService>((_,
+                                                configuration) =>
+                                               {
+                                                 foreach (var pair in collection)
+                                                 {
+                                                   configuration[pair.Key] = pair.Value;
+                                                 }
+                                               });
+
+    var computePlane = app.Services.GetRequiredService<ComputePlane>();
+
+    // Verify default retry options are applied when not explicitly configured
+    Assert.AreEqual(5,
+                    computePlane.WorkerChannel.RetryPolicy.MaxAttempts);
+    Assert.AreEqual(TimeSpan.FromSeconds(1),
+                    computePlane.WorkerChannel.RetryPolicy.InitialBackoff);
+    Assert.AreEqual(TimeSpan.FromSeconds(10),
+                    computePlane.WorkerChannel.RetryPolicy.MaxBackoff);
+    Assert.AreEqual(2.0,
+                    computePlane.WorkerChannel.RetryPolicy.BackoffMultiplier);
+
+    Assert.AreEqual(5,
+                    computePlane.AgentChannel.RetryPolicy.MaxAttempts);
+    Assert.AreEqual(TimeSpan.FromSeconds(1),
+                    computePlane.AgentChannel.RetryPolicy.InitialBackoff);
+    Assert.AreEqual(TimeSpan.FromSeconds(10),
+                    computePlane.AgentChannel.RetryPolicy.MaxBackoff);
+    Assert.AreEqual(2.0,
+                    computePlane.AgentChannel.RetryPolicy.BackoffMultiplier);
+
+    return Task.CompletedTask;
+  }
+
+  [Test]
+  public Task BuildServerRetryPolicyBuilderOverridesChannelOptions()
+  {
+    var collection = new List<KeyValuePair<string, string>>
+                     {
+                       new($"{nameof(ComputePlane)}:{nameof(ComputePlane.WorkerChannel)}:{nameof(ComputePlane.WorkerChannel.Address)}",
+                           "/tmp/worker.sock"),
+                       new($"{nameof(ComputePlane)}:{nameof(ComputePlane.WorkerChannel)}:{nameof(ComputePlane.WorkerChannel.SocketType)}",
+                           GrpcSocketType.UnixDomainSocket.ToString()),
+                       new($"{nameof(ComputePlane)}:{nameof(ComputePlane.AgentChannel)}:{nameof(ComputePlane.AgentChannel.Address)}",
+                           "/tmp/agent.sock"),
+                       new($"{nameof(ComputePlane)}:{nameof(ComputePlane.AgentChannel)}:{nameof(ComputePlane.AgentChannel.SocketType)}",
+                           GrpcSocketType.UnixDomainSocket.ToString()),
+                     };
+
+    var workerRetryPolicy = new GrpcChannelRetryPolicy().WithMaxAttempts(7)
+                                                        .WithInitialBackoff(TimeSpan.FromMilliseconds(500))
+                                                        .WithMaxBackoff(TimeSpan.FromSeconds(20))
+                                                        .WithBackoffMultiplier(3.0);
+
+    var agentRetryPolicy = new GrpcChannelRetryPolicy().WithMaxAttempts(2)
+                                                       .WithInitialBackoff(TimeSpan.FromMilliseconds(200));
+
+    collection.Add(new($"{nameof(ComputePlane)}:{nameof(ComputePlane.WorkerChannel)}:{nameof(GrpcChannel.RetryPolicy)}:{nameof(GrpcChannelRetryPolicy.MaxAttempts)}",
+                       workerRetryPolicy.MaxAttempts.ToString()));
+    collection.Add(new($"{nameof(ComputePlane)}:{nameof(ComputePlane.WorkerChannel)}:{nameof(GrpcChannel.RetryPolicy)}:{nameof(GrpcChannelRetryPolicy.InitialBackoff)}",
+                       workerRetryPolicy.InitialBackoff.ToString()));
+    collection.Add(new($"{nameof(ComputePlane)}:{nameof(ComputePlane.WorkerChannel)}:{nameof(GrpcChannel.RetryPolicy)}:{nameof(GrpcChannelRetryPolicy.MaxBackoff)}",
+                       workerRetryPolicy.MaxBackoff.ToString()));
+    collection.Add(new($"{nameof(ComputePlane)}:{nameof(ComputePlane.WorkerChannel)}:{nameof(GrpcChannel.RetryPolicy)}:{nameof(GrpcChannelRetryPolicy.BackoffMultiplier)}",
+                       workerRetryPolicy.BackoffMultiplier.ToString()));
+    collection.Add(new($"{nameof(ComputePlane)}:{nameof(ComputePlane.AgentChannel)}:{nameof(GrpcChannel.RetryPolicy)}:{nameof(GrpcChannelRetryPolicy.MaxAttempts)}",
+                       agentRetryPolicy.MaxAttempts.ToString()));
+    collection.Add(new($"{nameof(ComputePlane)}:{nameof(ComputePlane.AgentChannel)}:{nameof(GrpcChannel.RetryPolicy)}:{nameof(GrpcChannelRetryPolicy.InitialBackoff)}",
+                       agentRetryPolicy.InitialBackoff.ToString()));
+
+    var app = WorkerServer.Create<TestService>((_,
+                                                configuration) =>
+                                               {
+                                                 foreach (var pair in collection)
+                                                 {
+                                                   configuration[pair.Key] = pair.Value;
+                                                 }
+                                               });
+
+    var computePlane = app.Services.GetRequiredService<ComputePlane>();
+
+    Assert.AreEqual(7,
+                    computePlane.WorkerChannel.RetryPolicy.MaxAttempts);
+    Assert.AreEqual(TimeSpan.FromMilliseconds(500),
+                    computePlane.WorkerChannel.RetryPolicy.InitialBackoff);
+    Assert.AreEqual(TimeSpan.FromSeconds(20),
+                    computePlane.WorkerChannel.RetryPolicy.MaxBackoff);
+    Assert.AreEqual(3.0,
+                    computePlane.WorkerChannel.RetryPolicy.BackoffMultiplier);
+
+    Assert.AreEqual(2,
+                    computePlane.AgentChannel.RetryPolicy.MaxAttempts);
+    Assert.AreEqual(TimeSpan.FromMilliseconds(200),
+                    computePlane.AgentChannel.RetryPolicy.InitialBackoff);
+
     return Task.CompletedTask;
   }
 

--- a/packages/csharp/ArmoniK.Api.Worker/Utils/WorkerServer.cs
+++ b/packages/csharp/ArmoniK.Api.Worker/Utils/WorkerServer.cs
@@ -1,13 +1,13 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -110,28 +110,28 @@ public static class WorkerServer
                                       {
                                         WorkerChannel = new GrpcChannel
                                                         {
-                                                          Address = workerChannelOptions.GetRequiredValue<string>("Address"),
-                                                          SocketType = workerChannelOptions.GetValue("SocketType",
-                                                                                                     GrpcSocketType.UnixDomainSocket),
-                                                          KeepAlivePingTimeOut = workerChannelOptions.GetTimeSpanOrDefault("KeepAlivePingTimeOut",
-                                                                                                                           TimeSpan.FromSeconds(20)),
-                                                          KeepAliveTimeOut = workerChannelOptions.GetTimeSpanOrDefault("KeepAliveTimeOut",
-                                                                                                                       TimeSpan.FromSeconds(130)),
-                                                        },
-                                        AgentChannel = new GrpcChannel
-                                                       {
-                                                         Address = agentChannelOptions.GetRequiredValue<string>("Address"),
-                                                         SocketType = agentChannelOptions.GetValue("SocketType",
-                                                                                                   GrpcSocketType.UnixDomainSocket),
-                                                         KeepAlivePingTimeOut = agentChannelOptions.GetTimeSpanOrDefault("KeepAlivePingTimeOut",
-                                                                                                                         TimeSpan.FromSeconds(20)),
-                                                         KeepAliveTimeOut = agentChannelOptions.GetTimeSpanOrDefault("KeepAliveTimeOut",
-                                                                                                                     TimeSpan.FromSeconds(130)),
-                                                       },
-                                        MessageBatchSize = rawComputePlaneOptions.GetValue("MessageBatchSize",
-                                                                                           1),
-                                        AbortAfter = rawComputePlaneOptions.GetValue("AbortAfter",
-                                                                                     TimeSpan.Zero),
+                                                            Address = workerChannelOptions.GetRequiredValue<string>("Address"),
+                                                                            SocketType = workerChannelOptions.GetValue("SocketType",
+                                                                                                                       GrpcSocketType.UnixDomainSocket),
+                                                                            KeepAlivePingTimeOut = workerChannelOptions.GetTimeSpanOrDefault("KeepAlivePingTimeOut",
+                                                                                                                                             TimeSpan.FromSeconds(20)),
+                                                                            KeepAliveTimeOut = workerChannelOptions.GetTimeSpanOrDefault("KeepAliveTimeOut",
+                                                                                                                                         TimeSpan.FromSeconds(130)),
+                                                                          }.BuildWithRetryPolicy(workerChannelOptions),
+                                                          AgentChannel = new GrpcChannel
+                                                                         {
+                                                                           Address = agentChannelOptions.GetRequiredValue<string>("Address"),
+                                                                           SocketType = agentChannelOptions.GetValue("SocketType",
+                                                                                                                     GrpcSocketType.UnixDomainSocket),
+                                                                           KeepAlivePingTimeOut = agentChannelOptions.GetTimeSpanOrDefault("KeepAlivePingTimeOut",
+                                                                                                                                           TimeSpan.FromSeconds(20)),
+                                                                           KeepAliveTimeOut = agentChannelOptions.GetTimeSpanOrDefault("KeepAliveTimeOut",
+                                                                                                                                       TimeSpan.FromSeconds(130)),
+                                                                         }.BuildWithRetryPolicy(agentChannelOptions),
+                                                          MessageBatchSize = rawComputePlaneOptions.GetValue("MessageBatchSize",
+                                                                                                             1),
+                                                          AbortAfter = rawComputePlaneOptions.GetValue("AbortAfter",
+                                                                                                       TimeSpan.Zero),
                                       };
 
       builder.WebHost.ConfigureKestrel(options =>


### PR DESCRIPTION
# Motivation

There is no retry policy on grpc connection in place, this causes problems. Other changes will be made on ArmoniK Core to better manage the connection between agent - worker. 

# Description

Add configurable gRPC retry policies to worker channels.

# Testing

Unit tests and test

# Impact

Makes worker - agent connection more resilient 

# Additional Information

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
