### PR TITLE
fix: TCP no delay

### DIFF
--- a/packages/rust/armonik/Cargo.toml
+++ b/packages/rust/armonik/Cargo.toml
@@ -37,6 +37,7 @@ hyper = { version = "1.7", features = [
   "http1",
   "http2",
 ], optional = true }
+hyper-util = { version = "*", features = ["client", "http1"] }
 hyper-rustls = { version = "0.27", features = [
   "http1",
   "http2",
@@ -59,7 +60,6 @@ humantime = "2.3.0"
 [dev-dependencies]
 eyre = "0.6"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
-hyper-util = { version = "0.1", features = ["client", "http1"] }
 http-body-util = "0.1"
 serde_json = "1.0"
 serial_test = "3.2"

--- a/packages/rust/armonik/src/client/config.rs
+++ b/packages/rust/armonik/src/client/config.rs
@@ -30,8 +30,8 @@ pub struct ClientConfig {
     pub tcp_keepalive_interval: Option<Duration>,
     /// Number of TCP keepalive retries, defaults to OS default
     pub tcp_keepalive_retries: Option<u32>,
-    /// Disable Nagle's algorithm (TCP_NODELAY), defaults to false
-    pub tcp_nodelay: bool,
+    /// Enable Nagle's algorithm (disable TCP_NODELAY), defaults to false
+    pub tcp_nagle_algorithm: bool,
     /// HTTP/2 PING frame interval, defaults to no keepalive
     pub http2_keep_alive_interval: Option<Duration>,
     /// HTTP/2 PING timeout, defaults to no timeout
@@ -61,7 +61,7 @@ impl Clone for ClientConfig {
             tcp_keepalive: self.tcp_keepalive,
             tcp_keepalive_interval: self.tcp_keepalive_interval,
             tcp_keepalive_retries: self.tcp_keepalive_retries,
-            tcp_nodelay: self.tcp_nodelay,
+            tcp_nagle_algorithm: self.tcp_nagle_algorithm,
             http2_keep_alive_interval: self.http2_keep_alive_interval,
             http2_keep_alive_timeout: self.http2_keep_alive_timeout,
             http2_keep_alive_while_idle: self.http2_keep_alive_while_idle,
@@ -111,9 +111,9 @@ pub struct ClientConfigArgs {
     /// Number of TCP keepalive retries, defaults to OS default
     #[cfg_attr(feature = "serde", serde(default))]
     pub tcp_keepalive_retries: String,
-    /// Disable Nagle's algorithm (TCP_NODELAY), defaults to false
+    /// Enable Nagle's algorithm (disable TCP_NODELAY), defaults to false
     #[cfg_attr(feature = "serde", serde(default))]
-    pub tcp_nodelay: bool,
+    pub tcp_nagle_algorithm: bool,
     /// HTTP/2 PING frame interval (e.g. `20s`), defaults to no keepalive
     #[cfg_attr(feature = "serde", serde(default))]
     pub http2_keep_alive_interval: String,
@@ -149,7 +149,7 @@ impl ClientConfigArgs {
             tcp_keepalive: read_env("GrpcClient__TcpKeepalive").context(ctx)?,
             tcp_keepalive_interval: read_env("GrpcClient__TcpKeepaliveInterval").context(ctx)?,
             tcp_keepalive_retries: read_env("GrpcClient__TcpKeepaliveRetries").context(ctx)?,
-            tcp_nodelay: read_env_bool("GrpcClient__TcpNodelay").context(ctx)?,
+            tcp_nagle_algorithm: read_env_bool("GrpcClient__TcpNagleAlgorithm").context(ctx)?,
             http2_keep_alive_interval: read_env("GrpcClient__Http2KeepAliveInterval")
                 .context(ctx)?,
             http2_keep_alive_timeout: read_env("GrpcClient__Http2KeepAliveTimeout").context(ctx)?,
@@ -181,7 +181,7 @@ impl ClientConfig {
             args.tcp_keepalive,
             args.tcp_keepalive_interval,
             args.tcp_keepalive_retries,
-            args.tcp_nodelay,
+            args.tcp_nagle_algorithm,
             args.http2_keep_alive_interval,
             args.http2_keep_alive_timeout,
             args.http2_keep_alive_while_idle,
@@ -202,7 +202,7 @@ impl ClientConfig {
             tcp_keepalive,
             tcp_keepalive_interval,
             tcp_keepalive_retries,
-            tcp_nodelay,
+            tcp_nagle_algorithm,
             http2_keep_alive_interval,
             http2_keep_alive_timeout,
             http2_keep_alive_while_idle,
@@ -415,7 +415,7 @@ impl ClientConfig {
             tcp_keepalive,
             tcp_keepalive_interval,
             tcp_keepalive_retries,
-            tcp_nodelay,
+            tcp_nagle_algorithm,
             http2_keep_alive_interval,
             http2_keep_alive_timeout,
             http2_keep_alive_while_idle,

--- a/packages/rust/armonik/src/client/mod.rs
+++ b/packages/rust/armonik/src/client/mod.rs
@@ -3,7 +3,8 @@
 use std::sync::Arc;
 
 use hyper::Uri;
-use hyper_rustls::{ConfigBuilderExt, FixedServerNameResolver};
+use hyper_rustls::{ConfigBuilderExt, FixedServerNameResolver, HttpsConnector};
+use hyper_util::client::legacy::connect::HttpConnector;
 use rustls::pki_types::ServerName;
 use snafu::{ResultExt, Snafu};
 
@@ -80,34 +81,19 @@ impl Client<tonic::transport::Channel> {
             async move {
                 let endpoint = config.endpoint.clone();
                 let override_target = config.override_target.clone();
-                let connect_timeout = config.connect_timeout;
-                let tcp_keepalive = config.tcp_keepalive;
-                let tcp_keepalive_interval = config.tcp_keepalive_interval;
-                let tcp_keepalive_retries = config.tcp_keepalive_retries;
-                let tcp_nodelay = config.tcp_nodelay;
                 let http2_keep_alive_interval = config.http2_keep_alive_interval;
                 let http2_keep_alive_timeout = config.http2_keep_alive_timeout;
                 let http2_keep_alive_while_idle = config.http2_keep_alive_while_idle;
                 let http2_max_header_list_size = config.http2_max_header_list_size;
                 let user_agent = config.user_agent.clone();
 
-                let https = Self::https_connector_builder(config).await?.build();
+                let https = Self::https_connector(config).await?;
 
                 let mut transport_endpoint = tonic::transport::Endpoint::from(endpoint.clone());
                 if let Some(target) = override_target {
                     transport_endpoint = transport_endpoint.origin(target);
                 }
 
-                if let Some(timeout) = connect_timeout {
-                    transport_endpoint = transport_endpoint.connect_timeout(timeout);
-                }
-
-                transport_endpoint = transport_endpoint.tcp_keepalive(tcp_keepalive);
-                transport_endpoint =
-                    transport_endpoint.tcp_keepalive_interval(tcp_keepalive_interval);
-                transport_endpoint =
-                    transport_endpoint.tcp_keepalive_retries(tcp_keepalive_retries);
-                transport_endpoint = transport_endpoint.tcp_nodelay(tcp_nodelay);
                 if let Some(interval) = http2_keep_alive_interval {
                     transport_endpoint = transport_endpoint.http2_keep_alive_interval(interval);
                 }
@@ -138,12 +124,9 @@ impl Client<tonic::transport::Channel> {
         .await
     }
 
-    async fn https_connector_builder(
+    async fn https_connector(
         config: ClientConfig,
-    ) -> Result<
-        hyper_rustls::HttpsConnectorBuilder<hyper_rustls::builderstates::WantsProtocols3>,
-        ConnectionError,
-    > {
+    ) -> Result<HttpsConnector<HttpConnector>, ConnectionError> {
         let endpoint = config.endpoint;
 
         // Get the default crypto provider or fallback to the ring crypto provider
@@ -203,7 +186,17 @@ impl Client<tonic::transport::Channel> {
             https = https.with_server_name_resolver(FixedServerNameResolver::new(server_name));
         };
 
-        Ok(https.enable_http1().enable_http2())
+        let mut http = HttpConnector::new();
+        http.enforce_http(false); // required for hyper-rustls to switch schemes
+        http.set_nodelay(config.tcp_nodelay);
+        http.set_keepalive(config.tcp_keepalive);
+        http.set_keepalive_interval(config.tcp_keepalive_interval);
+        http.set_keepalive_retries(config.tcp_keepalive_retries);
+        if let Some(timeout) = config.connect_timeout {
+            http.set_connect_timeout(Some(timeout));
+        }
+
+        Ok(https.enable_http1().enable_http2().wrap_connector(http))
     }
 
     #[cfg(test)]
@@ -229,10 +222,9 @@ impl Client<tonic::transport::Channel> {
             .body(http_body_util::Empty::<&[u8]>::new())
             .expect("Request");
 
-        let https = Self::https_connector_builder(config)
+        let https = Self::https_connector(config)
             .await
-            .expect("Build connection information")
-            .build();
+            .expect("Build connection information");
 
         let client = hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build(https);
 

--- a/packages/rust/armonik/src/client/mod.rs
+++ b/packages/rust/armonik/src/client/mod.rs
@@ -188,7 +188,7 @@ impl Client<tonic::transport::Channel> {
 
         let mut http = HttpConnector::new();
         http.enforce_http(false); // required for hyper-rustls to switch schemes
-        http.set_nodelay(config.tcp_nodelay);
+        http.set_nodelay(!config.tcp_nagle_algorithm);
         http.set_keepalive(config.tcp_keepalive);
         http.set_keepalive_interval(config.tcp_keepalive_interval);
         http.set_keepalive_retries(config.tcp_keepalive_retries);


### PR DESCRIPTION
# Motivation

#672 added support for extra options within the rust client, but some options like no delay were ignored because the connector is handled on our side.

# Description

For options that were ignored, configure them directly on the HttpConnector when creating the connector.
Renamed the option `tcp_noedlay` to `tcp_nagle_algorithm` to keep a positive option (true means enabled), and have a sensible default.

# Testing

It has been tested with load balancer benchmark and Nagle algorithm induced latency has disappeared when using no_delay.

# Impact

Now, Nagle's algorithm is disabled by default, which should improve the latency in the same way as seen on the benchmarks.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
