### PR TITLE
build(rust): declare the build script's proto dependencies

### DIFF
--- a/packages/rust/armonik/build.rs
+++ b/packages/rust/armonik/build.rs
@@ -1,7 +1,7 @@
 /// The proto files to compile, relative to [`PROTO_ROOT`].
 ///
-/// A list rather than a glob, so that adding a proto stays a deliberate act — as it already was. The only
-/// change is that the `protos/V1/` prefix is no longer repeated forty times.
+/// A list rather than a glob, as it already was; the only change is that the `protos/V1/` prefix is no
+/// longer repeated forty times.
 const PROTO_FILES: &[&str] = &[
     "agent_common.proto",
     "agent_service.proto",
@@ -55,10 +55,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map(|file| format!("{PROTO_ROOT}/{file}"))
         .collect::<Vec<_>>();
 
-    // Without these, editing a `.proto` regenerates nothing. A build script that declares no dependencies
-    // gets cargo's fallback — watch the whole crate directory — and that only reaches the protos through
-    // the `protos` symlink, which cargo does not follow. So the generated code went stale silently, on
-    // every platform, until something unrelated happened to force a rebuild.
+    // With nothing declared, cargo watches the whole crate directory, so editing a test re-runs `protoc`
+    // over all forty protos. Declaring them replaces that fallback rather than adding to it, which is why
+    // this list now decides rebuilds as well as what gets compiled.
     for file in &proto_files {
         println!("cargo:rerun-if-changed={file}");
     }

--- a/packages/rust/armonik/build.rs
+++ b/packages/rust/armonik/build.rs
@@ -1,52 +1,76 @@
+/// The proto files to compile, relative to [`PROTO_ROOT`].
+///
+/// A list rather than a glob, so that adding a proto stays a deliberate act — as it already was. The only
+/// change is that the `protos/V1/` prefix is no longer repeated forty times.
+const PROTO_FILES: &[&str] = &[
+    "agent_common.proto",
+    "agent_service.proto",
+    "applications_common.proto",
+    "applications_fields.proto",
+    "applications_filters.proto",
+    "applications_service.proto",
+    "auth_common.proto",
+    "auth_service.proto",
+    "events_common.proto",
+    "events_service.proto",
+    "filters_common.proto",
+    "objects.proto",
+    "health_checks_common.proto",
+    "health_checks_service.proto",
+    "partitions_common.proto",
+    "partitions_fields.proto",
+    "partitions_filters.proto",
+    "partitions_service.proto",
+    "result_status.proto",
+    "results_common.proto",
+    "results_fields.proto",
+    "results_filters.proto",
+    "results_service.proto",
+    "session_status.proto",
+    "sessions_common.proto",
+    "sessions_fields.proto",
+    "sessions_filters.proto",
+    "sessions_service.proto",
+    "sort_direction.proto",
+    "submitter_common.proto",
+    "submitter_service.proto",
+    "task_status.proto",
+    "tasks_common.proto",
+    "tasks_fields.proto",
+    "tasks_filters.proto",
+    "tasks_service.proto",
+    "versions_common.proto",
+    "versions_service.proto",
+    "worker_common.proto",
+    "worker_service.proto",
+];
+
+/// Where the protos live, as seen from this crate: under a symlink to the repository's `Protos`, which is
+/// what makes `include = ["protos/**"]` vendor them into the published crate.
+const PROTO_ROOT: &str = "protos/V1";
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let proto_files = PROTO_FILES
+        .iter()
+        .map(|file| format!("{PROTO_ROOT}/{file}"))
+        .collect::<Vec<_>>();
+
+    // Without these, editing a `.proto` regenerates nothing. A build script that declares no dependencies
+    // gets cargo's fallback — watch the whole crate directory — and that only reaches the protos through
+    // the `protos` symlink, which cargo does not follow. So the generated code went stale silently, on
+    // every platform, until something unrelated happened to force a rebuild.
+    for file in &proto_files {
+        println!("cargo:rerun-if-changed={file}");
+    }
+    // The symlink itself, so that repointing it counts as a change too.
+    println!("cargo:rerun-if-changed=protos");
+    println!("cargo:rerun-if-changed=build.rs");
+
     tonic_prost_build::configure()
         .use_arc_self(true)
         .build_client(cfg!(feature = "_gen-client"))
         .build_server(cfg!(feature = "_gen-server"))
-        .compile_protos(
-            &[
-                "protos/V1/agent_common.proto",
-                "protos/V1/agent_service.proto",
-                "protos/V1/applications_common.proto",
-                "protos/V1/applications_fields.proto",
-                "protos/V1/applications_filters.proto",
-                "protos/V1/applications_service.proto",
-                "protos/V1/auth_common.proto",
-                "protos/V1/auth_service.proto",
-                "protos/V1/events_common.proto",
-                "protos/V1/events_service.proto",
-                "protos/V1/filters_common.proto",
-                "protos/V1/objects.proto",
-                "protos/V1/health_checks_common.proto",
-                "protos/V1/health_checks_service.proto",
-                "protos/V1/partitions_common.proto",
-                "protos/V1/partitions_fields.proto",
-                "protos/V1/partitions_filters.proto",
-                "protos/V1/partitions_service.proto",
-                "protos/V1/result_status.proto",
-                "protos/V1/results_common.proto",
-                "protos/V1/results_fields.proto",
-                "protos/V1/results_filters.proto",
-                "protos/V1/results_service.proto",
-                "protos/V1/session_status.proto",
-                "protos/V1/sessions_common.proto",
-                "protos/V1/sessions_fields.proto",
-                "protos/V1/sessions_filters.proto",
-                "protos/V1/sessions_service.proto",
-                "protos/V1/sort_direction.proto",
-                "protos/V1/submitter_common.proto",
-                "protos/V1/submitter_service.proto",
-                "protos/V1/task_status.proto",
-                "protos/V1/tasks_common.proto",
-                "protos/V1/tasks_fields.proto",
-                "protos/V1/tasks_filters.proto",
-                "protos/V1/tasks_service.proto",
-                "protos/V1/versions_common.proto",
-                "protos/V1/versions_service.proto",
-                "protos/V1/worker_common.proto",
-                "protos/V1/worker_service.proto",
-            ],
-            &["protos/V1"],
-        )?;
+        // Both slices have to hold the same type, and `proto_files` is `Vec<String>`.
+        .compile_protos(&proto_files, &[String::from(PROTO_ROOT)])?;
     Ok(())
 }


### PR DESCRIPTION
`packages/rust/armonik/build.rs` declares no `cargo:rerun-if-changed`. With none declared, cargo re-runs the
build script whenever anything in the crate changes, so editing a test file re-runs `protoc` over all forty
protos and rebuilds the library.

Measured from a settled baseline:

|                        | before | after |
|------------------------|--------|-------|
| touch a `.proto`       | rebuilds | rebuilds |
| touch `tests/agent.rs` | rebuilds the library | does not |

The forty file names become a `const` array joined onto a `PROTO_ROOT`, because the paths are needed twice
now: once for the `rerun-if-changed` lines, once for `compile_protos`.

Nothing else changes. Same protos, same options, identical generated code.

Note that declared dependencies replace cargo's fallback rather than adding to it, so `PROTO_FILES` is now
load-bearing for rebuild decisions as well as for compilation. A proto missing from that list was never
compiled anyway.

Verified with `cargo build --all --locked`, `cargo fmt --all --check`, `cargo doc` and
`cargo clippy --all --no-deps -- -Dwarnings -Dunused-crate-dependencies`, all clean.
