### PR TITLE
refactor(rust): let armonik load the options, and the transport receive them

### DIFF
--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -19,7 +19,7 @@ pub enum ProxySource {
     /// `HTTP_PROXY` and `NO_PROXY`, in either case, with `NO_PROXY` matched as curl matches it.
     ///
     /// Read once, when `connect` builds the channel, so one that reconnects keeps the values it
-    /// started with. Every other option is read in [`ClientConfigArgs::from_env`].
+    /// started with. This is the one value this crate goes looking for; every other is handed to it.
     System,
     /// Use this specific proxy.
     Explicit(Uri),
@@ -189,10 +189,11 @@ impl Clone for ClientConfig {
     }
 }
 
-/// Options for creating a gRPC Client (as given in the environment)
+/// Options for creating a gRPC Client, in the string form a caller supplies them in
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[non_exhaustive]
+// Deliberately exhaustive, unlike the configuration it becomes: this is what a caller fills in, and a
+// caller that cannot name every field cannot be told by the compiler when a new one appears.
 pub struct ClientConfigArgs {
     /// Endpoint for sending requests
     pub endpoint: String,
@@ -271,45 +272,7 @@ pub struct ClientConfigArgs {
     pub reuse_ports: Option<bool>,
 }
 
-impl ClientConfigArgs {
-    pub fn from_env() -> Result<Self, ConfigError> {
-        use crate::utils::{read_env, read_env_bool};
-        let ctx = EnvSnafu {};
-        Ok(Self {
-            endpoint: read_env("GrpcClient__Endpoint").context(ctx)?,
-            cert_pem: read_env("GrpcClient__CertPem").context(ctx)?,
-            key_pem: read_env("GrpcClient__KeyPem").context(ctx)?,
-            ca_cert: read_env("GrpcClient__CaCert").context(ctx)?,
-            allow_unsafe_connection: read_env_bool("GrpcClient__AllowUnsafeConnection")
-                .context(ctx)?,
-            override_target_name: read_env("GrpcClient__OverrideTargetName").context(ctx)?,
-            connect_timeout: read_env("GrpcClient__ConnectTimeout").context(ctx)?,
-            timeout: read_env("GrpcClient__Timeout").context(ctx)?,
-            rate_limit: read_env("GrpcClient__RateLimit").context(ctx)?,
-            tcp_keepalive: read_env("GrpcClient__TcpKeepalive").context(ctx)?,
-            tcp_keepalive_interval: read_env("GrpcClient__TcpKeepaliveInterval").context(ctx)?,
-            tcp_keepalive_retries: read_env("GrpcClient__TcpKeepaliveRetries").context(ctx)?,
-            tcp_nagle_algorithm: read_env_bool("GrpcClient__TcpNagleAlgorithm").context(ctx)?,
-            http2_keep_alive_interval: read_env("GrpcClient__Http2KeepAliveInterval")
-                .context(ctx)?,
-            http2_keep_alive_timeout: read_env("GrpcClient__Http2KeepAliveTimeout").context(ctx)?,
-            http2_keep_alive_while_idle: read_env_bool("GrpcClient__Http2KeepAliveWhileIdle")
-                .context(ctx)?,
-            http2_max_header_list_size: read_env("GrpcClient__Http2MaxHeaderListSize")
-                .context(ctx)?,
-            user_agent: read_env("GrpcClient__UserAgent").context(ctx)?,
-            proxy: read_env("GrpcClient__Proxy").context(ctx)?,
-            proxy_username: read_env("GrpcClient__ProxyUsername").context(ctx)?,
-            proxy_password: read_env("GrpcClient__ProxyPassword").context(ctx)?.into(),
-            reuse_ports: crate::utils::read_env_bool_opt("GrpcClient__ReusePorts").context(ctx)?,
-        })
-    }
-}
-
 impl ClientConfig {
-    pub fn from_env() -> Result<Self, ConfigError> {
-        Self::from_config_args(ClientConfigArgs::from_env()?)
-    }
     pub fn from_config_args(args: ClientConfigArgs) -> Result<Self, ConfigError> {
         let _span = tracing::debug_span!(
             "ClientConfig",
@@ -376,7 +339,7 @@ impl ClientConfig {
         // Read client cert and key files
         let identity = match (cert_path.as_str(), key_path.as_str()) {
             ("", "") => None,
-            ("", _) | (_, "") => return IncompatibleOptionsSnafu{msg: format!("`GrpcClient__CertPem={cert_path}` and `GrpcClient__KeyPem={key_path}` must be either both empty or both set")}.fail(),
+            ("", _) | (_, "") => return IncompatibleOptionsSnafu{msg: format!("`cert_pem={cert_path}` and `key_pem={key_path}` must be either both empty or both set")}.fail(),
             (cert_path, key_path) => {
                 let cert_pem =
                     std::fs::read_to_string(cert_path).context(IoSnafu { path: cert_path })?;
@@ -435,6 +398,7 @@ impl ClientConfig {
                 connect_timeout
                     .parse::<humantime::Duration>()
                     .context(InvalidDurationSnafu {
+                        option: "connect_timeout",
                         value: connect_timeout,
                     })?
                     .into(),
@@ -447,7 +411,10 @@ impl ClientConfig {
             Some(
                 timeout
                     .parse::<humantime::Duration>()
-                    .context(InvalidDurationSnafu { value: timeout })?
+                    .context(InvalidDurationSnafu {
+                        option: "timeout",
+                        value: timeout,
+                    })?
                     .into(),
             )
         };
@@ -469,6 +436,7 @@ impl ClientConfig {
             let duration: Duration = parts[1]
                 .parse::<humantime::Duration>()
                 .context(InvalidDurationSnafu {
+                    option: "rate_limit",
                     value: rate_limit.clone(),
                 })?
                 .into();
@@ -477,7 +445,7 @@ impl ClientConfig {
             if limit == 0 || duration.is_zero() {
                 return IncompatibleOptionsSnafu {
                     msg: format!(
-                        "`GrpcClient__RateLimit={rate_limit}` has a zero count or duration. Both have \
+                        "`rate_limit={rate_limit}` has a zero count or duration. Both have \
                          to be above zero, as in `100/1s`; leave it empty for no rate limit"
                     ),
                 }
@@ -493,6 +461,7 @@ impl ClientConfig {
                 tcp_keepalive
                     .parse::<humantime::Duration>()
                     .context(InvalidDurationSnafu {
+                        option: "tcp_keepalive",
                         value: tcp_keepalive,
                     })?
                     .into(),
@@ -506,6 +475,7 @@ impl ClientConfig {
                 tcp_keepalive_interval
                     .parse::<humantime::Duration>()
                     .context(InvalidDurationSnafu {
+                        option: "tcp_keepalive_interval",
                         value: tcp_keepalive_interval,
                     })?
                     .into(),
@@ -531,6 +501,7 @@ impl ClientConfig {
                 http2_keep_alive_interval
                     .parse::<humantime::Duration>()
                     .context(InvalidDurationSnafu {
+                        option: "http2_keep_alive_interval",
                         value: http2_keep_alive_interval,
                     })?
                     .into(),
@@ -544,6 +515,7 @@ impl ClientConfig {
                 http2_keep_alive_timeout
                     .parse::<humantime::Duration>()
                     .context(InvalidDurationSnafu {
+                        option: "http2_keep_alive_timeout",
                         value: http2_keep_alive_timeout,
                     })?
                     .into(),
@@ -616,7 +588,7 @@ impl ClientConfig {
     }
 }
 
-/// Interpret the `GrpcClient__Proxy` value.
+/// Interpret the `proxy` value.
 ///
 /// As ArmoniK's other clients spell it: empty is a direct connection, `none` disables proxying,
 /// `system` reads the environment, anything else is a proxy URL, defaulting to the `http` scheme.
@@ -644,7 +616,7 @@ fn parse_proxy_source(proxy: &str) -> Result<ProxySource, ConfigError> {
                     IncompatibleOptionsSnafu {
                         msg: format!(
                             "The `CONNECT` handshake is written in the clear, so only an `http` \
-                             proxy can be reached, and `GrpcClient__Proxy={}` names another scheme",
+                             proxy can be reached, and `proxy={}` names another scheme",
                             crate::proxy::elide_userinfo(proxy)
                         ),
                     }
@@ -654,7 +626,7 @@ fn parse_proxy_source(proxy: &str) -> Result<ProxySource, ConfigError> {
                 None => IncompatibleOptionsSnafu {
                     // Elided: a URL rejected for having no host can still have carried a password.
                     msg: format!(
-                        "`GrpcClient__Proxy={}` is not a valid proxy URL. Expected `none`, \
+                        "`proxy={}` is not a valid proxy URL. Expected `none`, \
                          `system`, or a URL such as `http://proxy.example.com:3128`",
                         crate::proxy::elide_userinfo(proxy)
                     ),
@@ -676,14 +648,6 @@ impl TryFrom<&ClientConfig> for tonic::transport::Endpoint {
 #[derive(Debug, Snafu)]
 #[non_exhaustive]
 pub enum ConfigError {
-    #[snafu(display("Could not read environment variable [{location}]"))]
-    #[non_exhaustive]
-    Env {
-        #[snafu(source(from(crate::utils::ReadEnvError, Box::new)))]
-        source: Box<crate::utils::ReadEnvError>,
-        #[snafu(implicit)]
-        location: snafu::Location,
-    },
     #[snafu(display("Invalid TLS configuration [{location}]"))]
     #[non_exhaustive]
     Tls {
@@ -727,10 +691,13 @@ pub enum ConfigError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
-    #[snafu(display("`GrpcClient__ConnectTimeout={value}` is not a valid duration (e.g. `30s` or `1m`) [{location}]"))]
+    #[snafu(display(
+        "`{option}={value}` is not a valid duration (e.g. `30s` or `1m`) [{location}]"
+    ))]
     #[non_exhaustive]
     InvalidDuration {
         source: humantime::DurationError,
+        option: &'static str,
         value: String,
         #[snafu(implicit)]
         location: snafu::Location,
@@ -980,8 +947,8 @@ mod tests {
                 "{error:?}"
             );
             let rendered = chain(&error);
-            assert!(rendered.contains("GrpcClient__CertPem"), "{rendered}");
-            assert!(rendered.contains("GrpcClient__KeyPem"), "{rendered}");
+            assert!(rendered.contains("cert_pem"), "{rendered}");
+            assert!(rendered.contains("key_pem"), "{rendered}");
         }
     }
 

--- a/packages/rust/armonik-transport/src/connect.rs
+++ b/packages/rust/armonik-transport/src/connect.rs
@@ -96,7 +96,7 @@ pub async fn https_connector(
         // Do not verify the server
         tls_config
             .dangerous()
-            .with_custom_certificate_verifier(Arc::new(crate::utils::InsecureCertVerifier))
+            .with_custom_certificate_verifier(Arc::new(InsecureCertVerifier))
     } else if let Some(cacert) = config.cacert {
         // Verify that the server certificate is signed with a specific CA cert
         let mut root_cert_store = rustls::RootCertStore::empty();
@@ -143,7 +143,59 @@ pub async fn https_connector(
     Ok(https.enable_http1().enable_http2().wrap_connector(http))
 }
 
-/// Everything that can go wrong between a [`ClientConfig`] and a usable channel.
+/// Accepts any certificate, which is what `allow_unsafe_connection` asks for.
+#[derive(Debug)]
+pub(crate) struct InsecureCertVerifier;
+
+impl rustls::client::danger::ServerCertVerifier for InsecureCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        vec![
+            rustls::SignatureScheme::RSA_PKCS1_SHA1,
+            rustls::SignatureScheme::ECDSA_SHA1_Legacy,
+            rustls::SignatureScheme::RSA_PKCS1_SHA256,
+            rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
+            rustls::SignatureScheme::RSA_PKCS1_SHA384,
+            rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
+            rustls::SignatureScheme::RSA_PKCS1_SHA512,
+            rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
+            rustls::SignatureScheme::RSA_PSS_SHA256,
+            rustls::SignatureScheme::RSA_PSS_SHA384,
+            rustls::SignatureScheme::RSA_PSS_SHA512,
+            rustls::SignatureScheme::ED25519,
+            rustls::SignatureScheme::ED448,
+        ]
+    }
+}
+
 #[derive(Debug, Snafu)]
 #[non_exhaustive]
 // snafu keeps its generated context selectors module-private by default. Public so that a caller in

--- a/packages/rust/armonik-transport/src/lib.rs
+++ b/packages/rust/armonik-transport/src/lib.rs
@@ -3,23 +3,22 @@
 //! Configuration parsing, TLS and mTLS: what it takes to turn an endpoint into a connected channel.
 //! Depending on this alone leaves protobuf codegen, and the `protoc` a build script would need, out of
 //! the build.
+//!
+//! A caller hands over a [`ClientConfigArgs`], filled in from wherever it keeps its settings. Nothing
+//! here reads an environment variable or a file of options: where the values come from is the business
+//! of whoever knows what the deployment looks like. The exception is `ProxySource::System`, which is
+//! the `*_PROXY` convention every HTTP client obeys rather than a setting of ArmoniK's.
 
 mod config;
 mod connect;
 mod proxy;
 mod secret;
 mod tcp;
-mod utils;
 
 pub use config::{ClientConfig, ClientConfigArgs, ConfigError, ProxyConfig, ProxySource};
 pub use connect::{connect, https_connector, ConnectionError};
 pub use proxy::ProxyError;
 pub use secret::Secret;
-// Snafu's context selectors, so a caller in another crate can build the error with the location
-// captured at its own call site. Hidden: this is how the error is built, not API to design against.
-#[doc(hidden)]
-pub use connect::{ConfigSnafu, IoSnafu, TlsSnafu, TransportSnafu};
-pub use utils::ReadEnvError;
 
 /// Re-exports of this crate's own dependencies, at the versions it was built with.
 ///

--- a/packages/rust/armonik-transport/src/proxy.rs
+++ b/packages/rust/armonik-transport/src/proxy.rs
@@ -280,8 +280,8 @@ pub enum ProxyError {
         location: snafu::Location,
     },
     #[snafu(display(
-        "The proxy requires authentication; set `GrpcClient__ProxyUsername` and \
-         `GrpcClient__ProxyPassword` [{location}]"
+        "The proxy requires authentication, and the configuration carries no credentials \
+         [{location}]"
     ))]
     #[non_exhaustive]
     AuthenticationRequired {

--- a/packages/rust/armonik-transport/tests/common/mod.rs
+++ b/packages/rust/armonik-transport/tests/common/mod.rs
@@ -165,8 +165,8 @@ pub async fn call(
 /// Build a [`ClientConfig`] from the string form, applying `set` to the arguments first.
 ///
 /// Going through `ClientConfigArgs` keeps the parsing inside what is under test. It is a helper at all
-/// because both structs are `#[non_exhaustive]`: a test outside the crate cannot write either as a
-/// struct expression, and `..Default::default()` is the form that is forbidden.
+/// because `ClientConfig` is `#[non_exhaustive]`: a test outside the crate cannot write it as a struct
+/// expression, and `..Default::default()` is the form that is forbidden.
 #[allow(clippy::field_reassign_with_default)]
 pub fn config(
     endpoint: &str,

--- a/packages/rust/armonik-transport/tests/proxy.rs
+++ b/packages/rust/armonik-transport/tests/proxy.rs
@@ -249,16 +249,16 @@ async fn a_missing_credential_is_reported_as_such() {
         .await
         .expect_err("the proxy should have refused the tunnel");
 
-    // The message has to name the options to set, otherwise a 407 is a dead end for whoever hits
-    // it.
+    // The message has to say what is missing, otherwise a 407 is a dead end for whoever hits it.
+    // Which option supplies it is the caller's vocabulary, not this crate's.
     let rendered = error_chain(error.as_ref());
     assert!(
         rendered.contains("requires authentication"),
         "unexpected error: {rendered}"
     );
     assert!(
-        rendered.contains("GrpcClient__ProxyUsername"),
-        "the error should say which options to set: {rendered}"
+        rendered.contains("no credentials"),
+        "the error should say what is missing: {rendered}"
     );
     assert_eq!(stats.rejected.load(Ordering::SeqCst), 1);
     assert_eq!(stats.tunnels.load(Ordering::SeqCst), 0);
@@ -335,8 +335,8 @@ async fn system_mode_takes_the_proxy_from_the_environment() {
     let (proxy, stats) = spawn_proxy(ProxyAuth::None).await;
 
     // The variable has to still be set when `connect` runs, not merely when the configuration is
-    // built: `system` resolves the environment as the connection is made. Every other option is read
-    // once, in `ClientConfigArgs::from_env`.
+    // built: `system` resolves the environment as the connection is made. Every other option is
+    // fixed once the configuration is built.
     std::env::set_var("HTTP_PROXY", format!("http://{proxy}"));
     let outcome = call_through(common::config(&server, |args| {
         args.proxy = String::from("system")

--- a/packages/rust/armonik/src/client/env.rs
+++ b/packages/rust/armonik/src/client/env.rs
@@ -1,7 +1,61 @@
-//! Reading configuration from the environment, and the one deliberately-insecure certificate
-//! verifier that `allow_unsafe_connection` selects.
+//! Building a client configuration out of the `GrpcClient__*` environment variables.
+//!
+//! This is integration with a deployment, not transport: `armonik-transport` takes the configuration
+//! it is handed and never goes looking for one, so the vocabulary of ArmoniK's options and the reading
+//! of them live here, in the crate that knows what a deployment looks like.
 
-use snafu::Snafu;
+use snafu::{ResultExt, Snafu};
+
+use super::{ClientConfig, ClientConfigArgs, ConfigError, ConnectionError};
+
+/// Loading a value from the environment.
+///
+/// An extension trait because the types belong to `armonik-transport`, where an inherent method would
+/// have to live and does not belong.
+pub trait FromEnv: Sized {
+    /// Read every `GrpcClient__*` variable this type understands.
+    fn from_env() -> Result<Self, EnvConfigError>;
+}
+
+impl FromEnv for ClientConfigArgs {
+    fn from_env() -> Result<Self, EnvConfigError> {
+        let ctx = ReadSnafu {};
+        Ok(Self {
+            endpoint: read_env("GrpcClient__Endpoint").context(ctx)?,
+            cert_pem: read_env("GrpcClient__CertPem").context(ctx)?,
+            key_pem: read_env("GrpcClient__KeyPem").context(ctx)?,
+            ca_cert: read_env("GrpcClient__CaCert").context(ctx)?,
+            allow_unsafe_connection: read_env_bool("GrpcClient__AllowUnsafeConnection")
+                .context(ctx)?,
+            override_target_name: read_env("GrpcClient__OverrideTargetName").context(ctx)?,
+            connect_timeout: read_env("GrpcClient__ConnectTimeout").context(ctx)?,
+            timeout: read_env("GrpcClient__Timeout").context(ctx)?,
+            rate_limit: read_env("GrpcClient__RateLimit").context(ctx)?,
+            tcp_keepalive: read_env("GrpcClient__TcpKeepalive").context(ctx)?,
+            tcp_keepalive_interval: read_env("GrpcClient__TcpKeepaliveInterval").context(ctx)?,
+            tcp_keepalive_retries: read_env("GrpcClient__TcpKeepaliveRetries").context(ctx)?,
+            tcp_nagle_algorithm: read_env_bool("GrpcClient__TcpNagleAlgorithm").context(ctx)?,
+            http2_keep_alive_interval: read_env("GrpcClient__Http2KeepAliveInterval")
+                .context(ctx)?,
+            http2_keep_alive_timeout: read_env("GrpcClient__Http2KeepAliveTimeout").context(ctx)?,
+            http2_keep_alive_while_idle: read_env_bool("GrpcClient__Http2KeepAliveWhileIdle")
+                .context(ctx)?,
+            http2_max_header_list_size: read_env("GrpcClient__Http2MaxHeaderListSize")
+                .context(ctx)?,
+            user_agent: read_env("GrpcClient__UserAgent").context(ctx)?,
+            proxy: read_env("GrpcClient__Proxy").context(ctx)?,
+            proxy_username: read_env("GrpcClient__ProxyUsername").context(ctx)?,
+            proxy_password: read_env("GrpcClient__ProxyPassword").context(ctx)?.into(),
+            reuse_ports: read_env_bool_opt("GrpcClient__ReusePorts").context(ctx)?,
+        })
+    }
+}
+
+impl FromEnv for ClientConfig {
+    fn from_env() -> Result<Self, EnvConfigError> {
+        Self::from_config_args(ClientConfigArgs::from_env()?).context(InvalidSnafu {})
+    }
+}
 
 pub(crate) fn read_env(name: &str) -> Result<String, ReadEnvError> {
     match std::env::var(name) {
@@ -40,6 +94,54 @@ pub(crate) fn read_env_bool_opt(name: &str) -> Result<Option<bool>, ReadEnvError
     }
 }
 
+/// Turning the environment into a client configuration.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+#[snafu(visibility(pub))]
+pub enum EnvConfigError {
+    #[snafu(display("Could not read a `GrpcClient__*` environment variable [{location}]"))]
+    #[non_exhaustive]
+    Read {
+        #[snafu(source(from(ReadEnvError, Box::new)))]
+        source: Box<ReadEnvError>,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display(
+        "The environment does not describe a valid client configuration [{location}]"
+    ))]
+    #[non_exhaustive]
+    Invalid {
+        #[snafu(source(from(ConfigError, Box::new)))]
+        source: Box<ConfigError>,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+/// Creating a client from the environment.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+#[snafu(visibility(pub))]
+pub enum NewClientError {
+    #[snafu(display("Could not read the client configuration [{location}]"))]
+    #[non_exhaustive]
+    Config {
+        #[snafu(source(from(EnvConfigError, Box::new)))]
+        source: Box<EnvConfigError>,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("Could not connect with that configuration [{location}]"))]
+    #[non_exhaustive]
+    Connect {
+        #[snafu(source(from(ConnectionError, Box::new)))]
+        source: Box<ConnectionError>,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
 #[derive(Debug, Snafu)]
 #[non_exhaustive]
 pub enum ReadEnvError {
@@ -63,58 +165,6 @@ pub enum ReadEnvError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
-}
-
-#[derive(Debug)]
-pub(crate) struct InsecureCertVerifier;
-
-impl rustls::client::danger::ServerCertVerifier for InsecureCertVerifier {
-    fn verify_server_cert(
-        &self,
-        _end_entity: &rustls::pki_types::CertificateDer<'_>,
-        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
-        _server_name: &rustls::pki_types::ServerName<'_>,
-        _ocsp_response: &[u8],
-        _now: rustls::pki_types::UnixTime,
-    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-        Ok(rustls::client::danger::ServerCertVerified::assertion())
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        _message: &[u8],
-        _cert: &rustls::pki_types::CertificateDer<'_>,
-        _dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        _message: &[u8],
-        _cert: &rustls::pki_types::CertificateDer<'_>,
-        _dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        vec![
-            rustls::SignatureScheme::RSA_PKCS1_SHA1,
-            rustls::SignatureScheme::ECDSA_SHA1_Legacy,
-            rustls::SignatureScheme::RSA_PKCS1_SHA256,
-            rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
-            rustls::SignatureScheme::RSA_PKCS1_SHA384,
-            rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
-            rustls::SignatureScheme::RSA_PKCS1_SHA512,
-            rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
-            rustls::SignatureScheme::RSA_PSS_SHA256,
-            rustls::SignatureScheme::RSA_PSS_SHA384,
-            rustls::SignatureScheme::RSA_PSS_SHA512,
-            rustls::SignatureScheme::ED25519,
-            rustls::SignatureScheme::ED448,
-        ]
-    }
 }
 
 #[cfg(test)]
@@ -217,5 +267,20 @@ mod tests {
             read_env("ARMONIK_TEST_STRING")
         });
         assert_eq!(absent.expect("unset"), "", "absent reads as empty");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn the_endpoint_reaches_the_configuration() {
+        // The one test that the whole chain is wired: a variable set here comes out of
+        // `from_config_args` as a parsed endpoint.
+        let config = with_var(
+            "GrpcClient__Endpoint",
+            Some("http://localhost:5001"),
+            ClientConfig::from_env,
+        )
+        .expect("a lone endpoint is a valid configuration");
+
+        assert_eq!(config.endpoint.to_string(), "http://localhost:5001/");
     }
 }

--- a/packages/rust/armonik/src/client/env.rs
+++ b/packages/rust/armonik/src/client/env.rs
@@ -171,16 +171,33 @@ pub enum ReadEnvError {
 mod tests {
     use super::*;
 
-    /// A variable name of its own per test, so that a stray value cannot leak between them even though
-    /// they are serialised.
+    /// Puts back what the variable held, rather than removing it: these tests run in a process whose
+    /// environment may already carry a `GrpcClient__*` that other tests need. On drop, so that a
+    /// failing test does not take it away from them either.
+    struct Restore {
+        name: String,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(previous) => std::env::set_var(&self.name, previous),
+                None => std::env::remove_var(&self.name),
+            }
+        }
+    }
+
     fn with_var<T>(name: &str, value: Option<&str>, body: impl FnOnce() -> T) -> T {
+        let _restore = Restore {
+            name: name.to_owned(),
+            previous: std::env::var_os(name),
+        };
         match value {
             Some(value) => std::env::set_var(name, value),
             None => std::env::remove_var(name),
         }
-        let outcome = body();
-        std::env::remove_var(name);
-        outcome
+        body()
     }
 
     #[test]
@@ -271,16 +288,18 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn the_endpoint_reaches_the_configuration() {
-        // The one test that the whole chain is wired: a variable set here comes out of
-        // `from_config_args` as a parsed endpoint.
-        let config = with_var(
-            "GrpcClient__Endpoint",
-            Some("http://localhost:5001"),
-            ClientConfig::from_env,
+    fn a_variable_reaches_the_field_that_carries_it() {
+        // The drift-prone half of this module is the mapping from name to field, so that is what is
+        // checked. `UserAgent` on purpose: the tests that build a real client share this process and
+        // are not serialised against this one, so borrowing a variable any of them depends on, the
+        // endpoint above all, would send them somewhere else while this runs.
+        let args = with_var(
+            "GrpcClient__UserAgent",
+            Some("armonik-test/1"),
+            ClientConfigArgs::from_env,
         )
-        .expect("a lone endpoint is a valid configuration");
+        .expect("reading the environment must not fail");
 
-        assert_eq!(config.endpoint.to_string(), "http://localhost:5001/");
+        assert_eq!(args.user_agent, "armonik-test/1");
     }
 }

--- a/packages/rust/armonik/src/client/mod.rs
+++ b/packages/rust/armonik/src/client/mod.rs
@@ -5,12 +5,16 @@ use snafu::{ResultExt, Snafu};
 // Re-exported here, so a caller reaches them through the client rather than through the transport
 // crate.
 #[cfg(feature = "_gen-client")]
-use armonik_transport::ConfigSnafu;
-#[cfg(feature = "_gen-client")]
 pub use armonik_transport::{
     ClientConfig, ClientConfigArgs, ConfigError, ConnectionError, ProxyConfig, ProxyError,
-    ProxySource, ReadEnvError, Secret,
+    ProxySource, Secret,
 };
+
+/// Reading the `GrpcClient__*` variables, which is this crate's business rather than the transport's.
+#[cfg(feature = "_gen-client")]
+mod env;
+#[cfg(feature = "_gen-client")]
+pub use env::{EnvConfigError, FromEnv, NewClientError, ReadEnvError};
 
 #[cfg(feature = "worker")]
 mod agent;
@@ -71,8 +75,11 @@ pub struct Client<T = tonic::transport::Channel> {
 
 impl Client<tonic::transport::Channel> {
     /// Create a new client using the configuration from the environment variables
-    pub async fn new() -> Result<Self, ConnectionError> {
-        Self::with_config(ClientConfig::from_env().context(ConfigSnafu {})?).await
+    pub async fn new() -> Result<Self, NewClientError> {
+        let config = ClientConfig::from_env().context(env::ConfigSnafu {})?;
+        Self::with_config(config)
+            .await
+            .context(env::ConnectSnafu {})
     }
 
     /// Create a new client with the specified client configuration
@@ -96,7 +103,7 @@ impl Client<tonic::transport::Channel> {
         use http_body_util::BodyExt;
         use hyper_util::rt::TokioExecutor;
 
-        let mut config = ClientConfig::from_env().unwrap();
+        let mut config = <ClientConfig as FromEnv>::from_env().unwrap();
 
         match std::env::var("Http__Endpoint") {
             Ok(value) if !value.is_empty() => {


### PR DESCRIPTION
> Depends on #697, which is its base branch.

# Motivation

`armonik-transport` read `GrpcClient__*` out of the environment. Knowing where settings live is the job
of a component that knows what a deployment looks like, which in the Rust chain is `armonik`. The
transport should receive its options rather than go looking for them.

# Description

`ClientConfigArgs::from_env` and `ClientConfig::from_env` become a `FromEnv` extension trait in
`armonik`, with `read_env*` and `ReadEnvError`. A trait because the types stay in the transport, where an
inherent method would have to live. What remained of the transport's `utils` is one certificate verifier,
now beside its only user.

`ConfigError` loses its `Env` variant; `armonik` gains `EnvConfigError` and `NewClientError`. Error
messages name the field, `cert_pem` where they said `GrpcClient__CertPem`.

`#[non_exhaustive]` comes off `ClientConfigArgs`: a foreign crate cannot write a literal for such a
struct, and `Default` plus field assignment would let an option added in the transport go unread in
`armonik` without a word.

Two things the move turned up. `InvalidDuration` served seven duration fields while its message named
`GrpcClient__ConnectTimeout`, so a bad `Timeout` was reported against `ConnectTimeout`; the variant now
carries the option, which closes #698. And `ConfigSnafu`, `IoSnafu`, `TlsSnafu` and `TransportSnafu` were
exported for `Client::new` alone, which no longer needs them.

# Testing

`cargo test --workspace --all-features --no-fail-fast -- --skip client::` gives 153 passing. The
`client::` tests want the ArmoniK mock server, which CI provides and my machine does not. The reading of
the environment moved unchanged, which git shows as a rename; one new test carries a variable through to
a parsed endpoint, so the trait is wired and not merely present.

# Impact

Three breaking changes for a Rust caller, none for anything else. `Client::new` returns `NewClientError`
rather than `ConnectionError`, which belongs to the transport and is `#[non_exhaustive]`, so `armonik`
cannot express a reading failure through it. `ClientConfig::from_env` needs `use
armonik::client::FromEnv`. And adding an option to `ClientConfigArgs` becomes breaking where it used to
be additive, which is the point.

The transport still reads `HTTPS_PROXY` and `NO_PROXY` for `ProxySource::System`, the convention every
HTTP client obeys rather than ArmoniK's vocabulary.

# Additional Information

Nothing in `armonik-transport` now names ArmoniK except its own crate name: it could be published alone.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
