### PR TITLE
fix(cpp): link abseil log libs on RHEL regardless of BUILD_SHARED_LIBS

### DIFF
--- a/packages/cpp/ArmoniK.Api.Common/CMakeLists.txt
+++ b/packages/cpp/ArmoniK.Api.Common/CMakeLists.txt
@@ -36,10 +36,11 @@ find_package(gRPC CONFIG REQUIRED)
 find_package(Threads)
 find_package(absl REQUIRED)
 
-# Check for Red Hat-based systems and static linking
+# Check for Red Hat-based systems. protobuf/gRPC on RHEL are built statically (grpc-rpm), and
+# their static archives require abseil's log symbols at link time regardless of whether
+# ArmoniK.Api.Common itself is built shared or static, so this must not be gated on BUILD_SHARED_LIBS.
 file(READ /etc/os-release OS_RELEASE_CONTENT)
-if(OS_RELEASE_CONTENT MATCHES "^(ID=|ID_LIKE=).*rhel|fedora" AND NOT BUILD_SHARED_LIBS)
-    # On Red Hat systems with static linking, we need to find the utf8_range and utf8_validity libraries.
+if(OS_RELEASE_CONTENT MATCHES "^(ID=|ID_LIKE=).*rhel|fedora")
     find_package(utf8_range REQUIRED)
     find_library(UTF8_VALIDITY_LIB
         NAMES utf8_validity
@@ -117,32 +118,27 @@ target_include_directories(${PROJECT_NAME}
 
 # Check if the system is Red Hat for linking Abseil
 if(OS_RELEASE_CONTENT MATCHES "^(ID=|ID_LIKE=).*rhel|fedora")
-    message(STATUS "Detected Red Hat system.")
-    if(NOT BUILD_SHARED_LIBS)
-        message(STATUS "Static linking is enabled. Linking Abseil libraries.")
+    message(STATUS "Detected Red Hat system. Linking Abseil libraries.")
 
-        target_link_libraries(${PROJECT_NAME} PUBLIC
-            utf8_range::utf8_range
-            ${UTF8_VALIDITY_LIB}
+    target_link_libraries(${PROJECT_NAME} PUBLIC
+        utf8_range::utf8_range
+        ${UTF8_VALIDITY_LIB}
 
-            absl::log
-            absl::check
-            absl::log_internal_check_op
-            absl::log_internal_message
-            absl::log_internal_format
-            absl::log_internal_proto
-            absl::log_internal_globals
-            absl::log_internal_conditions
-            absl::raw_logging_internal
+        absl::log
+        absl::check
+        absl::log_internal_check_op
+        absl::log_internal_message
+        absl::log_internal_format
+        absl::log_internal_proto
+        absl::log_internal_globals
+        absl::log_internal_conditions
+        absl::raw_logging_internal
 
-            absl::strings
-            absl::string_view
-            absl::throw_delegate
-            absl::base
-        )
-    else()
-        message(STATUS "Static linking is not enabled. Skipping Abseil libraries.")
-    endif()
+        absl::strings
+        absl::string_view
+        absl::throw_delegate
+        absl::base
+    )
 else()
     message(STATUS "Not a Red Hat system. Skipping Abseil libraries.")
 endif()


### PR DESCRIPTION
# Motivation

On Red Hat-based systems, `protobuf`/`gRPC` are distributed as static archives (`grpc-rpm`). Those archives require Abseil's `log` symbols to be resolved at link time, regardless of whether `ArmoniK.Api.Common` itself is built as a shared or static library. The existing CMake logic only linked the Abseil log libraries when `BUILD_SHARED_LIBS` was `OFF`, so shared builds on RHEL failed to link.

Before PR #678, this never surfaced because the packaging build didn't force BUILD_SHARED_LIBS=ON, so
the (static) release build always took the "link abseil" branch.

# Description

In `packages/cpp/ArmoniK.Api.Common/CMakeLists.txt`, removed the `NOT BUILD_SHARED_LIBS` condition guarding the RHEL/Fedora detection and the Abseil log library linking block. The library lookups (`utf8_range`, `utf8_validity`) and the `target_link_libraries` call for `absl::log`, `absl::check`, and related internal log/strings/base targets now run for any RHEL-like system, independent of the shared/static build mode.

# Testing

Verified the CMake configuration still succeeds for both `BUILD_SHARED_LIBS=ON` and `BUILD_SHARED_LIBS=OFF` on a RHEL-based system, and that linking no longer fails with undefined Abseil log symbols when building `ArmoniK.Api.Common` as a shared library.

# Impact

- Fixes shared-library builds of `ArmoniK.Api.Common` on RHEL/Fedora-based systems.
- No change in behaviour on non-RHEL systems.

# Additional Information

N/A

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.