### PR TITLE
fix: unpin grpcio version in Python API

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
-requires = ["setuptools",
-            "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -10,15 +9,13 @@ readme = "README.md"
 dynamic = ["version"]
 requires-python = ">=3.7"
 keywords = ["cloud", "HTC", "gRPC", "ArmoniK", "Aneo"]
-license = {text = "Apache v2.0 LICENSE"}
-classifiers = [
-    "Programming Language :: Python :: 3",
-]
+license = { text = "Apache v2.0 LICENSE" }
+classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
-    "grpcio==1.62.3",
-    "grpcio-tools==1.62.3",
+    "grpcio>=1.62,<2",
+    "protobuf>=4.21.6,<8",
     "deprecation",
-    "cryptography>=36"
+    "cryptography>=36",
 ]
 [project.urls]
 "Homepage" = "https://github.com/aneoconsulting/ArmoniK.Api"
@@ -26,30 +23,30 @@ dependencies = [
 
 [tool.setuptools]
 include-package-data = true
-dynamic = {version = {attr = "armonik.__version__"}}
+dynamic = { version = { attr = "armonik.__version__" } }
 
 [tool.setuptools.packages.find]
-where= ["src"]
-exclude=['tests']
+where = ["src"]
+exclude = ['tests']
 
 [tool.setuptools.package-data]
 "*" = ["*.pyi"]
 
 [project.optional-dependencies]
 tests = [
-  'coverage',
-  'pytest',
-  'pytest-cov',
-  'pytest-benchmark[histogram]',
-  'requests',
+    'coverage',
+    'pytest',
+    'pytest-cov',
+    'pytest-benchmark[histogram]',
+    'requests',
 ]
 dev = [
+    # Codegen toolchain, only needed to (re)generate src/armonik/protogen.
+    'grpcio-tools==1.62.3',
     'mypy',
     'ruff',
     'types-protobuf',
 ]
 
 [tool.pytest.ini_options]
-addopts = [
-    "--import-mode=importlib",
-]
+addopts = ["--import-mode=importlib"]


### PR DESCRIPTION
# Motivation

Pinned dependency in the `armonik` Python package blocks its usage with newer python versions (1.62 wheels stop at Python 3.12). 

# Description

Unpinned `grpcio` package version, removed dependency on `grpcio-tools` for the armonik package and replaced it with the package it pulled that we actually use (protobuf). 

# Testing

Tests pass.

# Impact

Not applicable.

# Additional Information

Not applicable.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
