### PR TITLE
test(rust): run the workspace tests with every feature on

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,12 +59,12 @@ jobs:
             env: {}
           - lang: Rust
             toolchain: stable
-            cmd: cargo test --locked --workspace
+            cmd: cargo test --locked --workspace --all-features
             dir: rust
             env: {}
           - lang: Rust
             toolchain: nightly
-            cmd: cargo test --locked --workspace
+            cmd: cargo test --locked --workspace --all-features
             dir: rust
             env: {}
         plateform:

--- a/packages/rust/armonik/Cargo.toml
+++ b/packages/rust/armonik/Cargo.toml
@@ -53,6 +53,8 @@ tokio = { workspace = true, features = [
   "macros",
   "sync",
   "time",
+  # `test-util` for the paused clock the cancellation tests run on.
+  "test-util",
 ] }
 tokio-util.workspace = true
 

--- a/packages/rust/armonik/tests/results.rs
+++ b/packages/rust/armonik/tests/results.rs
@@ -459,7 +459,7 @@ async fn upload() {
 
 // Cancellations
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn get_wait() {
     let cancellation_token = tokio_util::sync::CancellationToken::new();
     let mut client = armonik::Client::with_channel(
@@ -490,7 +490,7 @@ async fn get_wait() {
     }
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn download_wait_early() {
     let cancellation_token = tokio_util::sync::CancellationToken::new();
     let mut client = armonik::Client::with_channel(
@@ -523,7 +523,7 @@ async fn download_wait_early() {
     }
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn download_wait_late() {
     let cancellation_token = tokio_util::sync::CancellationToken::new();
     let mut client = armonik::Client::with_channel(
@@ -555,7 +555,7 @@ async fn download_wait_late() {
     }
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn upload_wait_early() {
     let cancellation_token = tokio_util::sync::CancellationToken::new();
     let mut client = armonik::Client::with_channel(
@@ -591,7 +591,7 @@ async fn upload_wait_early() {
     }
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn upload_wait_late() {
     let cancellation_token = tokio_util::sync::CancellationToken::new();
     let mut client = armonik::Client::with_channel(


### PR DESCRIPTION
The Rust legs of `test.yml` run `cargo test --locked --workspace`, which builds the default features:
`client` for `armonik`, and none at all for `armonik-transport`. Diffing `cargo test -- --list` between
that and `--all-features` gives **128 tests against 211**. Eighty-three have never run in CI: the server,
agent and worker suite among them, and everything behind `serde`. `clippy --workspace --all-features` in
`ci.yml` is the only thing that reaches that code, and clippy compiles without executing.

## Description

`--all-features` on both Rust legs.

Two of the tests that this starts running fail. Five cancellation tests in `armonik/tests/results.rs` time
their assertions off the real clock and lose that bet under parallelism; they now run on tokio's paused
clock, which is what brings `test-util` into the dev features. The commit message carries the failure as it
read, and the check that a paused clock leaves those assertions biting.

## Testing

`cargo test --locked --workspace --all-features --no-fail-fast -- --skip client::` gives 97 passing, and
the `results` target passes five runs in a row.

The `client::` tests want the ArmoniK mock server, which CI provides and my machine does not. They are the
one thing this pull request's own run verifies rather than me.

## Impact

CI only. The Rust legs compile more, since the server codegen is now built where it was skipped, and run 83
tests more.

`Cargo.lock` is unchanged: `test-util` brings no new dependency, and `--locked` accepted it.
