### PR TITLE
fix(rust): apply the request timeout and rate limit that were being parsed and dropped

### DIFF
--- a/packages/rust/Cargo.lock
+++ b/packages/rust/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
 name = "armonik-transport"
 version = "3.29.2-beta-0"
 dependencies = [
+ "bytes",
  "humantime",
  "hyper",
  "hyper-rustls",
@@ -57,7 +58,9 @@ dependencies = [
  "serde_json",
  "serial_test",
  "snafu",
+ "tokio",
  "tonic",
+ "tower-service",
  "tracing",
 ]
 

--- a/packages/rust/Cargo.toml
+++ b/packages/rust/Cargo.toml
@@ -21,6 +21,7 @@ version = "3.29.2-beta-0"
 # `nr update-versions` keeps it in step.
 armonik-transport = { path = "armonik-transport", version = "3.29.2-beta-0" }
 async-stream = "0.3"
+bytes = "1"
 eyre = "0.6"
 futures = "0.3"
 http-body-util = "0.1"
@@ -42,6 +43,7 @@ tokio-util = "0.7"
 tonic = { version = "0.14", default-features = false }
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
+tower-service = "0.3"
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = "0.3"

--- a/packages/rust/armonik-transport/Cargo.toml
+++ b/packages/rust/armonik-transport/Cargo.toml
@@ -38,3 +38,11 @@ humantime.workspace = true
 serial_test.workspace = true
 # Only to round-trip `ClientConfigArgs` in the test that pins the `serde` feature.
 serde_json.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+# The integration tests serve a gRPC service to call, which the regular build never does; these features
+# union with the `channel`/`codegen` above for test builds only.
+tonic = { workspace = true, features = ["server", "router"] }
+# The test service is a `tower` service and its codec moves raw `Bytes`; production code here needs
+# neither, since it hands whole channels to its caller rather than framing messages itself.
+tower-service.workspace = true
+bytes.workspace = true

--- a/packages/rust/armonik-transport/Cargo.toml
+++ b/packages/rust/armonik-transport/Cargo.toml
@@ -15,7 +15,7 @@ serde = ["dep:serde"]
 
 [dependencies]
 # `channel` for `tonic::transport::Endpoint`, which is what `connect` builds; `codegen` for the
-# `http`/`tokio_stream` re-exports `armonik` reaches through this crate.
+# `http`/`tokio_stream` re-exports a dependent reaches through this crate.
 tonic = { workspace = true, features = ["channel", "codegen"] }
 snafu.workspace = true
 tracing.workspace = true

--- a/packages/rust/armonik-transport/README.md
+++ b/packages/rust/armonik-transport/README.md
@@ -3,10 +3,9 @@
 Transport layer for the [ArmoniK](https://github.com/aneoconsulting/ArmoniK) Rust client:
 configuration parsing, and TLS/mTLS connection setup.
 
-This crate is factored out of [`armonik`](../armonik), which re-exports everything here at the same
-paths it always used (`armonik::ClientConfig`, `armonik::client::ConfigError`, ...), so depending on
-`armonik` directly is unaffected by the split. Depend on `armonik-transport` instead when you need the
-connection layer without generated protobuf types or a `protoc`/`tonic-prost-build` build step.
+Depend on it when you need the connection layer without generated protobuf types or a
+`protoc`/`tonic-prost-build` build step. [`armonik`](../armonik) re-exports all of it, so a client that
+wants the services as well needs only that one.
 
 ## Publishing
 

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -315,10 +315,23 @@ impl ClientConfig {
                 .context(InvalidRateLimitCountSnafu {
                     value: parts[0].to_string(),
                 })?;
-            let duration = parts[1]
+            let duration: Duration = parts[1]
                 .parse::<humantime::Duration>()
-                .context(InvalidDurationSnafu { value: rate_limit })?
+                .context(InvalidDurationSnafu {
+                    value: rate_limit.clone(),
+                })?
                 .into();
+            // `tower`'s rate limiter asserts both are non-zero, so leaving these to it turns a mistyped
+            // option into a panic inside `connect` rather than an error the caller can read.
+            if limit == 0 || duration.is_zero() {
+                return IncompatibleOptionsSnafu {
+                    msg: format!(
+                        "`GrpcClient__RateLimit={rate_limit}` has a zero count or duration. Both have \
+                         to be above zero, as in `100/1s`; leave it empty for no rate limit"
+                    ),
+                }
+                .fail();
+            }
             Some((limit, duration))
         };
 
@@ -660,6 +673,26 @@ mod tests {
         .expect("valid");
 
         assert_eq!(config.rate_limit, Some((100, Duration::from_secs(1))));
+    }
+
+    #[test]
+    fn a_zero_rate_limit_is_rejected_rather_than_left_to_panic() {
+        // `tower`'s `Rate::new` asserts both halves are above zero, and this is the change that starts
+        // handing them to it: without this, `0/1s` panics inside `connect` instead of being reported.
+        for value in ["0/1s", "1/0s", "0/0s"] {
+            let error = ClientConfig::from_config_args(ClientConfigArgs {
+                rate_limit: String::from(value),
+                ..args()
+            })
+            .expect_err("a zero rate limit must be rejected")
+            .to_string();
+
+            assert!(error.contains("zero count or duration"), "{value}: {error}");
+            assert!(
+                error.contains(value),
+                "the message should quote it: {error}"
+            );
+        }
     }
 
     #[test]

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -287,9 +287,6 @@ impl ClientConfig {
             )
         };
 
-        // `None`, not `Some(60s)`: nothing applied this until now, so the 60s was never observable, and
-        // keeping it while starting to apply it would deadline every existing caller's requests at one
-        // minute. `connect_timeout` above is the opposite case, its 60s having always been applied.
         let timeout = if timeout.is_empty() {
             None
         } else {
@@ -677,8 +674,8 @@ mod tests {
 
     #[test]
     fn a_zero_rate_limit_is_rejected_rather_than_left_to_panic() {
-        // `tower`'s `Rate::new` asserts both halves are above zero, and this is the change that starts
-        // handing them to it: without this, `0/1s` panics inside `connect` instead of being reported.
+        // `tower`'s `Rate::new` asserts both halves are above zero, so a zero has to be refused here
+        // rather than reaching it: a panic inside `connect` tells the caller nothing.
         for value in ["0/1s", "1/0s", "0/0s"] {
             let error = ClientConfig::from_config_args(ClientConfigArgs {
                 rate_limit: String::from(value),

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -18,7 +18,7 @@ pub struct ClientConfig {
     pub cacert: Option<CertificateDer<'static>>,
     /// Override the endpoint name during SSL verification
     pub override_target: Option<Uri>,
-    /// Timeout for establishing a connection to the server, defaults to no timeout
+    /// Timeout for establishing a connection to the server, defaults to 60s
     pub connect_timeout: Option<Duration>,
     /// Timeout for each request, defaults to no timeout
     pub timeout: Option<Duration>,
@@ -287,8 +287,14 @@ impl ClientConfig {
             )
         };
 
+        // `None`, not `Some(60s)`, and deliberately: the field is documented as defaulting to no
+        // timeout, and until this release nothing applied it, so the 60s was never observable. Keeping
+        // it while starting to apply it would have imposed a one-minute deadline on every request of
+        // every existing caller — a silent behaviour change dressed up as a bug fix. `connect_timeout`
+        // above is the opposite case: its 60s has always been applied, so there the documentation is
+        // what was wrong.
         let timeout = if timeout.is_empty() {
-            Some(Duration::from_secs(60))
+            None
         } else {
             Some(
                 timeout

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -287,12 +287,9 @@ impl ClientConfig {
             )
         };
 
-        // `None`, not `Some(60s)`, and deliberately: the field is documented as defaulting to no
-        // timeout, and until this release nothing applied it, so the 60s was never observable. Keeping
-        // it while starting to apply it would have imposed a one-minute deadline on every request of
-        // every existing caller — a silent behaviour change dressed up as a bug fix. `connect_timeout`
-        // above is the opposite case: its 60s has always been applied, so there the documentation is
-        // what was wrong.
+        // `None`, not `Some(60s)`: nothing applied this until now, so the 60s was never observable, and
+        // keeping it while starting to apply it would deadline every existing caller's requests at one
+        // minute. `connect_timeout` above is the opposite case, its 60s having always been applied.
         let timeout = if timeout.is_empty() {
             None
         } else {

--- a/packages/rust/armonik-transport/src/connect.rs
+++ b/packages/rust/armonik-transport/src/connect.rs
@@ -1,7 +1,6 @@
 //! Turning a [`ClientConfig`] into a connected `tonic` channel.
 //!
-//! Moved out of `armonik`'s `Client::with_config`, which now calls [`connect`] and keeps only what is
-//! about a client rather than about a connection.
+//! TLS, mTLS, and every timeout, keepalive and identity setting come together here.
 
 use std::sync::Arc;
 
@@ -58,9 +57,9 @@ pub async fn connect(config: ClientConfig) -> Result<tonic::transport::Channel, 
 /// Build the connector stack, TCP then TLS or mTLS, that [`connect`] wraps in a channel.
 ///
 /// Most callers want [`connect`]. This exists so a caller can drive plain HTTP through the same
-/// connection configuration a channel would use: `armonik`'s test helper reads the mock server's
-/// `/calls.json` that way. Hidden because its return type names this crate's dependencies rather than
-/// its own; `pub` only so the signature is expressible.
+/// connection configuration a channel would use, which is what it takes to reach a mock server's
+/// diagnostic endpoint from a test. Hidden because its return type names this crate's dependencies
+/// rather than its own; `pub` only so the signature is expressible.
 #[doc(hidden)]
 pub async fn https_connector(
     config: ClientConfig,

--- a/packages/rust/armonik-transport/src/connect.rs
+++ b/packages/rust/armonik-transport/src/connect.rs
@@ -23,12 +23,21 @@ pub async fn connect(config: ClientConfig) -> Result<tonic::transport::Channel, 
     let http2_keep_alive_while_idle = config.http2_keep_alive_while_idle;
     let http2_max_header_list_size = config.http2_max_header_list_size;
     let user_agent = config.user_agent.clone();
+    let timeout = config.timeout;
+    let rate_limit = config.rate_limit;
 
     let https = https_connector(config).await?;
 
     let mut transport_endpoint = tonic::transport::Endpoint::from(endpoint.clone());
     if let Some(target) = override_target {
         transport_endpoint = transport_endpoint.origin(target);
+    }
+
+    if let Some(timeout) = timeout {
+        transport_endpoint = transport_endpoint.timeout(timeout);
+    }
+    if let Some((limit, duration)) = rate_limit {
+        transport_endpoint = transport_endpoint.rate_limit(limit, duration);
     }
 
     if let Some(interval) = http2_keep_alive_interval {

--- a/packages/rust/armonik-transport/src/lib.rs
+++ b/packages/rust/armonik-transport/src/lib.rs
@@ -1,10 +1,8 @@
 //! Transport layer for the ArmoniK Rust client.
 //!
 //! Configuration parsing, TLS and mTLS: what it takes to turn an endpoint into a connected channel.
-//! Split out of [`armonik`](https://docs.rs/armonik) so that a consumer needing only a channel does
-//! not also need protobuf codegen and a `protoc` build step.
-//!
-//! `armonik` re-exports all of this at the paths it always had, so the split breaks nothing for it.
+//! Depending on this alone leaves protobuf codegen, and the `protoc` a build script would need, out of
+//! the build.
 
 mod config;
 mod connect;
@@ -20,8 +18,8 @@ pub use utils::ReadEnvError;
 
 /// Re-exports of this crate's own dependencies, at the versions it was built with.
 ///
-/// `armonik` re-exports these rather than declaring its own requirements for the same crates, so
-/// nothing can end up with a `rustls` other than the one the connection was built with.
+/// A dependent should take these rather than declare its own requirement for the same crates, so it
+/// cannot end up with a `rustls` other than the one the connection was built with.
 pub mod reexports {
     pub use hyper;
     pub use hyper_rustls;

--- a/packages/rust/armonik-transport/tests/common/mod.rs
+++ b/packages/rust/armonik-transport/tests/common/mod.rs
@@ -1,8 +1,7 @@
 //! A gRPC service that answers slowly, and a raw client to call it with.
 //!
 //! Hand-rolled rather than generated: this crate has no protos and deliberately no `protoc` in its
-//! build, so the codec here moves opaque bytes and the "service" is one method that sleeps before
-//! replying. That is all a timeout test needs, and it keeps the fixture readable.
+//! build, so the codec moves opaque bytes and the service is one method that sleeps before replying.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -161,10 +160,9 @@ pub async fn call(
 
 /// Build a [`ClientConfig`] from the string form, applying `set` to the arguments first.
 ///
-/// Going through `ClientConfigArgs` rather than constructing a `ClientConfig` directly keeps the parsing
-/// inside what is under test. The field assignments are why this is a helper at all: both structs are
-/// `#[non_exhaustive]`, so a test outside the crate cannot write either as a struct expression, and
-/// `..Default::default()` is exactly the form that is forbidden.
+/// Going through `ClientConfigArgs` keeps the parsing inside what is under test. It is a helper at all
+/// because both structs are `#[non_exhaustive]`: a test outside the crate cannot write either as a
+/// struct expression, and `..Default::default()` is the form that is forbidden.
 #[allow(clippy::field_reassign_with_default)]
 pub fn config(
     endpoint: &str,

--- a/packages/rust/armonik-transport/tests/common/mod.rs
+++ b/packages/rust/armonik-transport/tests/common/mod.rs
@@ -1,0 +1,179 @@
+//! A gRPC service that answers slowly, and a raw client to call it with.
+//!
+//! Hand-rolled rather than generated: this crate has no protos and deliberately no `protoc` in its
+//! build, so the codec here moves opaque bytes and the "service" is one method that sleeps before
+//! replying. That is all a timeout test needs, and it keeps the fixture readable.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use armonik_transport::reexports::hyper;
+use armonik_transport::reexports::tonic::body::Body;
+use armonik_transport::reexports::tonic::codec::{Codec, DecodeBuf, Decoder, EncodeBuf, Encoder};
+use armonik_transport::reexports::tonic::server::NamedService;
+use armonik_transport::reexports::tonic::{Request, Response, Status};
+use bytes::{Buf, BufMut, Bytes};
+use tower_service::Service;
+
+/// The one method the test service answers to.
+pub const METHOD_PATH: &str = "/armonik_transport.test.Slow/Call";
+
+/// A codec whose wire representation *is* the message: no framing beyond what gRPC already adds.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BytesCodec;
+
+impl Codec for BytesCodec {
+    type Encode = Bytes;
+    type Decode = Bytes;
+    type Encoder = Self;
+    type Decoder = Self;
+
+    fn encoder(&mut self) -> Self::Encoder {
+        *self
+    }
+
+    fn decoder(&mut self) -> Self::Decoder {
+        *self
+    }
+}
+
+impl Encoder for BytesCodec {
+    type Item = Bytes;
+    type Error = Status;
+
+    fn encode(&mut self, item: Self::Item, dst: &mut EncodeBuf<'_>) -> Result<(), Self::Error> {
+        dst.reserve(item.len());
+        dst.put_slice(&item);
+        Ok(())
+    }
+}
+
+impl Decoder for BytesCodec {
+    type Item = Bytes;
+    type Error = Status;
+
+    fn decode(&mut self, src: &mut DecodeBuf<'_>) -> Result<Option<Self::Item>, Self::Error> {
+        let len = src.remaining();
+        Ok(Some(src.copy_to_bytes(len)))
+    }
+}
+
+/// A service that waits `delay` before answering, whatever it was sent.
+#[derive(Clone)]
+pub struct SlowService {
+    delay: Duration,
+}
+
+impl SlowService {
+    pub fn new(delay: Duration) -> Self {
+        Self { delay }
+    }
+}
+
+impl NamedService for SlowService {
+    const NAME: &'static str = "armonik_transport.test.Slow";
+}
+
+/// The gRPC handler. `tonic::server::UnaryService` is a blanket implementation over a `tower` service
+/// of the right shape rather than a trait to implement, so this is where the handler goes.
+impl Service<Request<Bytes>> for SlowService {
+    type Response = Response<Bytes>;
+    type Error = Status;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _request: Request<Bytes>) -> Self::Future {
+        let delay = self.delay;
+        Box::pin(async move {
+            tokio::time::sleep(delay).await;
+            Ok(Response::new(Bytes::from_static(b"late")))
+        })
+    }
+}
+
+impl Service<hyper::Request<Body>> for SlowService {
+    type Response = hyper::Response<Body>;
+    type Error = std::convert::Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: hyper::Request<Body>) -> Self::Future {
+        let mut handler = self.clone();
+        Box::pin(async move {
+            Ok(
+                armonik_transport::reexports::tonic::server::Grpc::new(BytesCodec)
+                    .unary(&mut handler, request)
+                    .await,
+            )
+        })
+    }
+}
+
+/// Serve `service` on an ephemeral loopback port and return its `http://` endpoint.
+pub async fn serve(service: SlowService) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind the test server");
+    let address = listener.local_addr().expect("the test server's address");
+
+    tokio::spawn(async move {
+        let incoming =
+            armonik_transport::reexports::tonic::transport::server::TcpIncoming::from(listener);
+        armonik_transport::reexports::tonic::transport::Server::builder()
+            .add_service(service)
+            .serve_with_incoming(incoming)
+            .await
+            .expect("serve the test service");
+    });
+
+    format!("http://{address}")
+}
+
+/// Make one unary call over `channel`, returning whatever gRPC says about it.
+pub async fn call(
+    channel: armonik_transport::reexports::tonic::transport::Channel,
+) -> Result<Bytes, Status> {
+    let path = armonik_transport::reexports::tonic::codegen::http::uri::PathAndQuery::try_from(
+        METHOD_PATH,
+    )
+    .expect("a valid method path");
+
+    let mut grpc = armonik_transport::reexports::tonic::client::Grpc::new(channel);
+    // Generated clients always do this first, and `Grpc::unary` does not do it implicitly: skipping it
+    // trips `tower::Buffer`'s "send_item called without first calling poll_reserve" assertion.
+    grpc.ready()
+        .await
+        .map_err(|error| Status::unknown(format!("the channel was not ready: {error}")))?;
+
+    let response = grpc
+        .unary(Request::new(Bytes::from_static(b"ping")), path, BytesCodec)
+        .await?;
+    Ok(response.into_inner())
+}
+
+/// Build a [`ClientConfig`] from the string form, applying `set` to the arguments first.
+///
+/// Going through `ClientConfigArgs` rather than constructing a `ClientConfig` directly keeps the parsing
+/// inside what is under test. The field assignments are why this is a helper at all: both structs are
+/// `#[non_exhaustive]`, so a test outside the crate cannot write either as a struct expression, and
+/// `..Default::default()` is exactly the form that is forbidden.
+#[allow(clippy::field_reassign_with_default)]
+pub fn config(
+    endpoint: &str,
+    set: impl FnOnce(&mut armonik_transport::ClientConfigArgs),
+) -> armonik_transport::ClientConfig {
+    let mut args = armonik_transport::ClientConfigArgs::default();
+    args.endpoint = endpoint.to_owned();
+    args.allow_unsafe_connection = true;
+    set(&mut args);
+    armonik_transport::ClientConfig::from_config_args(args)
+        .expect("the configuration should be valid")
+}

--- a/packages/rust/armonik-transport/tests/timeout.rs
+++ b/packages/rust/armonik-transport/tests/timeout.rs
@@ -83,8 +83,8 @@ fn an_empty_timeout_means_no_timeout_rather_than_a_minute() {
 
 #[test]
 fn an_empty_connect_timeout_still_means_a_minute() {
-    // The mirror image, and the reason the two are treated differently: this 60s *has* always been
-    // applied, so it is observable behaviour and changing it would be a regression rather than a fix.
+    // The mirror image of the test above: an absent `ConnectTimeout` bounds the connection at a
+    // minute, which is what a caller who sets nothing gets.
     let config = config("http://localhost:5001", |_| {});
 
     assert_eq!(config.connect_timeout, Some(Duration::from_secs(60)));

--- a/packages/rust/armonik-transport/tests/timeout.rs
+++ b/packages/rust/armonik-transport/tests/timeout.rs
@@ -1,0 +1,110 @@
+//! `GrpcClient__Timeout` and `GrpcClient__RateLimit`, now that they reach the channel.
+//!
+//! Both were parsed into `ClientConfig` and then dropped on the floor. A test that only asserted the
+//! parsing would have passed before this change as well, so these go through a real connection to a
+//! real server and measure what the caller actually gets.
+
+mod common;
+
+use std::time::{Duration, Instant};
+
+use common::{call, config, serve, SlowService};
+
+#[tokio::test]
+async fn a_request_timeout_ends_a_call_the_server_is_too_slow_to_answer() {
+    // The server takes ten seconds; the caller allows 300ms. Before this change the option was parsed
+    // and ignored, so the call waited for the full ten.
+    let endpoint = serve(SlowService::new(Duration::from_secs(10))).await;
+
+    let channel = armonik_transport::connect(config(&endpoint, |args| {
+        args.timeout = String::from("300ms");
+    }))
+    .await
+    .expect("connecting should succeed");
+
+    let started = Instant::now();
+    let outcome = call(channel).await;
+    let elapsed = started.elapsed();
+
+    let status = outcome.expect_err("the call should not have completed");
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "the call took {elapsed:?}, so the timeout was not applied"
+    );
+    // The message is `tower`'s, reached through `tonic`; asserting on the timing above is the real
+    // check, and this only pins that the failure is the timeout rather than something else.
+    let rendered = format!("{status:?}").to_lowercase();
+    assert!(
+        rendered.contains("time") || rendered.contains("elapsed") || rendered.contains("cancel"),
+        "unexpected failure: {status:?}"
+    );
+}
+
+#[tokio::test]
+async fn no_timeout_lets_a_slow_call_finish() {
+    // The other half: the timeout has to bound a call, not shorten one that was within its budget. Also
+    // the default path — an empty `Timeout` must not impose one.
+    let endpoint = serve(SlowService::new(Duration::from_millis(300))).await;
+
+    let channel = armonik_transport::connect(config(&endpoint, |_| {}))
+        .await
+        .expect("connecting should succeed");
+
+    let answer = call(channel).await.expect("the call should complete");
+    assert_eq!(answer.as_ref(), b"late");
+}
+
+#[tokio::test]
+async fn a_rate_limit_is_accepted_and_still_lets_calls_through() {
+    // `Endpoint::rate_limit` is `tower`'s, and testing that it throttles would be testing `tower`. What
+    // is worth pinning here is that passing it on does not break a call — the failure mode of wiring an
+    // option through incorrectly.
+    let endpoint = serve(SlowService::new(Duration::ZERO)).await;
+
+    let channel = armonik_transport::connect(config(&endpoint, |args| {
+        args.rate_limit = String::from("100/1s");
+    }))
+    .await
+    .expect("connecting should succeed");
+
+    assert_eq!(
+        call(channel)
+            .await
+            .expect("the call should complete")
+            .as_ref(),
+        b"late"
+    );
+}
+
+#[test]
+fn an_empty_timeout_means_no_timeout_rather_than_a_minute() {
+    // The field is documented as defaulting to no timeout, and nothing applied it until now, so the
+    // `Some(60s)` it used to parse to was never observable. This is the assertion that keeps a
+    // one-minute deadline from appearing on every request of every caller.
+    let config = config("http://localhost:5001", |_| {});
+
+    assert_eq!(config.timeout, None);
+}
+
+#[test]
+fn an_empty_connect_timeout_still_means_a_minute() {
+    // The mirror image, and the reason the two are treated differently: this 60s *has* always been
+    // applied, so it is observable behaviour and changing it would be a regression rather than a fix.
+    let config = config("http://localhost:5001", |_| {});
+
+    assert_eq!(config.connect_timeout, Some(Duration::from_secs(60)));
+}
+
+#[test]
+fn a_timeout_is_parsed_in_the_units_it_was_written_in() {
+    for (written, expected) in [
+        ("30s", Duration::from_secs(30)),
+        ("500ms", Duration::from_millis(500)),
+        ("2m", Duration::from_secs(120)),
+    ] {
+        let config = config("http://localhost:5001", |args| {
+            args.timeout = String::from(written);
+        });
+        assert_eq!(config.timeout, Some(expected), "for {written}");
+    }
+}

--- a/packages/rust/armonik-transport/tests/timeout.rs
+++ b/packages/rust/armonik-transport/tests/timeout.rs
@@ -1,7 +1,7 @@
-//! `GrpcClient__Timeout` and `GrpcClient__RateLimit`, now that they reach the channel.
+//! `GrpcClient__Timeout` and `GrpcClient__RateLimit` reaching the channel.
 //!
-//! A test that only asserted the parsing would have passed before this change too, since both options
-//! were already parsed and then dropped. So these go through a real connection to a real server.
+//! Through a real connection to a real server, measuring what the caller gets: asserting on the parsing
+//! alone would say nothing about whether either option reaches the channel.
 
 mod common;
 
@@ -11,8 +11,7 @@ use common::{call, config, serve, SlowService};
 
 #[tokio::test]
 async fn a_request_timeout_ends_a_call_the_server_is_too_slow_to_answer() {
-    // The server takes ten seconds; the caller allows 300ms. Before this change the option was parsed
-    // and ignored, so the call waited for the full ten.
+    // A server that takes ten seconds against a caller that allows 300ms.
     let endpoint = serve(SlowService::new(Duration::from_secs(10))).await;
 
     let channel = armonik_transport::connect(config(&endpoint, |args| {
@@ -76,9 +75,7 @@ async fn a_rate_limit_is_accepted_and_still_lets_calls_through() {
 
 #[test]
 fn an_empty_timeout_means_no_timeout_rather_than_a_minute() {
-    // The field is documented as defaulting to no timeout, and nothing applied it until now, so the
-    // `Some(60s)` it used to parse to was never observable. This is the assertion that keeps a
-    // one-minute deadline from appearing on every request of every caller.
+    // What keeps a one-minute deadline off every request of every caller who set nothing.
     let config = config("http://localhost:5001", |_| {});
 
     assert_eq!(config.timeout, None);

--- a/packages/rust/armonik-transport/tests/timeout.rs
+++ b/packages/rust/armonik-transport/tests/timeout.rs
@@ -1,8 +1,7 @@
 //! `GrpcClient__Timeout` and `GrpcClient__RateLimit`, now that they reach the channel.
 //!
-//! Both were parsed into `ClientConfig` and then dropped on the floor. A test that only asserted the
-//! parsing would have passed before this change as well, so these go through a real connection to a
-//! real server and measure what the caller actually gets.
+//! A test that only asserted the parsing would have passed before this change too, since both options
+//! were already parsed and then dropped. So these go through a real connection to a real server.
 
 mod common;
 
@@ -42,8 +41,8 @@ async fn a_request_timeout_ends_a_call_the_server_is_too_slow_to_answer() {
 
 #[tokio::test]
 async fn no_timeout_lets_a_slow_call_finish() {
-    // The other half: the timeout has to bound a call, not shorten one that was within its budget. Also
-    // the default path — an empty `Timeout` must not impose one.
+    // The timeout has to bound a call, not shorten one already within its budget. Also the default
+    // path: an empty `Timeout` must not impose one.
     let endpoint = serve(SlowService::new(Duration::from_millis(300))).await;
 
     let channel = armonik_transport::connect(config(&endpoint, |_| {}))
@@ -56,9 +55,8 @@ async fn no_timeout_lets_a_slow_call_finish() {
 
 #[tokio::test]
 async fn a_rate_limit_is_accepted_and_still_lets_calls_through() {
-    // `Endpoint::rate_limit` is `tower`'s, and testing that it throttles would be testing `tower`. What
-    // is worth pinning here is that passing it on does not break a call — the failure mode of wiring an
-    // option through incorrectly.
+    // Testing that `Endpoint::rate_limit` throttles would be testing `tower`. What is worth pinning is
+    // that passing the option on does not break the call, which is how wiring one through goes wrong.
     let endpoint = serve(SlowService::new(Duration::ZERO)).await;
 
     let channel = armonik_transport::connect(config(&endpoint, |args| {

--- a/packages/rust/armonik/build.rs
+++ b/packages/rust/armonik/build.rs
@@ -1,7 +1,6 @@
 /// The proto files to compile, relative to [`PROTO_ROOT`].
 ///
-/// A list rather than a glob, as it already was; the only change is that the `protos/V1/` prefix is no
-/// longer repeated forty times.
+/// A list rather than a glob, so that each file can be named to `cargo:rerun-if-changed` below.
 const PROTO_FILES: &[&str] = &[
     "agent_common.proto",
     "agent_service.proto",

--- a/packages/rust/armonik/src/client/mod.rs
+++ b/packages/rust/armonik/src/client/mod.rs
@@ -2,8 +2,8 @@
 
 use snafu::{ResultExt, Snafu};
 
-// Re-exported at the paths they have always had: the split moved where these are defined, not where
-// they are used from.
+// Re-exported here, so a caller reaches them through the client rather than through the transport
+// crate.
 #[cfg(feature = "_gen-client")]
 use armonik_transport::ConfigSnafu;
 #[cfg(feature = "_gen-client")]

--- a/packages/rust/armonik/src/lib.rs
+++ b/packages/rust/armonik/src/lib.rs
@@ -17,7 +17,7 @@ pub use objects::*;
 mod utils;
 
 pub mod reexports {
-    // Through `armonik-transport`, which owns these now, so `armonik::reexports::rustls` cannot differ
+    // Through `armonik-transport`, which owns these, so `armonik::reexports::rustls` cannot differ
     // from the `rustls` the connection was built with.
     #[cfg(feature = "_gen-client")]
     pub use armonik_transport::reexports::{hyper, hyper_rustls, rustls};


### PR DESCRIPTION
`GrpcClient__Timeout` and `GrpcClient__RateLimit` were parsed into `ClientConfig` and never passed to
anything: `connect` copied fifteen of the seventeen fields onto the endpoint and skipped these two. Setting
either had no effect, with no error and no warning.

Both are now applied, through `Endpoint::timeout` and `Endpoint::rate_limit`.

## The default that had to change with it

`timeout` parsed an empty value to `Some(60s)` while its doc comment said "defaults to no timeout". Nothing
applied it, so the 60s was never observable, and wiring the field through while keeping that default would
have imposed a one-minute deadline on every request of every existing caller. It is now `None`, as documented.

`connect_timeout` is the mirror image and is left alone: its 60s has always been applied, so there the doc
comment is what was wrong, and only the comment changes.

## Testing

`armonik-transport` had no tests. This adds a fixture serving one gRPC method that sleeps, and six tests:
the timeout firing, a slow call finishing without one, a rate limit not breaking a call, and the three
default and parsing cases.

The first was checked against the bug. With the two lines removed from `connect`,
`cargo test -p armonik-transport --test timeout` fails on the elapsed-time assertion after 10.02s, the call
having completed rather than been cut short.

## Also here

A zero-valued rate limit is refused while parsing. `tower`'s rate limiter asserts both halves are above
zero, and this is what starts handing them to it, so `0/1s` would otherwise panic inside `connect`.

Comments that narrated the code's history are gone, following a review comment on this pull request. The
same habit was in the transport crate's own module docs, which also named `armonik` from inside the layer
below it; corrected here because these are files this change already touches, plus the crate's README.

## Impact

`GrpcClient__Timeout` and `GrpcClient__RateLimit` now do what they say, so anyone who set them and got
nothing will start getting what they asked for. No change for anyone who set neither. No API change; the new
dev-dependencies are for the test fixture only.

