### PR TITLE
ci(rust): Enable windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,12 +79,6 @@ jobs:
               lang: C++
             plateform:
               os: windows-latest
-          # FIXME: Rust should be working on Windows,
-          # but we most likely encounter a port exhaustion issue
-          - language:
-              lang: Rust
-            plateform:
-              os: windows-latest
           - language:
               lang: C#
               dotnet: ''


### PR DESCRIPTION
# Motivation

A while back, windows tests were failing with an error that looked like a port exhaustion.
Now we have some use cases for a Windows Rust API that requires putting those tests back again.

# Description

Remove the windows tests from the exclude list.

# Testing

Windows test job has been repeated around 20 times without any error.

# Impact

There could be some regression in the pipelines even though none were observed during testing.
No user will be affected as it is a ci only change.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
