### PR TITLE
fix(python): declare the ruff rule selection instead of inheriting it

### DIFF
--- a/packages/python/ruff.toml
+++ b/packages/python/ruff.toml
@@ -48,6 +48,14 @@ exclude = ["*.pyi"]
 fixable = ["ALL"]
 
 [format]
+# What to format: this project's Python, and nothing else.
+#
+# Ruff 0.16 promoted Markdown formatting out of preview, so `ruff format .` started rewriting the code
+# blocks in `README.md` — a documentation file that has never been formatted by a Python formatter. Same
+# class of surprise as the rule selection above, and the same answer: say what is wanted rather than
+# inherit it.
+exclude = ["*.md"]
+
 # Like Black, indent with spaces, rather than tabs.
 indent-style = "space"
 

--- a/packages/python/ruff.toml
+++ b/packages/python/ruff.toml
@@ -29,6 +29,18 @@ line-length = 100
 indent-width = 4
 
 [lint]
+# The rules to enforce, declared rather than left implicit.
+#
+# These four are exactly what ruff selected by default up to and including 0.15, and so the set this
+# project has been enforcing all along: `E4` import conventions, `E7`/`E9` pycodestyle errors, `F`
+# pyflakes. Ruff 0.16 widened its defaults, and because nothing here said otherwise, every pull request
+# went red without a line of Python changing. Naming the set makes the linter's behaviour a function of
+# this file instead of of whichever ruff version CI happened to install.
+#
+# Widening it is a deliberate decision rather than the side effect of a release: the rules 0.16 added by
+# default report 340 findings across `src/` and `tests/` as things stand.
+select = ["E4", "E7", "E9", "F"]
+
 # A list of file patterns to exclude from formatting and linting.
 exclude = ["*.pyi"]
 


### PR DESCRIPTION
# Motivation

`Check linting, formatting and typing` fails on every open pull request, and has since 23 July. No
Python changed in between.

`ruff` is unpinned in the `dev` extra of `packages/python/pyproject.toml`, so CI installs whatever is
current. Comparing the last green CI run with the first red one — both the same day, both on unrelated
Renovate branches:

| run | ruff | `Check linting, formatting and typing` |
|---|---|---|
| [30027982533](https://github.com/aneoconsulting/ArmoniK.Api/actions/runs/30027982533) | 0.15.22 | pass |
| [30046882840](https://github.com/aneoconsulting/ArmoniK.Api/actions/runs/30046882840) | 0.16.0 | fail |

Ruff 0.16 changed two defaults, and `ruff.toml` had declared neither, so both were a function of
whichever version CI happened to install rather than of anything in this repository:

- it **widened the default rule selection**, which fails the `Lint` step with 340 findings;
- it **promoted Markdown formatting out of preview**, so `ruff format .` began rewriting the Python code
  blocks in `packages/python/README.md`, which fails the `Check Diff` step that follows. 0.15.22 refused
  outright: *"Markdown formatting is experimental, enable preview mode"*.

It also means `main` is red and nobody sees it: `ci.yml` runs on `pull_request` only, so this job never
runs on the default branch. It only surfaces as a red cross on everyone else's work.

# Description

Both are now stated in `packages/python/ruff.toml`:

```toml
[lint]
select = ["E4", "E7", "E9", "F"]

[format]
exclude = ["*.md"]
```

Those four rules are exactly what ruff selected by default up to and including 0.15, and so the set this
project has been enforcing all along: `E4` import conventions, `E7`/`E9` pycodestyle errors, `F`
pyflakes. Nothing is added and nothing is dropped.

The format exclusion says the same thing about scope: this project formats its Python, and `README.md` is
documentation that no Python formatter has ever touched.

No Python source changes, and no Markdown changes.

# Testing

Run against both ruff versions, on sources normalised to LF (see below):

| | `ruff check .` | `ruff format --check .` |
|---|---|---|
| ruff 0.15.22 | All checks passed | 39 files already formatted |
| ruff 0.16.0 | All checks passed | 39 files already formatted |

Without this change, 0.16.0 reports 340 lint findings — 100 `UP045`, 75 `UP006`, 35 `I001`, 27 `UP007`,
23 `FA100`, 17 `UP037`, and a long tail of `RUF`/`SIM`/`C4`/`B`/`TRY` rules — and reformats `README.md`.

The first push of this branch fixed only the lint half, which is how the Markdown half showed itself: the
`Lint` step went green and `Check Diff` then failed on a rewritten `README.md`. Both halves are covered
now.

On the LF normalisation: a local run on a Windows checkout appears to want 38 files reformatted, but that
is a working-tree artefact. `core.autocrlf` leaves `.py` files with CRLF while `[format] line-ending =
"lf"` asks for LF, and `.gitattributes` normalises `*.proto` and nothing else. CI checks out on Linux, so
it never sees this; the numbers above are measured on a copy with LF endings, which is what CI has.

# Impact

- CI goes green again on every open pull request, and future ones are not blocked by a red cross that has
  nothing to do with them.
- No change to what the linter enforces today, so no Python source is touched and no behaviour changes.
- The enforced rule set and the set of formatted files are now independent of the installed ruff version.
  Ruff can still be upgraded freely; an upgrade can no longer widen either as a side effect.

# Additional Information

Two things this deliberately does **not** do.

**It does not adopt the rules 0.16 added, nor its Markdown formatting.** Several look worth having — `I001` import sorting, the `UP`
pyupgrade family. But that is 340 findings across a published package, 78 of them auto-fixable and the
rest by hand, and it deserves its own pull request where the diff can be read and the tests judged. It
should not arrive as the side effect of a release, which is exactly what happened here.

**It does not pin `ruff`.** A pin would have stopped this incident, but it would leave both settings
undeclared, so the next change of defaults would land the same way, just later — and it would hold the
whole project on one ruff version to do it. Declaring what is wanted addresses the cause; pinning
postpones the symptom.

Worth considering separately: `ci.yml` runs on `pull_request` only, which is how this stayed broken for a
week without anyone owning it. A `push: branches: [main]` trigger, as `test.yml` already has, would have
put the red cross on the commit that caused it.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas. *(the reason the set is
      declared, and what widening it would cost, are in `ruff.toml` next to the setting)*
- [x] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary. *(no test added — the
      change is a lint configuration, and CI running the linter is the test)*
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications. *(none — configuration only)*
