### PR TITLE
ci(rust): refuse a committed copy where a symlink belongs, and document the Windows case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,25 @@ jobs:
       - name: Verify Versions
         run: nr verify-versions
 
+  check-symlinks:
+    name: Check symlinks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+
+      - name: The repository's symlinks must still be symlinks
+        run: |
+          # The script reports to stderr and answers with its exit status; the annotation is added here
+          # rather than by the script, so that the script stays useful to a contributor running it by hand
+          # as CONTRIBUTING.md suggests.
+          if ! ./scripts/check-symlinks.sh; then
+            echo "::error::a path that must be a symlink is not one; see the job log and the Windows section of CONTRIBUTING.md"
+            exit 1
+          fi
+
   format-csharp:
     name: Format C#
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,7 @@ jobs:
           fetch-depth: 0
 
       - name: The repository's symlinks must still be symlinks
-        run: |
-          # The script reports to stderr and answers with its exit status; the annotation is added here
-          # rather than by the script, so that the script stays useful to a contributor running it by hand
-          # as CONTRIBUTING.md suggests.
-          if ! ./scripts/check-symlinks.sh; then
-            echo "::error::a path that must be a symlink is not one; see the job log and the Windows section of CONTRIBUTING.md"
-            exit 1
-          fi
+        run: ./scripts/check-symlinks.sh
 
   format-csharp:
     name: Format C#

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,48 @@ Hi! We are very happy that you are interested in contributing to ArmoniK.Api. Be
 4. Make sure you clearly define the changes in the description of the PR
 5. Make sure all tests pass
 
+## Building on Windows
+
+`packages/rust/armonik` reaches the shared `Protos` directory, `README.md` and `LICENSE` through symlinks.
+That is deliberate: it keeps one copy of each in the repository while letting `cargo package` vendor them
+into the published crate.
+
+Git only materialises a symlink when `core.symlinks` is enabled, and that is **not** the default on Windows.
+Creating one there needs `SeCreateSymbolicLinkPrivilege`, which is granted to administrators, or to ordinary
+users only when Developer Mode is on — so on a managed workstation, an unelevated account cannot do it at
+all. Git detects this when cloning and records `core.symlinks = false` in `.git/config`, after which each
+entry is checked out as an ordinary file containing its target, such as `../../../Protos`.
+
+The Rust crate then fails to build, because `protos/V1` is not a directory. Two ways forward:
+
+**Enable symlinks, if you can.** With Developer Mode on, or from an elevated shell:
+
+```sh
+git config --global core.symlinks true
+git config --unset core.symlinks   # drop the per-repository `false` recorded at clone time
+```
+
+then re-checkout the affected paths so Git creates the links:
+
+```sh
+git checkout -- packages/rust/armonik/protos packages/rust/armonik/README.md packages/rust/armonik/LICENSE
+```
+
+**Or work with a local copy.** Replace the placeholder file with a copy of what it points at:
+
+```sh
+rm packages/rust/armonik/protos
+cp -r Protos packages/rust/armonik/protos
+```
+
+If you do, **do not commit it**. A committed copy detaches the crate from the shared `Protos` and lets the
+two drift apart silently — and a crate packaged from such a checkout ships *no* protos at all, since
+`include = ["protos/**"]` finds nothing to match when `protos` is a file rather than a directory. CI refuses
+it: `scripts/check-symlinks.sh` runs on every pull request and fails if any of the three is no longer a
+symlink. You can run it yourself before pushing.
+
+Remember to restore the symlink, or to keep the copy out of your commits, when you are done.
+
 ## Release Process
 
 When necessary, maintainers can release a new version. This new version will publish packages to registries.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,28 +18,34 @@ Hi! We are very happy that you are interested in contributing to ArmoniK.Api. Be
 That is deliberate: it keeps one copy of each in the repository while letting `cargo package` vendor them
 into the published crate.
 
-Git only materialises a symlink when `core.symlinks` is enabled, and that is **not** the default on Windows.
-Creating one there needs `SeCreateSymbolicLinkPrivilege`, which is granted to administrators, or to ordinary
-users only when Developer Mode is on — so on a managed workstation, an unelevated account cannot do it at
-all. Git detects this when cloning and records `core.symlinks = false` in `.git/config`, after which each
-entry is checked out as an ordinary file containing its target, such as `../../../Protos`.
+Creating a symlink on Windows normally requires `SeCreateSymbolicLinkPrivilege`, which an ordinary
+unelevated account does not hold. Git checks for this while cloning and, finding it absent, records
+`core.symlinks = false` in the repository's own `.git/config` — after which each entry is checked out as an
+ordinary file containing its target, such as the fifteen bytes `../../../Protos`.
 
-The Rust crate then fails to build, because `protos/V1` is not a directory. Two ways forward:
+The Rust crate then fails to build, because `protos/V1` is not a directory.
 
-**Enable symlinks, if you can.** With Developer Mode on, or from an elevated shell:
-
-```sh
-git config --global core.symlinks true
-git config --unset core.symlinks   # drop the per-repository `false` recorded at clone time
-```
-
-then re-checkout the affected paths so Git creates the links:
+**Enable symlinks.** Turn on Developer Mode (Settings → System → For developers). No elevation is needed,
+now or later: Developer Mode does not grant the privilege, it allows `CreateSymbolicLink` to accept a flag
+that waives the check, and Git passes that flag. Then:
 
 ```sh
+git config --unset core.symlinks   # the per-repository `false`, recorded at clone time
+git config --global --get core.symlinks   # if this prints nothing, add: git config --global core.symlinks true
+rm packages/rust/armonik/protos packages/rust/armonik/README.md packages/rust/armonik/LICENSE
 git checkout -- packages/rust/armonik/protos packages/rust/armonik/README.md packages/rust/armonik/LICENSE
 ```
 
-**Or work with a local copy.** Replace the placeholder file with a copy of what it points at:
+The `--unset` is the step that is easy to miss and the one that matters: a repository-local `false` beats a
+global `true`, so setting the global alone appears to do nothing at all.
+
+Note that Developer Mode only helps programs that pass the flag. Git does; some others do not — PowerShell
+5.1's `New-Item -ItemType SymbolicLink`, for instance, still fails with "Administrator privilege required".
+That is a limitation of those tools, not a sign that Developer Mode is off.
+
+**Or, if you cannot enable it,** work with a local copy instead.
+
+Replace the placeholder file with a copy of what it points at:
 
 ```sh
 rm packages/rust/armonik/protos

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,12 +20,12 @@ into the published crate.
 
 Creating a symlink on Windows normally requires `SeCreateSymbolicLinkPrivilege`, which an ordinary
 unelevated account does not hold. Git checks for this while cloning and, finding it absent, records
-`core.symlinks = false` in the repository's own `.git/config` — after which each entry is checked out as an
+`core.symlinks = false` in the repository's own `.git/config`, after which each entry is checked out as an
 ordinary file containing its target, such as the fifteen bytes `../../../Protos`.
 
 The Rust crate then fails to build, because `protos/V1` is not a directory.
 
-**Enable symlinks.** Turn on Developer Mode (Settings → System → For developers). No elevation is needed,
+**Enable symlinks.** Turn on Developer Mode (Settings > System > For developers). No elevation is needed,
 now or later: Developer Mode does not grant the privilege, it allows `CreateSymbolicLink` to accept a flag
 that waives the check, and Git passes that flag. Then:
 
@@ -39,7 +39,7 @@ git checkout -- packages/rust/armonik/protos packages/rust/armonik/README.md pac
 The `--unset` is the step that is easy to miss and the one that matters: a repository-local `false` beats a
 global `true`, so setting the global alone appears to do nothing at all.
 
-Note that Developer Mode only helps programs that pass the flag. Git does; some others do not — PowerShell
+Note that Developer Mode only helps programs that pass the flag. Git does; some others do not. PowerShell
 5.1's `New-Item -ItemType SymbolicLink`, for instance, still fails with "Administrator privilege required".
 That is a limitation of those tools, not a sign that Developer Mode is off.
 
@@ -53,7 +53,7 @@ cp -r Protos packages/rust/armonik/protos
 ```
 
 If you do, **do not commit it**. A committed copy detaches the crate from the shared `Protos` and lets the
-two drift apart silently — and a crate packaged from such a checkout ships *no* protos at all, since
+two drift apart silently, and a crate packaged from such a checkout ships *no* protos at all, since
 `include = ["protos/**"]` finds nothing to match when `protos` is a file rather than a directory. CI refuses
 it: `scripts/check-symlinks.sh` runs on every pull request and fails if any of the three is no longer a
 symlink. You can run it yourself before pushing.

--- a/scripts/check-symlinks.sh
+++ b/scripts/check-symlinks.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Verify that the symlinks this repository relies on are still symlinks.
+#
+# `packages/rust/armonik` reaches the shared `Protos`, `README.md` and `LICENSE` through symlinks, which is
+# what lets `cargo package` vendor them into the published crate while keeping a single source in the
+# repository.
+#
+# Git only materialises a symlink when `core.symlinks` is enabled, and that is not the default on Windows:
+# there each one is checked out as an ordinary file containing its target. Committing such a file — or a
+# copy of the tree it pointed at — would detach the crate from the shared source and let the two drift, so
+# this refuses it.
+#
+# Run from the repository root, in CI or by hand. Diagnostics go to stderr; the exit status is the verdict.
+
+set -uo pipefail
+
+status=0
+
+check() {
+  local path="$1" want="$2"
+  local entry mode blob
+
+  entry=$(git ls-files -s -- "$path")
+
+  if [[ -z "$entry" ]]; then
+    echo "${path}: not in the index. A symlink was expected; it may have been replaced by a directory." >&2
+    return 1
+  fi
+
+  if [[ "$(printf '%s\n' "$entry" | wc -l)" -ne 1 ]]; then
+    echo "${path}: expands to several index entries. A single symlink was expected, not a copy of the tree it points at." >&2
+    return 1
+  fi
+
+  mode=$(printf '%s' "$entry" | awk '{ print $1 }')
+  if [[ "$mode" != "120000" ]]; then
+    echo "${path}: expected a symlink (mode 120000) but found mode ${mode}. On Windows without symlink support you may work with a local copy, but it must not be committed — see the Windows section of CONTRIBUTING.md." >&2
+    return 1
+  fi
+
+  blob=$(git cat-file blob ":${path}")
+  if [[ "$blob" != "$want" ]]; then
+    echo "${path}: symlink points at '${blob}', expected '${want}'." >&2
+    return 1
+  fi
+
+  printf '  ok  %-44s -> %s\n' "$path" "$blob"
+}
+
+# path                                  expected target
+check packages/rust/armonik/protos      ../../../Protos    || status=1
+check packages/rust/armonik/README.md   ../../../README.md || status=1
+check packages/rust/armonik/LICENSE     ../../../LICENSE   || status=1
+
+if [[ "$status" -ne 0 ]]; then
+  echo "One or more symlinks are no longer symlinks. See the Windows section of CONTRIBUTING.md." >&2
+fi
+
+exit "$status"

--- a/scripts/check-symlinks.sh
+++ b/scripts/check-symlinks.sh
@@ -1,46 +1,44 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # Verify that the symlinks this repository relies on are still symlinks.
 #
-# `packages/rust/armonik` reaches the shared `Protos`, `README.md` and `LICENSE` through symlinks, which is
-# what lets `cargo package` vendor them into the published crate while keeping a single source in the
-# repository.
+# packages/rust/armonik reaches the shared Protos, README.md and LICENSE through symlinks, which is what
+# lets `cargo package` vendor them into the published crate while keeping a single source in the repository.
 #
-# Git only materialises a symlink when `core.symlinks` is enabled, and that is not the default on Windows:
-# there each one is checked out as an ordinary file containing its target. Committing such a file — or a
-# copy of the tree it pointed at — would detach the crate from the shared source and let the two drift, so
-# this refuses it.
+# A checkout without symlink support (Git for Windows without core.symlinks) materialises each of them as an
+# ordinary file containing its target. Committing such a file, or a copy of the tree it pointed at, would
+# detach the crate from the shared source and let the two drift, so this refuses it.
 #
-# Run from the repository root, in CI or by hand. Diagnostics go to stderr; the exit status is the verdict.
+# Run from the repository root. Diagnostics go to stderr; the exit status is the verdict.
 
-set -uo pipefail
+set -u
 
 status=0
 
 check() {
-  local path="$1" want="$2"
-  local entry mode blob
+  path=$1
+  want=$2
 
   entry=$(git ls-files -s -- "$path")
 
-  if [[ -z "$entry" ]]; then
+  if [ -z "$entry" ]; then
     echo "${path}: not in the index. A symlink was expected; it may have been replaced by a directory." >&2
     return 1
   fi
 
-  if [[ "$(printf '%s\n' "$entry" | wc -l)" -ne 1 ]]; then
+  if [ "$(printf '%s\n' "$entry" | wc -l)" -ne 1 ]; then
     echo "${path}: expands to several index entries. A single symlink was expected, not a copy of the tree it points at." >&2
     return 1
   fi
 
   mode=$(printf '%s' "$entry" | awk '{ print $1 }')
-  if [[ "$mode" != "120000" ]]; then
-    echo "${path}: expected a symlink (mode 120000) but found mode ${mode}. On Windows without symlink support you may work with a local copy, but it must not be committed — see the Windows section of CONTRIBUTING.md." >&2
+  if [ "$mode" != "120000" ]; then
+    echo "${path}: expected a symlink (mode 120000) but found mode ${mode}. On Windows without symlink support you may work with a local copy, but it must not be committed. See the Windows section of CONTRIBUTING.md." >&2
     return 1
   fi
 
   blob=$(git cat-file blob ":${path}")
-  if [[ "$blob" != "$want" ]]; then
+  if [ "$blob" != "$want" ]; then
     echo "${path}: symlink points at '${blob}', expected '${want}'." >&2
     return 1
   fi
@@ -53,7 +51,7 @@ check packages/rust/armonik/protos      ../../../Protos    || status=1
 check packages/rust/armonik/README.md   ../../../README.md || status=1
 check packages/rust/armonik/LICENSE     ../../../LICENSE   || status=1
 
-if [[ "$status" -ne 0 ]]; then
+if [ "$status" -ne 0 ]; then
   echo "One or more symlinks are no longer symlinks. See the Windows section of CONTRIBUTING.md." >&2
 fi
 


### PR DESCRIPTION
# Motivation

`packages/rust/armonik` reaches the shared `Protos` directory, `README.md` and `LICENSE` through symlinks.
That is deliberate: the repository keeps one copy of each, and `cargo package` follows the links to vendor
them into the published crate.

Creating a symlink on Windows normally requires `SeCreateSymbolicLinkPrivilege`, which an ordinary unelevated
account does not hold. Git checks while cloning and, finding it absent, records `core.symlinks = false` in the
repository's own `.git/config` — after which each entry is checked out as an ordinary file containing its
target, such as the fifteen bytes `../../../Protos`.

Developer Mode gets a contributor out of this, and the second commit here documents it accurately after
measuring what it actually does: it does *not* grant the privilege, it lets `CreateSymbolicLink` accept a flag
waiving the check, which the calling program must pass. Git passes it; PowerShell 5.1's
`New-Item -ItemType SymbolicLink` does not, and still fails on a machine where Git works — which reads as if
Developer Mode had not taken effect. The step that actually matters is `git config --unset core.symlinks`: a
repository-local `false` beats a global `true`, so setting the global alone changes nothing.

The Rust crate then does not build there, since `protos/V1` is not a directory. The obvious local fix is to
delete the placeholder and copy in what it pointed at — which works, and which would be a slow disaster if
committed:

- the crate's protos would drift from the shared `Protos` with nothing to notice the divergence;
- and a crate packaged from such a checkout ships **no protos at all**. `include = ["protos/**"]` matches
  nothing when `protos` is a file rather than a directory. Confirmed rather than assumed:

  ```
  $ cargo package --list --allow-dirty | grep proto
  (nothing)
  ```

  A consumer of that published crate could not build it.

So the local copy needs to be possible, and committing it needs to be impossible.

# Description

**`scripts/check-symlinks.sh`** asserts, for each of the three paths, that the index holds exactly one entry,
of mode `120000`, pointing where it should. Run from the repository root; annotates the offending path when
run in CI, and points at `CONTRIBUTING.md`.

All three, not only `protos`: `README.md` and `LICENSE` have the same failure mode, and nobody had noticed
them. `protos` is the one that breaks the build; the other two break `cargo package` quietly, shipping a
crate whose README and licence are fifteen-byte relative paths.

**A `Check symlinks` job** in `ci.yml` runs it on every pull request. Its own job rather than a step in an
existing one, so that a red cross names the problem.

**`CONTRIBUTING.md` gains a Windows section** covering both routes:

- Enabling symlinks through Developer Mode, which needs no elevation, with the `git config --unset
  core.symlinks` that is easy to miss and the note about which tools pass the flag.
- Working with a local copy, with the reason not to commit it and a pointer to the check that refuses it.

# Testing

The check was verified against both ways it can actually go wrong, by constructing the failing index in a
scratch `GIT_INDEX_FILE` rather than by reading the code:

| index state | result |
|---|---|
| the repository as it is | `exit 0`, three lines listing the links and their targets |
| a symlink replaced by an ordinary file — what a Windows contributor would commit | `exit 1`, error annotated on the path |
| a symlink replaced by a copy of the tree it pointed at | `exit 1` |

The first version of the script **passed** that third case: with the path gone from the index, the loop had
nothing to iterate over and reported nothing. That is why it now asserts presence before mode. Worth
mentioning because it is the failure this check exists for, and it was the one it missed.

The script is committed mode `100755`, matching the other scripts in `scripts/`, since the workflow invokes
it as `./scripts/check-symlinks.sh`. That also needed catching: a Windows checkout does not carry the
executable bit, so it committed as `100644` and CI would have failed with "Permission denied".

`ci.yml` parses, and the job resolves as expected.

# Impact

- One new CI job, a few seconds, no dependency on any toolchain.
- No behaviour change to any package. Nothing but a workflow, a script and a documentation section.
- A Windows contributor now has a documented way to build, and a guard rail if they take it.
- Existing contributors see nothing new unless they replace one of the three paths, which is the point.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas. *(the script's header explains why
      the symlinks exist and why a copy must not be committed, since that is the part a future reader will
      question)*
- [x] I have made corresponding changes to the documentation. *(the new Windows section in
      `CONTRIBUTING.md`, which is what the check's error message points at)*
- [x] I have thoroughly tested my modifications and added tests when necessary. *(see Testing — both failure
      modes exercised against a real index)*
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications. *(a few `git ls-files` calls in a job of
      its own)*
