### PR TITLE
fix(rust): build the crate on a Windows checkout

### DIFF
--- a/packages/rust/armonik/build.rs
+++ b/packages/rust/armonik/build.rs
@@ -1,52 +1,112 @@
+use std::path::{Path, PathBuf};
+
+/// Proto files to compile, relative to the proto root returned by [`proto_root`].
+const PROTO_FILES: &[&str] = &[
+    "agent_common.proto",
+    "agent_service.proto",
+    "applications_common.proto",
+    "applications_fields.proto",
+    "applications_filters.proto",
+    "applications_service.proto",
+    "auth_common.proto",
+    "auth_service.proto",
+    "events_common.proto",
+    "events_service.proto",
+    "filters_common.proto",
+    "objects.proto",
+    "health_checks_common.proto",
+    "health_checks_service.proto",
+    "partitions_common.proto",
+    "partitions_fields.proto",
+    "partitions_filters.proto",
+    "partitions_service.proto",
+    "result_status.proto",
+    "results_common.proto",
+    "results_fields.proto",
+    "results_filters.proto",
+    "results_service.proto",
+    "session_status.proto",
+    "sessions_common.proto",
+    "sessions_fields.proto",
+    "sessions_filters.proto",
+    "sessions_service.proto",
+    "sort_direction.proto",
+    "submitter_common.proto",
+    "submitter_service.proto",
+    "task_status.proto",
+    "tasks_common.proto",
+    "tasks_fields.proto",
+    "tasks_filters.proto",
+    "tasks_service.proto",
+    "versions_common.proto",
+    "versions_service.proto",
+    "worker_common.proto",
+    "worker_service.proto",
+];
+
+/// Locate the directory holding the `V1` proto package.
+///
+/// `protos` is a symlink to the repository-level `Protos` directory, which is what makes
+/// `include = ["protos/**"]` vendor the protos into the published crate. Git only materialises that
+/// symlink when `core.symlinks` is enabled, which is not the default on Windows; there it is
+/// checked out as a regular file containing the link target. Both layouts have to work, so the
+/// candidates are tried in order:
+///
+/// 1. `protos/V1` — a real directory: working symlink, or the published crate.
+/// 2. The path named inside `protos` when it is a regular file — Git on Windows without symlinks.
+/// 3. `../../../Protos` — the in-repository location, as a last resort.
+fn proto_root(manifest_dir: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let link = manifest_dir.join("protos");
+
+    if link.join("V1").is_dir() {
+        return Ok(link);
+    }
+
+    if link.is_file() {
+        let target = std::fs::read_to_string(&link)?;
+        let resolved = manifest_dir.join(target.trim());
+        if resolved.join("V1").is_dir() {
+            return Ok(resolved);
+        }
+    }
+
+    let repository = manifest_dir.join("../../../Protos");
+    if repository.join("V1").is_dir() {
+        return Ok(repository);
+    }
+
+    Err(format!(
+        "Could not locate the `V1` proto directory. Tried `{}` (as a directory and as a symlink \
+         file) and `{}`. On Windows, enable Git symlink support with `git config core.symlinks \
+         true` and re-checkout, or run from a full repository clone.",
+        link.display(),
+        repository.display(),
+    )
+    .into())
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?);
+    let proto_include = proto_root(&manifest_dir)?.join("V1");
+
+    let proto_files = PROTO_FILES
+        .iter()
+        .map(|file| proto_include.join(file))
+        .collect::<Vec<_>>();
+
+    for file in &proto_files {
+        println!("cargo:rerun-if-changed={}", file.display());
+    }
+    println!(
+        "cargo:rerun-if-changed={}",
+        manifest_dir.join("protos").display()
+    );
+    println!("cargo:rerun-if-changed=build.rs");
+
     tonic_prost_build::configure()
         .use_arc_self(true)
         .build_client(cfg!(feature = "_gen-client"))
         .build_server(cfg!(feature = "_gen-server"))
-        .compile_protos(
-            &[
-                "protos/V1/agent_common.proto",
-                "protos/V1/agent_service.proto",
-                "protos/V1/applications_common.proto",
-                "protos/V1/applications_fields.proto",
-                "protos/V1/applications_filters.proto",
-                "protos/V1/applications_service.proto",
-                "protos/V1/auth_common.proto",
-                "protos/V1/auth_service.proto",
-                "protos/V1/events_common.proto",
-                "protos/V1/events_service.proto",
-                "protos/V1/filters_common.proto",
-                "protos/V1/objects.proto",
-                "protos/V1/health_checks_common.proto",
-                "protos/V1/health_checks_service.proto",
-                "protos/V1/partitions_common.proto",
-                "protos/V1/partitions_fields.proto",
-                "protos/V1/partitions_filters.proto",
-                "protos/V1/partitions_service.proto",
-                "protos/V1/result_status.proto",
-                "protos/V1/results_common.proto",
-                "protos/V1/results_fields.proto",
-                "protos/V1/results_filters.proto",
-                "protos/V1/results_service.proto",
-                "protos/V1/session_status.proto",
-                "protos/V1/sessions_common.proto",
-                "protos/V1/sessions_fields.proto",
-                "protos/V1/sessions_filters.proto",
-                "protos/V1/sessions_service.proto",
-                "protos/V1/sort_direction.proto",
-                "protos/V1/submitter_common.proto",
-                "protos/V1/submitter_service.proto",
-                "protos/V1/task_status.proto",
-                "protos/V1/tasks_common.proto",
-                "protos/V1/tasks_fields.proto",
-                "protos/V1/tasks_filters.proto",
-                "protos/V1/tasks_service.proto",
-                "protos/V1/versions_common.proto",
-                "protos/V1/versions_service.proto",
-                "protos/V1/worker_common.proto",
-                "protos/V1/worker_service.proto",
-            ],
-            &["protos/V1"],
-        )?;
+        .compile_protos(&proto_files, &[proto_include])?;
     Ok(())
 }


### PR DESCRIPTION
# Motivation

`packages/rust/armonik` does not build on a Windows checkout.

`packages/rust/armonik/protos` is a symlink to the repository's `Protos` directory, which is what lets
`include = ["protos/**"]` vendor the protos into the published crate. Git only materialises a symlink
when `core.symlinks` is enabled, and that is not the default on Windows: there the entry is checked out
as an ordinary file whose content is the link target, `../../../Protos`.

`build.rs` passed `protos/V1/...` straight to `tonic-prost-build`, so on such a checkout the build fails
— `protos/V1` is not a directory — and the error names a missing `.proto` file rather than the symlink
that was never followed, which sends the reader looking in the wrong place entirely.

# Description

`build.rs` now resolves the proto root by trying the three layouts that actually occur, in order:

1. `protos/V1` as a real directory — a working symlink, and also the published crate, where the protos
   are vendored under that path.
2. The path named *inside* `protos` when it is a regular file — Git on Windows without symlink support.
3. `../../../Protos`, the in-repository location, as a last resort.

The order matters: keeping the direct directory first means a published crate never depends on the
repository layout, and never reads a file it shouldn't. If no candidate matches, the error lists the
paths tried and mentions `git config core.symlinks true`, instead of leaving the reader to work
backwards from a missing file.

Two changes come along with that, both consequences of the file list no longer being literal paths:

- The forty proto file names become a `const` array joined onto the resolved root, rather than forty
  string literals each carrying a `protos/V1/` prefix.
- `cargo:rerun-if-changed` is now emitted per proto file, plus one for `protos` itself and one for
  `build.rs`. There was none before, which means editing a `.proto` did not regenerate anything: when a
  build script declares no dependencies, cargo falls back to watching the whole crate directory — and
  that only covers the protos through the symlink it cannot see. So this also fixes a stale-codegen
  trap, on every platform.

No `.rs` file outside `build.rs` changes, and no generated code changes: the same forty protos are
compiled with the same options.

# Testing

Verified on the configuration that reproduces the bug — a Windows checkout where `protos` is a regular
file containing `../../../Protos`:

```
cargo build --all --locked                                              # ok
cargo fmt --all --check                                                 # clean
cargo clippy --all --no-deps -- -Dwarnings -Dunused-crate-dependencies  # clean
```

The first of those fails on `main` in this configuration, which is the bug.

Candidate 1 (a real `protos/V1` directory) is what CI exercises today; candidate 3 is the fallback and
goes through the same code path.

**CI cannot cover candidate 2, and adding a Windows job would not change that.** Measured on a
`windows-latest` runner rather than assumed: Git for Windows there ships `core.symlinks = true` in its
system config, so `protos` is checked out as a real symlink and `protos/V1` is a directory. A Windows
runner therefore takes candidate 1 and would pass just as well without this change. The layout this fixes
occurs on a developer's machine, not on a runner.

No test is added either: this is build-script path resolution, which has no unit-test seam short of
building the crate under a checkout CI cannot produce.

# Impact

Build-time only.

- No behaviour change for consumers of the crate, no API change, no new dependency.
- Windows contributors can build, test and review the crate without reconfiguring Git.
- Editing a `.proto` now triggers regeneration, where previously it could silently leave stale
  generated code behind. Nobody should notice except by getting correct results.
- Publishing is unaffected: `protos/V1` is still tried first, which is the layout inside a published
  crate.

# Additional Information

"Just enable symlinks" is not a prerequisite this repository can impose. Creating a symlink on Windows
needs `SeCreateSymbolicLinkPrivilege`, which is granted to Administrators, or to ordinary users only when
Developer Mode is on. On the machine this was found on — an unelevated account, Developer Mode off, which
is the default state of a managed corporate workstation — both `mklink /D` and
`New-Item -ItemType SymbolicLink` fail outright with *"You do not have sufficient privilege"*. Git
detects this at clone time and records `core.symlinks = false` in `.git/config`, so even setting the
global config afterwards has no effect: the repository-local value wins, and a re-checkout could not
create the links anyway.

Three entries are affected, all under `packages/rust/armonik`: `protos`, `README.md` and `LICENSE`. Only
`protos` breaks the build, which is why this change is scoped to it. The other two are read when
packaging, so a Windows contributor should not run `cargo publish` from such a checkout — worth writing
down in `CONTRIBUTING.md`, which mentions neither symlinks nor Windows today, but that is documentation
rather than a build fix and belongs in its own change.

One check on this PR is red: `Check linting, formatting and typing`, which runs `ruff` over
`packages/python`. It reports 343 errors in `packages/python/tests/*.py` and fails identically on every
recent branch, including Renovate branches that touch no Python at all — so it predates this change and
is untouched by it. Every other check passes, the four Rust ones included.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation. *(the resolution order and the reason for
      it are documented on `proto_root` itself, where someone changing it will read them)*
- [ ] I have thoroughly tested my modifications and added tests when necessary. *(no test added — see
      Testing for why a build script has no unit-test seam here)*
- [x] Tests pass locally and in the CI. *(one pre-existing, unrelated failure — see Additional
      Information)*
- [x] I have assessed the performance impact of my modifications. *(none at run time; at build time the
      added `rerun-if-changed` entries narrow what is watched rather than widen it)*
