### PR TITLE
refactor(rust): group the config's flat fields into thematic units

### DIFF
--- a/packages/rust/Cargo.lock
+++ b/packages/rust/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +69,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "serde_with",
  "serial_test",
  "snafu",
  "tokio",
@@ -87,7 +97,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -98,7 +108,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -115,6 +125,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
@@ -172,6 +188,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +231,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +257,21 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -346,7 +404,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -414,12 +472,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -441,6 +505,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -569,6 +639,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +673,17 @@ name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -618,6 +723,17 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -712,6 +828,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,7 +897,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -783,7 +914,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -803,7 +934,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -813,13 +944,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -839,7 +976,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "version_check",
  "yansi",
 ]
@@ -871,7 +1008,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -885,7 +1022,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -939,6 +1076,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1045,12 +1202,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1124,7 +1311,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1138,6 +1325,25 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.2",
+ "serde_core",
+ "serde_json",
+ "time",
 ]
 
 [[package]]
@@ -1162,7 +1368,7 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1210,7 +1416,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1234,6 +1440,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1269,6 +1486,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,7 +1553,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1366,7 +1628,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1391,7 +1653,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn",
+ "syn 2.0.117",
  "tempfile",
  "tonic-build",
 ]
@@ -1404,7 +1666,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -1446,7 +1708,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1585,6 +1847,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,7 +1908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -1614,8 +1921,43 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1623,6 +1965,24 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1740,9 +2100,9 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1758,7 +2118,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1771,7 +2131,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -1790,7 +2150,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/packages/rust/Cargo.lock
+++ b/packages/rust/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "serde_with",
  "serial_test",
  "snafu",
+ "tempfile",
  "tokio",
  "tonic",
  "tower-service",

--- a/packages/rust/Cargo.toml
+++ b/packages/rust/Cargo.toml
@@ -40,6 +40,7 @@ secrecy = "0.10"
 # the `serde` feature would not compile.
 serde = { version = "1.0", features = ["derive", "std"], default-features = false }
 serde_json = "1"
+serde_with = { version = "3", default-features = false }
 serial_test = "3.5"
 snafu = "0.9"
 tokio = { version = "1.52", default-features = false }

--- a/packages/rust/Cargo.toml
+++ b/packages/rust/Cargo.toml
@@ -43,6 +43,7 @@ serde_json = "1"
 serde_with = { version = "3", default-features = false }
 serial_test = "3.5"
 snafu = "0.9"
+tempfile = "3"
 tokio = { version = "1.52", default-features = false }
 tokio-util = "0.7"
 tonic = { version = "0.14", default-features = false }

--- a/packages/rust/armonik-transport/Cargo.toml
+++ b/packages/rust/armonik-transport/Cargo.toml
@@ -68,11 +68,13 @@ tower-service.workspace = true
 secrecy.workspace = true
 
 [dev-dependencies]
-# `HttpConfigArgs::from_env`'s own tests set real environment variables to exercise it: process-global
-# state, hence one test at a time.
+# The boolean options are read straight from the environment, so testing which spellings they accept
+# means setting variables: process-global state, hence one test at a time.
 serial_test.workspace = true
 # Only to round-trip `HttpConfigArgs` in the test that pins the `serde` feature.
 serde_json.workspace = true
+# A real file for the certificate-loading tests to read: garbage content that is not a valid PEM.
+tempfile.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 # The integration tests serve a gRPC service to call, which the regular build never does; these features
 # union with the `channel`/`codegen` above for test builds only.

--- a/packages/rust/armonik-transport/Cargo.toml
+++ b/packages/rust/armonik-transport/Cargo.toml
@@ -11,7 +11,7 @@ version.workspace = true
 include = ["**/*.rs", "Cargo.toml", "README.md"]
 
 [features]
-serde = ["dep:serde"]
+serde = ["dep:serde", "dep:serde_with"]
 # Environment reading deserialises `HttpConfigArgs`, whose field names are fixed at compile time
 # (`#[serde(rename_all = "PascalCase")]`), so it needs the derive `serde` turns on, plus `figment`'s
 # own `env` feature for its `Env` provider.
@@ -48,6 +48,11 @@ hyper-rustls = { workspace = true, features = [
 ] }
 rustls = { workspace = true, features = ["ring", "logging", "std", "tls12"] }
 serde = { workspace = true, optional = true }
+# `with_prefix!`, for a group of args whose flat names already share a literal prefix (`Tcp*`): it
+# composes with `#[serde(flatten)]` to read the same environment variable names as today while
+# keeping the option's own definition in its own thematic file. `std` because `with_prefix!` is
+# gated behind it.
+serde_with = { workspace = true, optional = true, default-features = false, features = ["std"] }
 humantime.workspace = true
 # `Proxy-Authorization: Basic` needs it. Already in the tree through `tonic`, so declaring it adds
 # nothing to the build.

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -4,6 +4,9 @@ use hyper::{http::HeaderValue, Uri};
 use rustls::pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer};
 use snafu::{ResultExt, Snafu};
 
+#[cfg(feature = "serde")]
+use crate::http2_config::prefix_http2;
+use crate::http2_config::{Http2Config, Http2ConfigArgs};
 use crate::secret::Secret;
 #[cfg(feature = "serde")]
 use crate::tcp_config::prefix_tcp;
@@ -110,14 +113,8 @@ pub struct HttpConfig {
     pub rate_limit: Option<(u64, Duration)>,
     /// TCP-level socket options.
     pub tcp: TcpConfig,
-    /// HTTP/2 PING frame interval, defaults to no keepalive
-    pub http2_keep_alive_interval: Option<Duration>,
-    /// HTTP/2 PING timeout, defaults to no timeout
-    pub http2_keep_alive_timeout: Option<Duration>,
-    /// Send HTTP/2 keepalive PINGs even when idle, defaults to false
-    pub http2_keep_alive_while_idle: bool,
-    /// HTTP/2 max header list size in bytes, defaults to no limit
-    pub http2_max_header_list_size: Option<u32>,
+    /// HTTP/2-level transport options.
+    pub http2: Http2Config,
     /// User-Agent header value sent with each request
     pub user_agent: Option<HeaderValue>,
     /// HTTP proxy used to reach the endpoint, defaults to a direct connection
@@ -139,10 +136,7 @@ impl Clone for HttpConfig {
             timeout: self.timeout,
             rate_limit: self.rate_limit,
             tcp: self.tcp,
-            http2_keep_alive_interval: self.http2_keep_alive_interval,
-            http2_keep_alive_timeout: self.http2_keep_alive_timeout,
-            http2_keep_alive_while_idle: self.http2_keep_alive_while_idle,
-            http2_max_header_list_size: self.http2_max_header_list_size,
+            http2: self.http2,
             user_agent: self.user_agent.clone(),
             proxy: self.proxy.clone(),
         }
@@ -185,18 +179,9 @@ pub struct HttpConfigArgs {
     /// TCP-level socket options.
     #[cfg_attr(feature = "serde", serde(flatten, with = "prefix_tcp"))]
     pub tcp: TcpConfigArgs,
-    /// HTTP/2 PING frame interval (e.g. `20s`), defaults to no keepalive
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
-    pub http2_keep_alive_interval: String,
-    /// HTTP/2 PING timeout (e.g. `10s`), defaults to no timeout
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
-    pub http2_keep_alive_timeout: String,
-    /// Send HTTP/2 keepalive PINGs even when idle, empty for false
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
-    pub http2_keep_alive_while_idle: String,
-    /// HTTP/2 max header list size in bytes, defaults to no limit
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
-    pub http2_max_header_list_size: String,
+    /// HTTP/2-level transport options.
+    #[cfg_attr(feature = "serde", serde(flatten, with = "prefix_http2"))]
+    pub http2: Http2ConfigArgs,
     /// User-Agent header value sent with each request
     #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
     pub user_agent: String,
@@ -356,10 +341,10 @@ impl HttpConfig {
             args.tcp.keepalive_interval,
             args.tcp.keepalive_retries,
             args.tcp.nagle_algorithm,
-            args.http2_keep_alive_interval,
-            args.http2_keep_alive_timeout,
-            args.http2_keep_alive_while_idle,
-            args.http2_max_header_list_size,
+            args.http2.keep_alive_interval,
+            args.http2.keep_alive_timeout,
+            args.http2.keep_alive_while_idle,
+            args.http2.max_header_list_size,
             args.user_agent,
             // Elided, and `proxy_password` left out entirely: this span is recorded at debug level, and
             // a proxy URL carries credentials as often as the dedicated option does. Do not complete
@@ -379,10 +364,7 @@ impl HttpConfig {
             timeout,
             rate_limit,
             tcp,
-            http2_keep_alive_interval,
-            http2_keep_alive_timeout,
-            http2_keep_alive_while_idle,
-            http2_max_header_list_size,
+            http2,
             user_agent,
             proxy,
             proxy_username,
@@ -392,8 +374,7 @@ impl HttpConfig {
         let allow_unsafe_connection =
             parse_bool("allow_unsafe_connection", &allow_unsafe_connection)?;
         let tcp = tcp.resolve()?;
-        let http2_keep_alive_while_idle =
-            parse_bool("http2_keep_alive_while_idle", &http2_keep_alive_while_idle)?;
+        let http2 = http2.resolve()?;
 
         // Read CAcert file
         let cacert = if !cacert_path.is_empty() {
@@ -501,47 +482,6 @@ impl HttpConfig {
             Some((limit, duration))
         };
 
-        let http2_keep_alive_interval = if http2_keep_alive_interval.is_empty() {
-            None
-        } else {
-            Some(
-                http2_keep_alive_interval
-                    .parse::<humantime::Duration>()
-                    .context(InvalidDurationSnafu {
-                        option: "http2_keep_alive_interval",
-                        value: http2_keep_alive_interval,
-                    })?
-                    .into(),
-            )
-        };
-
-        let http2_keep_alive_timeout = if http2_keep_alive_timeout.is_empty() {
-            None
-        } else {
-            Some(
-                http2_keep_alive_timeout
-                    .parse::<humantime::Duration>()
-                    .context(InvalidDurationSnafu {
-                        option: "http2_keep_alive_timeout",
-                        value: http2_keep_alive_timeout,
-                    })?
-                    .into(),
-            )
-        };
-
-        let http2_max_header_list_size = if http2_max_header_list_size.is_empty() {
-            None
-        } else {
-            Some(
-                http2_max_header_list_size
-                    .parse::<u32>()
-                    .context(InvalidIntegerSnafu {
-                        option: "http2_max_header_list_size",
-                        value: http2_max_header_list_size,
-                    })?,
-            )
-        };
-
         let user_agent = if user_agent.is_empty() {
             None
         } else {
@@ -574,10 +514,7 @@ impl HttpConfig {
             timeout,
             rate_limit,
             tcp,
-            http2_keep_alive_interval,
-            http2_keep_alive_timeout,
-            http2_keep_alive_while_idle,
-            http2_max_header_list_size,
+            http2,
             user_agent,
             proxy,
         })
@@ -794,13 +731,16 @@ mod tests {
                     nagle_algorithm: String::from(spelling),
                     ..Default::default()
                 },
-                http2_keep_alive_while_idle: String::from(spelling),
+                http2: Http2ConfigArgs {
+                    keep_alive_while_idle: String::from(spelling),
+                    ..Default::default()
+                },
                 ..args()
             })
             .expect(spelling);
             assert!(config.allow_unsafe_connection, "{spelling}");
             assert!(config.tcp.nagle_algorithm, "{spelling}");
-            assert!(config.http2_keep_alive_while_idle, "{spelling}");
+            assert!(config.http2.keep_alive_while_idle, "{spelling}");
         }
 
         for spelling in ["0", "false", "no", "disable", "disallow", "forbid", ""] {
@@ -841,7 +781,10 @@ mod tests {
                 keepalive_interval: String::from("2m"),
                 ..Default::default()
             },
-            http2_keep_alive_interval: String::from("1h"),
+            http2: Http2ConfigArgs {
+                keep_alive_interval: String::from("1h"),
+                ..Default::default()
+            },
             ..args()
         })
         .expect("valid durations");
@@ -853,7 +796,7 @@ mod tests {
             Some(Duration::from_secs(120))
         );
         assert_eq!(
-            config.http2_keep_alive_interval,
+            config.http2.keep_alive_interval,
             Some(Duration::from_secs(3600))
         );
     }
@@ -883,12 +826,15 @@ mod tests {
                 keepalive_retries: String::from("3"),
                 ..Default::default()
             },
-            http2_max_header_list_size: String::from("16384"),
+            http2: Http2ConfigArgs {
+                max_header_list_size: String::from("16384"),
+                ..Default::default()
+            },
             ..args()
         })
         .expect("valid integers");
         assert_eq!(config.tcp.keepalive_retries, Some(3));
-        assert_eq!(config.http2_max_header_list_size, Some(16384));
+        assert_eq!(config.http2.max_header_list_size, Some(16384));
 
         let error = HttpConfig::from_config_args(HttpConfigArgs {
             tcp: TcpConfigArgs {
@@ -909,7 +855,10 @@ mod tests {
     fn an_integer_that_does_not_fit_is_rejected_rather_than_wrapped() {
         // These are `u32`; a value past the top must fail rather than silently become something else.
         let error = HttpConfig::from_config_args(HttpConfigArgs {
-            http2_max_header_list_size: String::from("4294967296"),
+            http2: Http2ConfigArgs {
+                max_header_list_size: String::from("4294967296"),
+                ..Default::default()
+            },
             ..args()
         })
         .expect_err("2^32 does not fit in a u32");

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -7,88 +7,12 @@ use snafu::{ResultExt, Snafu};
 #[cfg(feature = "serde")]
 use crate::http2_config::prefix_http2;
 use crate::http2_config::{Http2Config, Http2ConfigArgs};
+use crate::proxy_config::{ProxyConfig, ProxyConfigArgs};
+#[cfg(feature = "serde")]
 use crate::secret::Secret;
 #[cfg(feature = "serde")]
 use crate::tcp_config::prefix_tcp;
 use crate::tcp_config::{TcpConfig, TcpConfigArgs};
-
-/// Where to find the HTTP proxy used to reach the endpoint.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum ProxySource {
-    /// Connect directly, ignoring any proxy configured in the environment.
-    ///
-    /// The default: a client that asks for nothing connects directly.
-    #[default]
-    Disabled,
-    /// Read the proxy from the environment, on `hyper_util`'s rules: `ALL_PROXY`, `HTTPS_PROXY`,
-    /// `HTTP_PROXY` and `NO_PROXY`, in either case, with `NO_PROXY` matched as curl matches it.
-    ///
-    /// Read once, when `connect` builds the channel, so one that reconnects keeps the values it
-    /// started with. Every other option is read in [`HttpConfigArgs::from_env`].
-    System,
-    /// Use this specific proxy.
-    Explicit(Uri),
-}
-
-/// Configuration of the HTTP proxy used to reach the endpoint.
-///
-/// Proxying uses a `CONNECT` tunnel, so TLS, mutual TLS included, is negotiated end to end with the
-/// real server and the proxy never sees the plaintext.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct ProxyConfig {
-    /// Where to find the proxy.
-    pub source: ProxySource,
-    /// Username for proxy authentication, empty for none.
-    pub username: String,
-    /// Password for proxy authentication, empty for none.
-    pub password: Secret,
-}
-
-impl ProxyConfig {
-    /// Use this specific proxy.
-    ///
-    /// Credentials written into the URL are taken out of it and kept here, so the URI carries none
-    /// wherever it is rendered. The type is `#[non_exhaustive]`, so this is the way in.
-    pub fn explicit(uri: Uri) -> Self {
-        let (uri, credentials) = crate::proxy::split_credentials(uri);
-        let (username, password) = credentials.unwrap_or_default();
-        Self {
-            source: ProxySource::Explicit(uri),
-            username,
-            password: password.into(),
-        }
-    }
-
-    /// Read the proxy from the environment.
-    pub fn system() -> Self {
-        Self {
-            source: ProxySource::System,
-            ..Default::default()
-        }
-    }
-
-    /// Attach credentials for proxy authentication.
-    pub fn with_credentials(
-        mut self,
-        username: impl Into<String>,
-        password: impl Into<Secret>,
-    ) -> Self {
-        self.username = username.into();
-        self.password = password.into();
-        self
-    }
-
-    /// Credentials to present to the proxy, if any were configured.
-    pub fn credentials(&self) -> Option<(&str, &str)> {
-        if self.username.is_empty() && self.password.is_empty() {
-            None
-        } else {
-            Some((&self.username, self.password.expose_secret()))
-        }
-    }
-}
 
 /// Options for the HTTP/2 transport: TLS, proxy, and everything else `connect` needs to reach the
 /// endpoint.
@@ -185,25 +109,9 @@ pub struct HttpConfigArgs {
     /// User-Agent header value sent with each request
     #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
     pub user_agent: String,
-    /// HTTP proxy to reach the endpoint through.
-    ///
-    /// Empty for a direct connection, `none` to disable proxying explicitly, `system` to read the
-    /// environment (see [`ProxySource::System`]), otherwise the proxy URL, whose scheme has to be
-    /// `http`: the `CONNECT` handshake is written in the clear.
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
-    pub proxy: String,
-    /// Username for proxy authentication.
-    ///
-    /// Empty falls back to the username the `proxy` URL carried, if any.
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
-    pub proxy_username: String,
-    /// Password for proxy authentication.
-    ///
-    /// Empty falls back to the password the `proxy` URL carried, independently of the username, so
-    /// setting this one alone still uses that URL's username. Redacted wherever it is written; see
-    /// [`Secret`].
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "secret_text"))]
-    pub proxy_password: Secret,
+    /// HTTP proxy used to reach the endpoint: where to find it, and the dedicated credentials.
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    pub proxy: ProxyConfigArgs,
 }
 
 /// Reads a duration option, empty for `None`.
@@ -349,8 +257,8 @@ impl HttpConfig {
             // Elided, and `proxy_password` left out entirely: this span is recorded at debug level, and
             // a proxy URL carries credentials as often as the dedicated option does. Do not complete
             // the list.
-            proxy = %crate::proxy::elide_userinfo(&args.proxy),
-            args.proxy_username,
+            proxy = %crate::proxy::elide_userinfo(&args.proxy.source),
+            args.proxy.username,
         );
 
         let HttpConfigArgs {
@@ -367,8 +275,6 @@ impl HttpConfig {
             http2,
             user_agent,
             proxy,
-            proxy_username,
-            proxy_password,
         } = args;
 
         let allow_unsafe_connection =
@@ -473,7 +379,7 @@ impl HttpConfig {
             if limit == 0 || duration.is_zero() {
                 return IncompatibleOptionsSnafu {
                     msg: format!(
-                        "`GrpcClient__RateLimit={rate_limit}` has a zero count or duration. Both have \
+                        "`rate_limit={rate_limit}` has a zero count or duration. Both have \
                          to be above zero, as in `100/1s`; leave it empty for no rate limit"
                     ),
                 }
@@ -490,19 +396,7 @@ impl HttpConfig {
             Some(header)
         };
 
-        let mut proxy = match parse_proxy_source(&proxy)? {
-            // Through the constructor, so credentials written into the URL are taken out of it.
-            ProxySource::Explicit(uri) => ProxyConfig::explicit(uri),
-            ProxySource::System => ProxyConfig::system(),
-            ProxySource::Disabled => ProxyConfig::default(),
-        };
-        // See `crate::proxy::prefer_dedicated`.
-        let username = crate::proxy::prefer_dedicated(&proxy_username, &proxy.username).to_owned();
-        let password = Secret::from(crate::proxy::prefer_dedicated(
-            proxy_password.expose_secret(),
-            proxy.password.expose_secret(),
-        ));
-        proxy = proxy.with_credentials(username, password);
+        let proxy = proxy.resolve()?;
 
         Ok(Self {
             endpoint,
@@ -518,55 +412,6 @@ impl HttpConfig {
             user_agent,
             proxy,
         })
-    }
-}
-
-/// Interpret the `GrpcClient__Proxy` value.
-///
-/// As ArmoniK's other clients spell it: empty is a direct connection, `none` disables proxying,
-/// `system` reads the environment, anything else is a proxy URL, defaulting to the `http` scheme.
-fn parse_proxy_source(proxy: &str) -> Result<ProxySource, ConfigError> {
-    match proxy {
-        "" => Ok(ProxySource::Disabled),
-        _ if proxy.eq_ignore_ascii_case("none") => Ok(ProxySource::Disabled),
-        _ if proxy.eq_ignore_ascii_case("system") => Ok(ProxySource::System),
-        _ => {
-            let with_scheme = if proxy.contains("://") {
-                proxy.to_owned()
-            } else {
-                format!("http://{proxy}")
-            };
-            // Not reported through `UriSnafu`: its message names the endpoint, which would send
-            // whoever reads it looking at the wrong option.
-            let uri = Uri::try_from(&with_scheme).ok().filter(|uri| {
-                uri.authority()
-                    .is_some_and(|authority| !authority.host().is_empty())
-            });
-            match uri {
-                // Caught here rather than at connect time, so a mistyped option fails while the
-                // configuration is being read and names itself.
-                Some(uri) if uri.scheme_str().is_some_and(|scheme| scheme != "http") => {
-                    IncompatibleOptionsSnafu {
-                        msg: format!(
-                            "The `CONNECT` handshake is written in the clear, so only an `http` \
-                             proxy can be reached, and `GrpcClient__Proxy={}` names another scheme",
-                            crate::proxy::elide_userinfo(proxy)
-                        ),
-                    }
-                    .fail()
-                }
-                Some(uri) => Ok(ProxySource::Explicit(uri)),
-                None => IncompatibleOptionsSnafu {
-                    // Elided: a URL rejected for having no host can still have carried a password.
-                    msg: format!(
-                        "`GrpcClient__Proxy={}` is not a valid proxy URL. Expected `none`, \
-                         `system`, or a URL such as `http://proxy.example.com:3128`",
-                        crate::proxy::elide_userinfo(proxy)
-                    ),
-                }
-                .fail(),
-            }
-        }
     }
 }
 
@@ -676,6 +521,7 @@ pub enum ConfigError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::proxy_config::ProxySource;
 
     /// The minimum viable arguments: an endpoint, and nothing else set.
     fn args() -> HttpConfigArgs {
@@ -1100,7 +946,10 @@ mod tests {
     fn proxy_none_and_empty_disable_proxying() {
         for value in ["", "none", "None", "NONE"] {
             let config = HttpConfig::from_config_args(HttpConfigArgs {
-                proxy: String::from(value),
+                proxy: ProxyConfigArgs {
+                    source: String::from(value),
+                    ..Default::default()
+                },
                 ..args()
             })
             .expect("a valid configuration");
@@ -1116,7 +965,10 @@ mod tests {
     fn proxy_system_reads_the_environment() {
         for value in ["system", "System", "SYSTEM"] {
             let config = HttpConfig::from_config_args(HttpConfigArgs {
-                proxy: String::from(value),
+                proxy: ProxyConfigArgs {
+                    source: String::from(value),
+                    ..Default::default()
+                },
                 ..args()
             })
             .expect("a valid configuration");
@@ -1127,12 +979,18 @@ mod tests {
     #[test]
     fn proxy_url_defaults_to_the_http_scheme() {
         let with_scheme = HttpConfig::from_config_args(HttpConfigArgs {
-            proxy: String::from("http://proxy.corp:3128"),
+            proxy: ProxyConfigArgs {
+                source: String::from("http://proxy.corp:3128"),
+                ..Default::default()
+            },
             ..args()
         })
         .expect("a valid configuration");
         let without_scheme = HttpConfig::from_config_args(HttpConfigArgs {
-            proxy: String::from("proxy.corp:3128"),
+            proxy: ProxyConfigArgs {
+                source: String::from("proxy.corp:3128"),
+                ..Default::default()
+            },
             ..args()
         })
         .expect("a valid configuration");
@@ -1148,16 +1006,21 @@ mod tests {
     #[test]
     fn proxy_credentials_are_optional() {
         let none = HttpConfig::from_config_args(HttpConfigArgs {
-            proxy: String::from("proxy.corp:3128"),
+            proxy: ProxyConfigArgs {
+                source: String::from("proxy.corp:3128"),
+                ..Default::default()
+            },
             ..args()
         })
         .expect("a valid configuration");
         assert_eq!(none.proxy.credentials(), None);
 
         let some = HttpConfig::from_config_args(HttpConfigArgs {
-            proxy: String::from("proxy.corp:3128"),
-            proxy_username: String::from("user"),
-            proxy_password: "secret".into(),
+            proxy: ProxyConfigArgs {
+                source: String::from("proxy.corp:3128"),
+                username: String::from("user"),
+                password: "secret".into(),
+            },
             ..args()
         })
         .expect("a valid configuration");
@@ -1167,7 +1030,10 @@ mod tests {
     #[test]
     fn proxy_credentials_in_the_url_are_honoured_and_removed_from_it() {
         let config = HttpConfig::from_config_args(HttpConfigArgs {
-            proxy: String::from("http://user:secret@proxy.corp:3128"),
+            proxy: ProxyConfigArgs {
+                source: String::from("http://user:secret@proxy.corp:3128"),
+                ..Default::default()
+            },
             ..args()
         })
         .expect("a valid configuration");
@@ -1185,9 +1051,11 @@ mod tests {
     #[test]
     fn the_dedicated_proxy_options_win_over_the_url() {
         let config = HttpConfig::from_config_args(HttpConfigArgs {
-            proxy: String::from("http://url-user:url-secret@proxy.corp:3128"),
-            proxy_username: String::from("option-user"),
-            proxy_password: "option-secret".into(),
+            proxy: ProxyConfigArgs {
+                source: String::from("http://url-user:url-secret@proxy.corp:3128"),
+                username: String::from("option-user"),
+                password: "option-secret".into(),
+            },
             ..args()
         })
         .expect("a valid configuration");
@@ -1203,9 +1071,11 @@ mod tests {
         // `HttpConfig` is `Debug` and holds a `ProxyConfig`, so a derived `Debug` would put the
         // password anywhere a configuration gets printed.
         let config = HttpConfig::from_config_args(HttpConfigArgs {
-            proxy: String::from("proxy.corp:3128"),
-            proxy_username: String::from("user"),
-            proxy_password: "s3cr3t".into(),
+            proxy: ProxyConfigArgs {
+                source: String::from("proxy.corp:3128"),
+                username: String::from("user"),
+                password: "s3cr3t".into(),
+            },
             ..args()
         })
         .expect("a valid configuration");
@@ -1230,8 +1100,11 @@ mod tests {
         // Replacing the pair rather than each field would leave an empty username here, and the proxy
         // would answer 407 with nothing to explain it.
         let config = HttpConfig::from_config_args(HttpConfigArgs {
-            proxy: String::from("http://url-user:url-secret@proxy.corp:3128"),
-            proxy_password: "option-secret".into(),
+            proxy: ProxyConfigArgs {
+                source: String::from("http://url-user:url-secret@proxy.corp:3128"),
+                password: "option-secret".into(),
+                ..Default::default()
+            },
             ..args()
         })
         .expect("a valid configuration");
@@ -1246,7 +1119,10 @@ mod tests {
     fn a_rejected_proxy_url_does_not_echo_its_password() {
         // A URL can be rejected for having no host and still have carried a credential.
         let error = HttpConfig::from_config_args(HttpConfigArgs {
-            proxy: String::from("http://user:s3cr3t@"),
+            proxy: ProxyConfigArgs {
+                source: String::from("http://user:s3cr3t@"),
+                ..Default::default()
+            },
             ..args()
         })
         .expect_err("a proxy without a host must be rejected")
@@ -1261,8 +1137,11 @@ mod tests {
         // `HttpConfig` is not the only type that holds it: these are what a caller inspects before
         // handing them over.
         let args = HttpConfigArgs {
-            proxy: String::from("http://user:url-secret@proxy.corp:3128"),
-            proxy_password: "option-secret".into(),
+            proxy: ProxyConfigArgs {
+                source: String::from("http://user:url-secret@proxy.corp:3128"),
+                password: "option-secret".into(),
+                ..Default::default()
+            },
             ..args()
         };
 
@@ -1281,7 +1160,10 @@ mod tests {
     #[test]
     fn an_ordinary_serialisation_redacts_the_password() {
         let args = HttpConfigArgs {
-            proxy_password: "s3cr3t".into(),
+            proxy: ProxyConfigArgs {
+                password: "s3cr3t".into(),
+                ..Default::default()
+            },
             ..args()
         };
 
@@ -1295,7 +1177,10 @@ mod tests {
         // Accepting the URL and failing at connect time would report it as an unreachable proxy.
         for value in ["https://proxy.corp:3128", "socks5://proxy.corp:1080"] {
             let error = HttpConfig::from_config_args(HttpConfigArgs {
-                proxy: String::from(value),
+                proxy: ProxyConfigArgs {
+                    source: String::from(value),
+                    ..Default::default()
+                },
                 ..args()
             })
             .expect_err("only an http proxy can be reached")
@@ -1311,7 +1196,10 @@ mod tests {
         // wrong setting.
         for value in ["http:///no-host", "http://", "http://:3128", "://"] {
             let error = HttpConfig::from_config_args(HttpConfigArgs {
-                proxy: String::from(value),
+                proxy: ProxyConfigArgs {
+                    source: String::from(value),
+                    ..Default::default()
+                },
                 ..args()
             })
             .expect_err("a proxy without a host must be rejected")

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -5,6 +5,9 @@ use rustls::pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer};
 use snafu::{ResultExt, Snafu};
 
 use crate::secret::Secret;
+#[cfg(feature = "serde")]
+use crate::tcp_config::prefix_tcp;
+use crate::tcp_config::{TcpConfig, TcpConfigArgs};
 
 /// Where to find the HTTP proxy used to reach the endpoint.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -105,14 +108,8 @@ pub struct HttpConfig {
     pub timeout: Option<Duration>,
     /// Rate limit for requests, defaults to no rate limit
     pub rate_limit: Option<(u64, Duration)>,
-    /// TCP keepalive duration, defaults to no keepalive
-    pub tcp_keepalive: Option<Duration>,
-    /// Interval between TCP keepalive probes, defaults to OS default
-    pub tcp_keepalive_interval: Option<Duration>,
-    /// Number of TCP keepalive retries, defaults to OS default
-    pub tcp_keepalive_retries: Option<u32>,
-    /// Enable Nagle's algorithm (disable TCP_NODELAY), defaults to false
-    pub tcp_nagle_algorithm: bool,
+    /// TCP-level socket options.
+    pub tcp: TcpConfig,
     /// HTTP/2 PING frame interval, defaults to no keepalive
     pub http2_keep_alive_interval: Option<Duration>,
     /// HTTP/2 PING timeout, defaults to no timeout
@@ -141,10 +138,7 @@ impl Clone for HttpConfig {
             connect_timeout: self.connect_timeout,
             timeout: self.timeout,
             rate_limit: self.rate_limit,
-            tcp_keepalive: self.tcp_keepalive,
-            tcp_keepalive_interval: self.tcp_keepalive_interval,
-            tcp_keepalive_retries: self.tcp_keepalive_retries,
-            tcp_nagle_algorithm: self.tcp_nagle_algorithm,
+            tcp: self.tcp,
             http2_keep_alive_interval: self.http2_keep_alive_interval,
             http2_keep_alive_timeout: self.http2_keep_alive_timeout,
             http2_keep_alive_while_idle: self.http2_keep_alive_while_idle,
@@ -188,18 +182,9 @@ pub struct HttpConfigArgs {
     /// Rate limit for requests, defaults to no rate limit
     #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
     pub rate_limit: String,
-    /// TCP keepalive duration (e.g. `30s`), defaults to no keepalive
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
-    pub tcp_keepalive: String,
-    /// Interval between TCP keepalive probes (e.g. `5s`), defaults to OS default
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
-    pub tcp_keepalive_interval: String,
-    /// Number of TCP keepalive retries, defaults to OS default
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
-    pub tcp_keepalive_retries: String,
-    /// Enable Nagle's algorithm (disable TCP_NODELAY), empty for false
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
-    pub tcp_nagle_algorithm: String,
+    /// TCP-level socket options.
+    #[cfg_attr(feature = "serde", serde(flatten, with = "prefix_tcp"))]
+    pub tcp: TcpConfigArgs,
     /// HTTP/2 PING frame interval (e.g. `20s`), defaults to no keepalive
     #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
     pub http2_keep_alive_interval: String,
@@ -236,11 +221,42 @@ pub struct HttpConfigArgs {
     pub proxy_password: Secret,
 }
 
+/// Reads a duration option, empty for `None`.
+pub(crate) fn parse_optional_duration(
+    option: &'static str,
+    value: String,
+) -> Result<Option<Duration>, ConfigError> {
+    if value.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(
+        value
+            .parse::<humantime::Duration>()
+            .context(InvalidDurationSnafu { option, value })?
+            .into(),
+    ))
+}
+
+/// Reads an integer option, empty for `None`.
+pub(crate) fn parse_optional_int<T: std::str::FromStr<Err = std::num::ParseIntError>>(
+    option: &'static str,
+    value: String,
+) -> Result<Option<T>, ConfigError> {
+    if value.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(
+        value
+            .parse::<T>()
+            .context(InvalidIntegerSnafu { option, value })?,
+    ))
+}
+
 /// Reads a boolean option, on the vocabulary every ArmoniK client accepts.
 ///
 /// The parsing lives here rather than in a `Deserialize` impl so that the error can name the option
-/// it came from: a `deserialize_with` function's signature carries only the value, not the field it
-/// was read for, so the name has to come from whoever calls it instead.
+/// it came from: a `serde` source that flattens its fields buffers values before handing them over,
+/// and by then the field's own name is no longer available.
 pub(crate) fn parse_bool(option: &'static str, value: &str) -> Result<bool, ConfigError> {
     match value {
         "" | "0" | "false" | "no" | "disable" | "disallow" | "forbid" => Ok(false),
@@ -336,10 +352,10 @@ impl HttpConfig {
             args.connect_timeout,
             args.timeout,
             args.rate_limit,
-            args.tcp_keepalive,
-            args.tcp_keepalive_interval,
-            args.tcp_keepalive_retries,
-            args.tcp_nagle_algorithm,
+            args.tcp.keepalive,
+            args.tcp.keepalive_interval,
+            args.tcp.keepalive_retries,
+            args.tcp.nagle_algorithm,
             args.http2_keep_alive_interval,
             args.http2_keep_alive_timeout,
             args.http2_keep_alive_while_idle,
@@ -362,10 +378,7 @@ impl HttpConfig {
             connect_timeout,
             timeout,
             rate_limit,
-            tcp_keepalive,
-            tcp_keepalive_interval,
-            tcp_keepalive_retries,
-            tcp_nagle_algorithm,
+            tcp,
             http2_keep_alive_interval,
             http2_keep_alive_timeout,
             http2_keep_alive_while_idle,
@@ -378,7 +391,7 @@ impl HttpConfig {
 
         let allow_unsafe_connection =
             parse_bool("allow_unsafe_connection", &allow_unsafe_connection)?;
-        let tcp_nagle_algorithm = parse_bool("tcp_nagle_algorithm", &tcp_nagle_algorithm)?;
+        let tcp = tcp.resolve()?;
         let http2_keep_alive_while_idle =
             parse_bool("http2_keep_alive_while_idle", &http2_keep_alive_while_idle)?;
 
@@ -446,29 +459,12 @@ impl HttpConfig {
             })?)
         };
 
-        let connect_timeout = if connect_timeout.is_empty() {
-            Some(Duration::from_secs(60))
-        } else {
-            Some(
-                connect_timeout
-                    .parse::<humantime::Duration>()
-                    .context(InvalidDurationSnafu {
-                        value: connect_timeout,
-                    })?
-                    .into(),
-            )
-        };
+        let connect_timeout = Some(
+            parse_optional_duration("connect_timeout", connect_timeout)?
+                .unwrap_or(Duration::from_secs(60)),
+        );
 
-        let timeout = if timeout.is_empty() {
-            None
-        } else {
-            Some(
-                timeout
-                    .parse::<humantime::Duration>()
-                    .context(InvalidDurationSnafu { value: timeout })?
-                    .into(),
-            )
-        };
+        let timeout = parse_optional_duration("timeout", timeout)?;
 
         let rate_limit = if rate_limit.is_empty() {
             None
@@ -487,6 +483,7 @@ impl HttpConfig {
             let duration: Duration = parts[1]
                 .parse::<humantime::Duration>()
                 .context(InvalidDurationSnafu {
+                    option: "rate_limit",
                     value: rate_limit.clone(),
                 })?
                 .into();
@@ -504,44 +501,6 @@ impl HttpConfig {
             Some((limit, duration))
         };
 
-        let tcp_keepalive = if tcp_keepalive.is_empty() {
-            None
-        } else {
-            Some(
-                tcp_keepalive
-                    .parse::<humantime::Duration>()
-                    .context(InvalidDurationSnafu {
-                        value: tcp_keepalive,
-                    })?
-                    .into(),
-            )
-        };
-
-        let tcp_keepalive_interval = if tcp_keepalive_interval.is_empty() {
-            None
-        } else {
-            Some(
-                tcp_keepalive_interval
-                    .parse::<humantime::Duration>()
-                    .context(InvalidDurationSnafu {
-                        value: tcp_keepalive_interval,
-                    })?
-                    .into(),
-            )
-        };
-
-        let tcp_keepalive_retries = if tcp_keepalive_retries.is_empty() {
-            None
-        } else {
-            Some(
-                tcp_keepalive_retries
-                    .parse::<u32>()
-                    .context(InvalidIntegerSnafu {
-                        value: tcp_keepalive_retries,
-                    })?,
-            )
-        };
-
         let http2_keep_alive_interval = if http2_keep_alive_interval.is_empty() {
             None
         } else {
@@ -549,6 +508,7 @@ impl HttpConfig {
                 http2_keep_alive_interval
                     .parse::<humantime::Duration>()
                     .context(InvalidDurationSnafu {
+                        option: "http2_keep_alive_interval",
                         value: http2_keep_alive_interval,
                     })?
                     .into(),
@@ -562,6 +522,7 @@ impl HttpConfig {
                 http2_keep_alive_timeout
                     .parse::<humantime::Duration>()
                     .context(InvalidDurationSnafu {
+                        option: "http2_keep_alive_timeout",
                         value: http2_keep_alive_timeout,
                     })?
                     .into(),
@@ -575,6 +536,7 @@ impl HttpConfig {
                 http2_max_header_list_size
                     .parse::<u32>()
                     .context(InvalidIntegerSnafu {
+                        option: "http2_max_header_list_size",
                         value: http2_max_header_list_size,
                     })?,
             )
@@ -611,10 +573,7 @@ impl HttpConfig {
             connect_timeout,
             timeout,
             rate_limit,
-            tcp_keepalive,
-            tcp_keepalive_interval,
-            tcp_keepalive_retries,
-            tcp_nagle_algorithm,
+            tcp,
             http2_keep_alive_interval,
             http2_keep_alive_timeout,
             http2_keep_alive_while_idle,
@@ -683,6 +642,7 @@ impl TryFrom<&HttpConfig> for tonic::transport::Endpoint {
 }
 
 #[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
 #[non_exhaustive]
 pub enum ConfigError {
     #[snafu(display("Invalid TLS configuration [{location}]"))]
@@ -728,10 +688,13 @@ pub enum ConfigError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
-    #[snafu(display("`GrpcClient__ConnectTimeout={value}` is not a valid duration (e.g. `30s` or `1m`) [{location}]"))]
+    #[snafu(display(
+        "`{option}={value}` is not a valid duration (e.g. `30s` or `1m`) [{location}]"
+    ))]
     #[non_exhaustive]
     InvalidDuration {
         source: humantime::DurationError,
+        option: &'static str,
         value: String,
         #[snafu(implicit)]
         location: snafu::Location,
@@ -754,10 +717,11 @@ pub enum ConfigError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
-    #[snafu(display("`{value}` is not a valid integer [{location}]"))]
+    #[snafu(display("`{option}={value}` is not a valid integer [{location}]"))]
     #[non_exhaustive]
     InvalidInteger {
         source: std::num::ParseIntError,
+        option: &'static str,
         value: String,
         #[snafu(implicit)]
         location: snafu::Location,
@@ -826,13 +790,16 @@ mod tests {
         for spelling in ["1", "true", "yes", "enable", "allow", "authorize"] {
             let config = HttpConfig::from_config_args(HttpConfigArgs {
                 allow_unsafe_connection: String::from(spelling),
-                tcp_nagle_algorithm: String::from(spelling),
+                tcp: TcpConfigArgs {
+                    nagle_algorithm: String::from(spelling),
+                    ..Default::default()
+                },
                 http2_keep_alive_while_idle: String::from(spelling),
                 ..args()
             })
             .expect(spelling);
             assert!(config.allow_unsafe_connection, "{spelling}");
-            assert!(config.tcp_nagle_algorithm, "{spelling}");
+            assert!(config.tcp.nagle_algorithm, "{spelling}");
             assert!(config.http2_keep_alive_while_idle, "{spelling}");
         }
 
@@ -869,17 +836,20 @@ mod tests {
     fn durations_are_read_in_the_units_they_are_written_in() {
         let config = HttpConfig::from_config_args(HttpConfigArgs {
             connect_timeout: String::from("500ms"),
-            tcp_keepalive: String::from("30s"),
-            tcp_keepalive_interval: String::from("2m"),
+            tcp: TcpConfigArgs {
+                keepalive: String::from("30s"),
+                keepalive_interval: String::from("2m"),
+                ..Default::default()
+            },
             http2_keep_alive_interval: String::from("1h"),
             ..args()
         })
         .expect("valid durations");
 
         assert_eq!(config.connect_timeout, Some(Duration::from_millis(500)));
-        assert_eq!(config.tcp_keepalive, Some(Duration::from_secs(30)));
+        assert_eq!(config.tcp.keepalive, Some(Duration::from_secs(30)));
         assert_eq!(
-            config.tcp_keepalive_interval,
+            config.tcp.keepalive_interval,
             Some(Duration::from_secs(120))
         );
         assert_eq!(
@@ -891,7 +861,10 @@ mod tests {
     #[test]
     fn a_duration_that_cannot_be_parsed_names_the_value() {
         let error = HttpConfig::from_config_args(HttpConfigArgs {
-            tcp_keepalive: String::from("soon"),
+            tcp: TcpConfigArgs {
+                keepalive: String::from("soon"),
+                ..Default::default()
+            },
             ..args()
         })
         .expect_err("`soon` is not a duration");
@@ -906,16 +879,22 @@ mod tests {
     #[test]
     fn integers_are_read_and_a_bad_one_names_the_value() {
         let config = HttpConfig::from_config_args(HttpConfigArgs {
-            tcp_keepalive_retries: String::from("3"),
+            tcp: TcpConfigArgs {
+                keepalive_retries: String::from("3"),
+                ..Default::default()
+            },
             http2_max_header_list_size: String::from("16384"),
             ..args()
         })
         .expect("valid integers");
-        assert_eq!(config.tcp_keepalive_retries, Some(3));
+        assert_eq!(config.tcp.keepalive_retries, Some(3));
         assert_eq!(config.http2_max_header_list_size, Some(16384));
 
         let error = HttpConfig::from_config_args(HttpConfigArgs {
-            tcp_keepalive_retries: String::from("many"),
+            tcp: TcpConfigArgs {
+                keepalive_retries: String::from("many"),
+                ..Default::default()
+            },
             ..args()
         })
         .expect_err("`many` is not an integer");
@@ -1162,7 +1141,7 @@ mod tests {
         )
         .expect("a number or boolean must still be read as text");
 
-        assert_eq!(deserialised.tcp_keepalive_retries, "3");
+        assert_eq!(deserialised.tcp.keepalive_retries, "3");
         assert_eq!(deserialised.allow_unsafe_connection, "true");
     }
 

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use hyper::{http::HeaderValue, Uri};
-use rustls::pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer};
 use snafu::{ResultExt, Snafu};
 
 #[cfg(feature = "serde")]
@@ -13,22 +12,17 @@ use crate::secret::Secret;
 #[cfg(feature = "serde")]
 use crate::tcp_config::prefix_tcp;
 use crate::tcp_config::{TcpConfig, TcpConfigArgs};
+use crate::tls_config::{TlsConfig, TlsConfigArgs};
 
 /// Options for the HTTP/2 transport: TLS, proxy, and everything else `connect` needs to reach the
 /// endpoint.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct HttpConfig {
     /// Endpoint for sending requests
     pub endpoint: Uri,
-    /// Allow unsafe connections to the endpoint (without SSL), defaults to false
-    pub allow_unsafe_connection: bool,
-    /// TLS identity of the client: key + cert
-    pub identity: Option<(CertificateDer<'static>, PrivateKeyDer<'static>)>,
-    /// CA certificate to authenticate the server
-    pub cacert: Option<CertificateDer<'static>>,
-    /// Override the endpoint name during SSL verification
-    pub override_target: Option<Uri>,
+    /// TLS and mTLS: the client's own identity, the server's CA, and SSL verification behaviour.
+    pub tls: TlsConfig,
     /// Timeout for establishing a connection to the server, defaults to 60s
     pub connect_timeout: Option<Duration>,
     /// Timeout for each request, defaults to no timeout
@@ -45,28 +39,6 @@ pub struct HttpConfig {
     pub proxy: ProxyConfig,
 }
 
-impl Clone for HttpConfig {
-    fn clone(&self) -> Self {
-        Self {
-            endpoint: self.endpoint.clone(),
-            allow_unsafe_connection: self.allow_unsafe_connection,
-            identity: self
-                .identity
-                .as_ref()
-                .map(|(cert, key)| (cert.clone(), key.clone_key())),
-            cacert: self.cacert.clone(),
-            override_target: self.override_target.clone(),
-            connect_timeout: self.connect_timeout,
-            timeout: self.timeout,
-            rate_limit: self.rate_limit,
-            tcp: self.tcp,
-            http2: self.http2,
-            user_agent: self.user_agent.clone(),
-            proxy: self.proxy.clone(),
-        }
-    }
-}
-
 /// Options for creating a gRPC Client, in the string form a caller supplies them in
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -76,21 +48,9 @@ pub struct HttpConfigArgs {
     /// Endpoint for sending requests
     #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
     pub endpoint: String,
-    /// Path to the certificate file in pem format
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
-    pub cert_pem: String,
-    /// Path to the key file in pem format
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
-    pub key_pem: String,
-    /// Path to the Certificate Authority file in pem format
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
-    pub ca_cert: String,
-    /// Allow unsafe connections to the endpoint (without SSL), empty for false
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
-    pub allow_unsafe_connection: String,
-    /// Override the endpoint name during SSL verification
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
-    pub override_target_name: String,
+    /// The client's TLS identity and the server's CA.
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    pub tls: TlsConfigArgs,
     /// Timeout for establishing a connection to the server, defaults to no timeout
     #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
     pub connect_timeout: String,
@@ -112,6 +72,14 @@ pub struct HttpConfigArgs {
     /// HTTP proxy used to reach the endpoint: where to find it, and the dedicated credentials.
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub proxy: ProxyConfigArgs,
+}
+
+/// Boxes any error as a trait object, for a [`ConfigError`] variant shared by more than one
+/// underlying error type.
+pub(crate) fn boxed(
+    error: impl std::error::Error + Send + Sync + 'static,
+) -> Box<dyn std::error::Error + Send + Sync> {
+    Box::new(error)
 }
 
 /// Reads a duration option, empty for `None`.
@@ -237,11 +205,11 @@ impl HttpConfig {
         let _span = tracing::debug_span!(
             "HttpConfig",
             args.endpoint,
-            args.cert_pem,
-            args.key_pem,
-            args.ca_cert,
-            args.allow_unsafe_connection,
-            args.override_target_name,
+            args.tls.cert_pem,
+            args.tls.key_pem,
+            args.tls.ca_cert,
+            args.tls.allow_unsafe_connection,
+            args.tls.override_target_name,
             args.connect_timeout,
             args.timeout,
             args.rate_limit,
@@ -263,11 +231,7 @@ impl HttpConfig {
 
         let HttpConfigArgs {
             endpoint,
-            cert_pem: cert_path,
-            key_pem: key_path,
-            ca_cert: cacert_path,
-            allow_unsafe_connection,
-            override_target_name,
+            tls,
             connect_timeout,
             timeout,
             rate_limit,
@@ -277,74 +241,13 @@ impl HttpConfig {
             proxy,
         } = args;
 
-        let allow_unsafe_connection =
-            parse_bool("allow_unsafe_connection", &allow_unsafe_connection)?;
-        let tcp = tcp.resolve()?;
-        let http2 = http2.resolve()?;
-
-        // Read CAcert file
-        let cacert = if !cacert_path.is_empty() {
-            let cacert_pem = std::fs::read_to_string(cacert_path.clone())
-                .context(IoSnafu { path: cacert_path })?;
-            Some(CertificateDer::from_pem_slice(cacert_pem.as_bytes()).context(TlsSnafu {})?)
-        } else {
-            None
-        };
-
-        // Read client cert and key files
-        let identity = match (cert_path.as_str(), key_path.as_str()) {
-            ("", "") => None,
-            ("", _) | (_, "") => return IncompatibleOptionsSnafu{msg: format!("`GrpcClient__CertPem={cert_path}` and `GrpcClient__KeyPem={key_path}` must be either both empty or both set")}.fail(),
-            (cert_path, key_path) => {
-                let cert_pem =
-                    std::fs::read_to_string(cert_path).context(IoSnafu { path: cert_path })?;
-                let key_pem = std::fs::read(key_path).context(IoSnafu { path: key_path })?;
-                let cert = CertificateDer::from_pem_slice(cert_pem.as_bytes()).context(TlsSnafu {})?;
-                let key = PrivateKeyDer::from_pem_slice(key_pem.as_slice()).context(TlsSnafu{})?;
-
-                Some((cert, key))
-            }
-        };
-
-        let endpoint = Uri::try_from(endpoint.clone()).context(UriSnafu { uri: endpoint })?;
-
-        let override_target = if override_target_name.is_empty() {
-            None
-        } else {
-            let authority;
-            let path_and_query;
-
-            if let Ok(auth) = override_target_name.parse::<hyper::http::uri::Authority>() {
-                authority = Some(auth);
-                path_and_query = endpoint.path_and_query().cloned();
-            } else {
-                hyper::http::uri::Parts {
-                    authority,
-                    path_and_query,
-                    ..
-                } = Uri::try_from(override_target_name.clone())
-                    .context(UriSnafu {
-                        uri: endpoint.to_string(),
-                    })?
-                    .into_parts();
-            }
-
-            let mut uri = hyper::http::uri::Builder::new();
-
-            if let Some(scheme) = endpoint.scheme() {
-                uri = uri.scheme(scheme.clone());
-            }
-            if let Some(authority) = authority.or_else(|| endpoint.authority().cloned()) {
-                uri = uri.authority(authority);
-            }
-            if let Some(path_and_query) = path_and_query {
-                uri = uri.path_and_query(path_and_query);
-            }
-
-            Some(uri.build().context(HttpSnafu {
-                uri: override_target_name,
-            })?)
-        };
+        let endpoint = Uri::try_from(endpoint.clone())
+            .map_err(boxed)
+            .context(UriSnafu {
+                option: "endpoint",
+                uri: endpoint,
+            })?;
+        let tls = tls.resolve(&endpoint)?;
 
         let connect_timeout = Some(
             parse_optional_duration("connect_timeout", connect_timeout)?
@@ -388,6 +291,9 @@ impl HttpConfig {
             Some((limit, duration))
         };
 
+        let tcp = tcp.resolve()?;
+        let http2 = http2.resolve()?;
+
         let user_agent = if user_agent.is_empty() {
             None
         } else {
@@ -400,10 +306,7 @@ impl HttpConfig {
 
         Ok(Self {
             endpoint,
-            allow_unsafe_connection,
-            identity,
-            cacert,
-            override_target,
+            tls,
             connect_timeout,
             timeout,
             rate_limit,
@@ -435,29 +338,21 @@ pub enum ConfigError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
-    #[snafu(display("Endpoint URI is not valid: `{uri}` [{location}]"))]
+    #[snafu(display("`{option}={uri}` is not a valid URI [{location}]"))]
     #[non_exhaustive]
     Uri {
-        #[snafu(source(from(hyper::http::uri::InvalidUri, Box::new)))]
-        source: Box<hyper::http::uri::InvalidUri>,
+        source: Box<dyn std::error::Error + Send + Sync>,
+        option: &'static str,
         uri: String,
         #[snafu(implicit)]
         location: snafu::Location,
     },
-    #[snafu(display("Override URI is not valid: `{uri}` [{location}]"))]
-    #[non_exhaustive]
-    Http {
-        #[snafu(source(from(hyper::http::Error, Box::new)))]
-        source: Box<hyper::http::Error>,
-        uri: String,
-        #[snafu(implicit)]
-        location: snafu::Location,
-    },
-    #[snafu(display("Could not read file `{path}` [{location}]"))]
+    #[snafu(display("Could not read `{option}`'s file `{path}` [{location}]"))]
     #[non_exhaustive]
     Io {
         #[snafu(source(from(std::io::Error, Box::new)))]
         source: Box<std::io::Error>,
+        option: &'static str,
         path: String,
         #[snafu(implicit)]
         location: snafu::Location,
@@ -549,9 +444,9 @@ mod tests {
         let config = HttpConfig::from_config_args(args()).expect("an endpoint is enough");
 
         assert_eq!(config.endpoint.to_string(), "http://localhost:5001/");
-        assert!(config.identity.is_none());
-        assert!(config.cacert.is_none());
-        assert_eq!(config.override_target, None);
+        assert!(config.tls.identity.is_none());
+        assert!(config.tls.cacert.is_none());
+        assert_eq!(config.tls.override_target, None);
         assert_eq!(config.rate_limit, None);
     }
 
@@ -564,56 +459,6 @@ mod tests {
         .expect_err("an empty endpoint is not a URI");
 
         assert!(matches!(error, ConfigError::Uri { .. }), "{error:?}");
-    }
-
-    // --- booleans ---
-
-    #[test]
-    fn every_accepted_boolean_spelling_is_accepted() {
-        for spelling in ["1", "true", "yes", "enable", "allow", "authorize"] {
-            let config = HttpConfig::from_config_args(HttpConfigArgs {
-                allow_unsafe_connection: String::from(spelling),
-                tcp: TcpConfigArgs {
-                    nagle_algorithm: String::from(spelling),
-                    ..Default::default()
-                },
-                http2: Http2ConfigArgs {
-                    keep_alive_while_idle: String::from(spelling),
-                    ..Default::default()
-                },
-                ..args()
-            })
-            .expect(spelling);
-            assert!(config.allow_unsafe_connection, "{spelling}");
-            assert!(config.tcp.nagle_algorithm, "{spelling}");
-            assert!(config.http2.keep_alive_while_idle, "{spelling}");
-        }
-
-        for spelling in ["0", "false", "no", "disable", "disallow", "forbid", ""] {
-            let config = HttpConfig::from_config_args(HttpConfigArgs {
-                allow_unsafe_connection: String::from(spelling),
-                ..args()
-            })
-            .expect(spelling);
-            assert!(!config.allow_unsafe_connection, "{spelling:?}");
-        }
-    }
-
-    #[test]
-    fn an_unrecognised_boolean_names_the_option_and_the_value() {
-        let error = HttpConfig::from_config_args(HttpConfigArgs {
-            allow_unsafe_connection: String::from("perhaps"),
-            ..args()
-        })
-        .expect_err("`perhaps` is not a boolean");
-
-        assert!(
-            matches!(error, ConfigError::InvalidBool { .. }),
-            "{error:?}"
-        );
-        let rendered = chain(&error);
-        assert!(rendered.contains("perhaps"), "{rendered}");
-        assert!(rendered.contains("allow_unsafe_connection"), "{rendered}");
     }
 
     // --- durations and numbers ---
@@ -798,8 +643,11 @@ mod tests {
         // on an mTLS one. Neither path is read from disk before the check, so this needs no fixture.
         for (cert, key) in [("cert.pem", ""), ("", "key.pem")] {
             let error = HttpConfig::from_config_args(HttpConfigArgs {
-                cert_pem: String::from(cert),
-                key_pem: String::from(key),
+                tls: TlsConfigArgs {
+                    cert_pem: String::from(cert),
+                    key_pem: String::from(key),
+                    ..Default::default()
+                },
                 ..args()
             })
             .expect_err("half an identity must be rejected");
@@ -809,50 +657,96 @@ mod tests {
                 "{error:?}"
             );
             let rendered = chain(&error);
-            assert!(rendered.contains("GrpcClient__CertPem"), "{rendered}");
-            assert!(rendered.contains("GrpcClient__KeyPem"), "{rendered}");
+            assert!(rendered.contains("cert_pem"), "{rendered}");
+            assert!(rendered.contains("key_pem"), "{rendered}");
         }
     }
 
     #[test]
     fn neither_half_is_no_identity_rather_than_an_error() {
         let config = HttpConfig::from_config_args(args()).expect("valid");
-        assert!(config.identity.is_none());
+        assert!(config.tls.identity.is_none());
     }
 
     #[test]
-    fn a_certificate_path_that_does_not_exist_is_reported_with_the_path() {
-        // These options are paths, not contents. A typo in one has to name the file rather than surface
-        // later as a TLS failure.
-        let error = HttpConfig::from_config_args(HttpConfigArgs {
-            cert_pem: String::from("no/such/cert.pem"),
-            key_pem: String::from("no/such/key.pem"),
-            ..args()
-        })
-        .expect_err("a missing file must be reported");
+    fn content_that_is_not_pem_fails_as_such() {
+        // Garbage content gets a PEM error naming what was wrong, rather than this crate silently
+        // accepting it.
+        let mut cert = tempfile::NamedTempFile::new().expect("temp file");
+        std::io::Write::write_all(&mut cert, b"not a certificate").expect("write");
+        let mut key = tempfile::NamedTempFile::new().expect("temp file");
+        std::io::Write::write_all(&mut key, b"not a key").expect("write");
 
-        assert!(matches!(error, ConfigError::Io { .. }), "{error:?}");
-        assert!(
-            chain(&error).contains("no/such/cert.pem"),
-            "{}",
-            chain(&error)
-        );
+        for args in [
+            HttpConfigArgs {
+                tls: TlsConfigArgs {
+                    cert_pem: cert.path().to_str().expect("utf8 path").to_owned(),
+                    key_pem: key.path().to_str().expect("utf8 path").to_owned(),
+                    ..Default::default()
+                },
+                ..args()
+            },
+            HttpConfigArgs {
+                tls: TlsConfigArgs {
+                    ca_cert: cert.path().to_str().expect("utf8 path").to_owned(),
+                    ..Default::default()
+                },
+                ..args()
+            },
+        ] {
+            let error = HttpConfig::from_config_args(args)
+                .expect_err("garbage content is not a certificate");
+
+            assert!(matches!(error, ConfigError::Tls { .. }), "{error:?}");
+        }
     }
 
     #[test]
-    fn a_missing_ca_certificate_is_reported_with_the_path() {
+    fn a_path_that_leads_nowhere_names_the_option_and_the_path() {
+        for args in [
+            HttpConfigArgs {
+                tls: TlsConfigArgs {
+                    cert_pem: String::from("no/such/cert.pem"),
+                    key_pem: String::from("no/such/key.pem"),
+                    ..Default::default()
+                },
+                ..args()
+            },
+            HttpConfigArgs {
+                tls: TlsConfigArgs {
+                    ca_cert: String::from("no/such/ca.pem"),
+                    ..Default::default()
+                },
+                ..args()
+            },
+        ] {
+            let error =
+                HttpConfig::from_config_args(args).expect_err("a missing file must be reported");
+
+            assert!(matches!(error, ConfigError::Io { .. }), "{error:?}");
+            let rendered = chain(&error);
+            assert!(rendered.contains("no/such/"), "{rendered}");
+        }
+    }
+
+    #[test]
+    fn a_path_to_a_real_file_is_actually_read() {
+        // Proven by the error changing kind, not by a successful parse: generating a real certificate
+        // is more than this needs. A file that exists but holds no certificate must fail as `Tls`, not
+        // as `Io`, or the path was never opened at all.
+        let mut ca = tempfile::NamedTempFile::new().expect("temp file");
+        std::io::Write::write_all(&mut ca, b"clearly not a certificate").expect("write");
+
         let error = HttpConfig::from_config_args(HttpConfigArgs {
-            ca_cert: String::from("no/such/ca.pem"),
+            tls: TlsConfigArgs {
+                ca_cert: ca.path().to_str().expect("utf8 path").to_owned(),
+                ..Default::default()
+            },
             ..args()
         })
-        .expect_err("a missing file must be reported");
+        .expect_err("this file holds no certificate");
 
-        assert!(matches!(error, ConfigError::Io { .. }), "{error:?}");
-        assert!(
-            chain(&error).contains("no/such/ca.pem"),
-            "{}",
-            chain(&error)
-        );
+        assert!(matches!(error, ConfigError::Tls { .. }), "{error:?}");
     }
 
     // --- override target ---
@@ -863,12 +757,15 @@ mod tests {
         // authority is being overridden, so everything else has to come from the endpoint.
         let config = HttpConfig::from_config_args(HttpConfigArgs {
             endpoint: String::from("https://10.0.0.1:5003/base"),
-            override_target_name: String::from("server.example.com"),
+            tls: TlsConfigArgs {
+                override_target_name: String::from("server.example.com"),
+                ..Default::default()
+            },
             ..args()
         })
         .expect("valid");
 
-        let override_target = config.override_target.expect("an override target");
+        let override_target = config.tls.override_target.expect("an override target");
         assert_eq!(override_target.scheme_str(), Some("https"));
         assert_eq!(
             override_target.authority().map(|a| a.as_str()),
@@ -881,12 +778,15 @@ mod tests {
     fn an_override_target_given_as_a_uri_replaces_the_authority_and_the_path() {
         let config = HttpConfig::from_config_args(HttpConfigArgs {
             endpoint: String::from("https://10.0.0.1:5003/base"),
-            override_target_name: String::from("https://server.example.com/other"),
+            tls: TlsConfigArgs {
+                override_target_name: String::from("https://server.example.com/other"),
+                ..Default::default()
+            },
             ..args()
         })
         .expect("valid");
 
-        let override_target = config.override_target.expect("an override target");
+        let override_target = config.tls.override_target.expect("an override target");
         assert_eq!(
             override_target.authority().map(|a| a.as_str()),
             Some("server.example.com")
@@ -900,44 +800,149 @@ mod tests {
     #[test]
     fn no_override_target_leaves_it_unset() {
         let config = HttpConfig::from_config_args(args()).expect("valid");
-        assert_eq!(config.override_target, None);
+        assert_eq!(config.tls.override_target, None);
     }
 
     // --- the serde feature ---
 
+    /// The rendered message is what a user actually reads, so assert it whole rather than by
+    /// fragments: a stray space or a missing spelling only shows up here.
+    #[test]
+    fn an_unusable_boolean_names_the_option_and_the_vocabulary() {
+        let rendered = HttpConfig::from_config_args(HttpConfigArgs {
+            tls: TlsConfigArgs {
+                allow_unsafe_connection: String::from("perhaps"),
+                ..Default::default()
+            },
+            ..args()
+        })
+        .expect_err("`perhaps` spells no boolean")
+        .to_string();
+
+        let (message, location) = rendered
+            .rsplit_once(" [")
+            .expect("every error in this crate carries its location");
+        // `concat!` rather than a `\`-continued literal: that one keeps the source indentation in
+        // the string, which is exactly the defect this test exists to catch.
+        assert_eq!(
+            message,
+            concat!(
+                "`allow_unsafe_connection=perhaps` is not a valid boolean ",
+                "(e.g. `true`, `1`, `yes`, or `false`, `0`, `no`)"
+            )
+        );
+        assert!(location.ends_with(']'), "{rendered}");
+    }
+
+    /// A document may spell a boolean option the way its own format does, rather than the way an
+    /// environment variable has to.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn a_boolean_option_accepts_the_spelling_its_source_writes_naturally() {
+        for (written, expected) in [
+            (r#"{"AllowUnsafeConnection":true}"#, true),
+            (r#"{"AllowUnsafeConnection":false}"#, false),
+            (r#"{"AllowUnsafeConnection":"yes"}"#, true),
+            (r#"{"AllowUnsafeConnection":1}"#, true),
+            (r#"{"AllowUnsafeConnection":0}"#, false),
+        ] {
+            let mut args: HttpConfigArgs =
+                serde_json::from_str(written).unwrap_or_else(|error| panic!("{written}: {error}"));
+            args.endpoint = String::from("http://localhost:5001");
+
+            let config = HttpConfig::from_config_args(args)
+                .unwrap_or_else(|error| panic!("{written}: {error}"));
+
+            assert_eq!(
+                config.tls.allow_unsafe_connection, expected,
+                "{written} should resolve to {expected}"
+            );
+        }
+    }
+
+    /// What this crate writes, this crate reads: the options are textual, so a boolean comes back as
+    /// the word it was resolved from rather than as the source's own boolean.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn a_boolean_option_survives_being_written_and_read_again() {
+        let written = serde_json::to_string(&HttpConfigArgs {
+            tls: TlsConfigArgs {
+                allow_unsafe_connection: String::from("yes"),
+                ..Default::default()
+            },
+            ..args()
+        })
+        .expect("serialise");
+
+        assert!(
+            written.contains(r#""AllowUnsafeConnection":"yes""#),
+            "kept as written: {written}"
+        );
+
+        let read: HttpConfigArgs = serde_json::from_str(&written).expect("read back");
+        let config = HttpConfig::from_config_args(read).expect("resolve");
+
+        assert!(config.tls.allow_unsafe_connection);
+    }
+
+    /// The point of grouping each thematic unit's own fields with `with_prefix!` rather than a
+    /// plain nested object: not one JSON key changes, so an existing document, or an existing
+    /// environment variable, still reads.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn a_thematic_units_own_fields_still_serialise_as_flat_top_level_keys() {
+        let args = HttpConfigArgs {
+            tcp: TcpConfigArgs {
+                keepalive: String::from("30s"),
+                ..Default::default()
+            },
+            http2: Http2ConfigArgs {
+                max_header_list_size: String::from("16384"),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let written = serde_json::to_string(&args).expect("serialise");
+        assert!(
+            written.contains(r#""TcpKeepalive":"30s""#),
+            "flat, not nested under \"Tcp\": {written}"
+        );
+        assert!(!written.contains(r#""Tcp":"#), "{written}");
+        assert!(
+            written.contains(r#""Http2MaxHeaderListSize":"16384""#),
+            "flat, not nested under \"Http2\": {written}"
+        );
+        assert!(!written.contains(r#""Http2":"#), "{written}");
+
+        let read: HttpConfigArgs =
+            serde_json::from_str(r#"{"TcpKeepalive":"5s","Http2MaxHeaderListSize":"8192"}"#)
+                .expect("read the flat keys back");
+        assert_eq!(read.tcp.keepalive, "5s");
+        assert_eq!(read.http2.max_header_list_size, "8192");
+    }
+
     #[cfg(feature = "serde")]
     #[test]
     fn arguments_round_trip_through_serde_with_absent_fields_defaulted() {
-        // A single struct-level `serde(default)` covers every field, endpoint included, so a
-        // configuration file need only name what it changes, in `PascalCase`, matching the
-        // environment. The feature is off by default, so nothing else here would notice it breaking.
+        // The struct carries `serde(default)`, so a configuration file need only name what it
+        // changes; an absent `endpoint` fails later, as `ConfigError::Uri`, not here. The feature is
+        // off by default, so nothing else here would notice it breaking.
         let deserialised: HttpConfigArgs =
-            serde_json::from_str(r#"{"Endpoint":"http://localhost:5001","Timeout":"30s"}"#)
-                .expect("absent fields should default");
+            serde_json::from_str(r#"{"Timeout":"30s"}"#).expect("absent fields should default");
 
-        assert_eq!(deserialised.endpoint, "http://localhost:5001");
+        assert_eq!(deserialised.endpoint, "", "an absent field defaults");
         assert_eq!(deserialised.timeout, "30s");
-        assert_eq!(deserialised.cert_pem, "", "an absent field defaults");
-        assert_eq!(deserialised.allow_unsafe_connection, "");
+        assert_eq!(deserialised.tls.cert_pem, "", "an absent field defaults");
+        assert_eq!(
+            deserialised.tls.allow_unsafe_connection, "",
+            "an absent boolean defaults to empty, which reads as false"
+        );
 
         let round_tripped: HttpConfigArgs =
             serde_json::from_str(&serde_json::to_string(&deserialised).expect("serialise"))
                 .expect("deserialise");
         assert_eq!(round_tripped, deserialised);
-    }
-
-    #[cfg(feature = "serde")]
-    #[test]
-    fn a_value_that_figment_would_parse_as_a_number_or_boolean_still_reads_as_text() {
-        // `serde_json` itself has no reason to coerce a quoted string into anything else, so this
-        // pins the shim's own visitor methods directly rather than through a real `figment` read.
-        let deserialised: HttpConfigArgs = serde_json::from_str(
-            r#"{"Endpoint":"http://localhost:5001","TcpKeepaliveRetries":3,"AllowUnsafeConnection":true}"#,
-        )
-        .expect("a number or boolean must still be read as text");
-
-        assert_eq!(deserialised.tcp.keepalive_retries, "3");
-        assert_eq!(deserialised.allow_unsafe_connection, "true");
     }
 
     // --- the proxy ---

--- a/packages/rust/armonik-transport/src/connect.rs
+++ b/packages/rust/armonik-transport/src/connect.rs
@@ -19,10 +19,10 @@ use crate::HttpConfig;
 pub async fn connect(config: HttpConfig) -> Result<tonic::transport::Channel, ConnectionError> {
     let endpoint = config.endpoint.clone();
     let override_target = config.override_target.clone();
-    let http2_keep_alive_interval = config.http2_keep_alive_interval;
-    let http2_keep_alive_timeout = config.http2_keep_alive_timeout;
-    let http2_keep_alive_while_idle = config.http2_keep_alive_while_idle;
-    let http2_max_header_list_size = config.http2_max_header_list_size;
+    let http2_keep_alive_interval = config.http2.keep_alive_interval;
+    let http2_keep_alive_timeout = config.http2.keep_alive_timeout;
+    let http2_keep_alive_while_idle = config.http2.keep_alive_while_idle;
+    let http2_max_header_list_size = config.http2.max_header_list_size;
     let user_agent = config.user_agent.clone();
     let timeout = config.timeout;
     let rate_limit = config.rate_limit;

--- a/packages/rust/armonik-transport/src/connect.rs
+++ b/packages/rust/armonik-transport/src/connect.rs
@@ -18,7 +18,7 @@ use crate::HttpConfig;
 /// established, not lazily on the first request.
 pub async fn connect(config: HttpConfig) -> Result<tonic::transport::Channel, ConnectionError> {
     let endpoint = config.endpoint.clone();
-    let override_target = config.override_target.clone();
+    let override_target = config.tls.override_target.clone();
     let http2_keep_alive_interval = config.http2.keep_alive_interval;
     let http2_keep_alive_timeout = config.http2.keep_alive_timeout;
     let http2_keep_alive_while_idle = config.http2.keep_alive_while_idle;
@@ -89,12 +89,12 @@ pub async fn https_connector(
         })?;
 
     // Configure the server verification
-    let tls_config = if config.allow_unsafe_connection {
+    let tls_config = if config.tls.allow_unsafe_connection {
         // Do not verify the server
         tls_config
             .dangerous()
             .with_custom_certificate_verifier(Arc::new(crate::utils::InsecureCertVerifier))
-    } else if let Some(cacert) = config.cacert {
+    } else if let Some(cacert) = config.tls.cacert {
         // Verify that the server certificate is signed with a specific CA cert
         let mut root_cert_store = rustls::RootCertStore::empty();
         root_cert_store.add(cacert).with_context(|_| TlsSnafu {
@@ -109,7 +109,7 @@ pub async fn https_connector(
     };
 
     // Configure client identity for mTLS
-    let tls_config = if let Some((cert, key)) = config.identity {
+    let tls_config = if let Some((cert, key)) = config.tls.identity {
         // Use the the specified client certificate and key for the client authentication
         tls_config
             .with_client_auth_cert(vec![cert], key)
@@ -126,7 +126,7 @@ pub async fn https_connector(
         .with_tls_config(tls_config)
         .https_or_http();
 
-    if let Some(hostname) = &config.override_target {
+    if let Some(hostname) = &config.tls.override_target {
         let server_name = ServerName::try_from(hostname.host().unwrap_or_default())
             .expect("A valid URI host should be a valid ServerName")
             .to_owned();

--- a/packages/rust/armonik-transport/src/connect.rs
+++ b/packages/rust/armonik-transport/src/connect.rs
@@ -135,10 +135,10 @@ pub async fn https_connector(
 
     let mut http = HttpConnector::new();
     http.enforce_http(false); // required for hyper-rustls to switch schemes
-    http.set_nodelay(!config.tcp_nagle_algorithm);
-    http.set_keepalive(config.tcp_keepalive);
-    http.set_keepalive_interval(config.tcp_keepalive_interval);
-    http.set_keepalive_retries(config.tcp_keepalive_retries);
+    http.set_nodelay(!config.tcp.nagle_algorithm);
+    http.set_keepalive(config.tcp.keepalive);
+    http.set_keepalive_interval(config.tcp.keepalive_interval);
+    http.set_keepalive_retries(config.tcp.keepalive_retries);
     if let Some(timeout) = config.connect_timeout {
         http.set_connect_timeout(Some(timeout));
     }

--- a/packages/rust/armonik-transport/src/env.rs
+++ b/packages/rust/armonik-transport/src/env.rs
@@ -245,7 +245,7 @@ mod tests {
         )
         .expect("a value that parses as a number must still be read");
 
-        assert_eq!(args.tcp_keepalive_retries, "3");
+        assert_eq!(args.tcp.keepalive_retries, "3");
         assert_eq!(args.http2_max_header_list_size, "16384");
     }
 

--- a/packages/rust/armonik-transport/src/env.rs
+++ b/packages/rust/armonik-transport/src/env.rs
@@ -145,7 +145,7 @@ mod tests {
         for spelling in ["1", "true", "yes", "enable", "allow", "authorize"] {
             let config = resolve(spelling).expect(spelling);
             assert!(
-                config.allow_unsafe_connection,
+                config.tls.allow_unsafe_connection,
                 "`{spelling}` should read as true"
             );
         }
@@ -153,14 +153,14 @@ mod tests {
         for spelling in ["0", "false", "no", "disable", "disallow", "forbid", ""] {
             let config = resolve(spelling).expect(spelling);
             assert!(
-                !config.allow_unsafe_connection,
+                !config.tls.allow_unsafe_connection,
                 "`{spelling}` should read as false"
             );
         }
 
         // An unusable spelling is the configuration's to reject, naming the option: reading it is
-        // just reading text, and the `deserialize_with` shim that reads it never sees which field
-        // it was called for.
+        // just reading text, and a flattened `serde` source no longer knows which variable it came
+        // from by the time a value is interpreted.
         let rendered = resolve("perhaps")
             .expect_err("`perhaps` is not a boolean")
             .to_string();
@@ -189,7 +189,7 @@ mod tests {
         )
         .expect("reading the variable itself must not fail");
 
-        assert_eq!(args.cert_pem, "no/such/cert.pem");
+        assert_eq!(args.tls.cert_pem, "no/such/cert.pem");
     }
 
     #[test]
@@ -198,27 +198,7 @@ mod tests {
         let args = HttpConfigArgs::from_env("ARMONIK_TEST_NOCERT__")
             .expect("an unset variable names no path");
 
-        assert_eq!(args.cert_pem, "");
-    }
-
-    #[test]
-    #[serial_test::serial]
-    fn a_certificate_variable_present_but_empty_is_no_certificate_either() {
-        // A deployment that declares the variable with an empty default must not be told to open an
-        // empty path: a plain `String` has only one absent representation, the empty string, so
-        // there is no separate empty-but-present case to collapse into by mistake.
-        let args = with_var("ARMONIK_TEST_EMPTYCERT__CertPem", Some(""), || {
-            HttpConfigArgs::from_env("ARMONIK_TEST_EMPTYCERT__")
-        })
-        .expect("an empty variable must not fail the read");
-
-        assert_eq!(args.cert_pem, "");
-        let config = HttpConfig::from_config_args(HttpConfigArgs {
-            endpoint: String::from("http://localhost:5001"),
-            ..args
-        })
-        .expect("an empty cert_pem must not be treated as half an identity");
-        assert!(config.identity.is_none());
+        assert_eq!(args.tls.cert_pem, "");
     }
 
     #[test]
@@ -312,7 +292,27 @@ mod tests {
         )
         .expect("the escape hatch this reader documents must work");
 
-        assert_eq!(args.override_target_name, "[::1]");
+        assert_eq!(args.tls.override_target_name, "[::1]");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn a_certificate_variable_present_but_empty_is_no_certificate_either() {
+        // A deployment that declares the variable with an empty default must not be told to open an
+        // empty path: a plain `String` has only one absent representation, the empty string, so
+        // there is no separate empty-but-present case to collapse into by mistake.
+        let args = with_var("ARMONIK_TEST_EMPTYCERT__CertPem", Some(""), || {
+            HttpConfigArgs::from_env("ARMONIK_TEST_EMPTYCERT__")
+        })
+        .expect("an empty variable must not fail the read");
+
+        assert_eq!(args.tls.cert_pem, "");
+        let config = HttpConfig::from_config_args(HttpConfigArgs {
+            endpoint: String::from("http://localhost:5001"),
+            ..args
+        })
+        .expect("an empty cert_pem must not be treated as half an identity");
+        assert!(config.tls.identity.is_none());
     }
 
     #[test]

--- a/packages/rust/armonik-transport/src/env.rs
+++ b/packages/rust/armonik-transport/src/env.rs
@@ -267,7 +267,7 @@ mod tests {
         )
         .expect("a numeric-looking secret must still be read");
 
-        assert_eq!(args.proxy_password.expose_secret(), "1234");
+        assert_eq!(args.proxy.password.expose_secret(), "1234");
     }
 
     #[test]

--- a/packages/rust/armonik-transport/src/env.rs
+++ b/packages/rust/armonik-transport/src/env.rs
@@ -246,7 +246,7 @@ mod tests {
         .expect("a value that parses as a number must still be read");
 
         assert_eq!(args.tcp.keepalive_retries, "3");
-        assert_eq!(args.http2_max_header_list_size, "16384");
+        assert_eq!(args.http2.max_header_list_size, "16384");
     }
 
     #[test]

--- a/packages/rust/armonik-transport/src/http2_config.rs
+++ b/packages/rust/armonik-transport/src/http2_config.rs
@@ -1,0 +1,82 @@
+//! HTTP/2-level transport options.
+//!
+//! Grouped because their names in the environment already share the `Http2` prefix
+//! (`Http2KeepAliveInterval`, `Http2MaxHeaderListSize`, ...): [`serde_with::with_prefix!`]
+//! reproduces that prefix from [`Http2ConfigArgs`]'s own field names composed with
+//! `#[serde(flatten)]`, so grouping these fields changes no environment variable a deployment
+//! already sets.
+
+use std::time::Duration;
+
+#[cfg(feature = "serde")]
+use crate::config::text;
+use crate::config::{parse_optional_duration, parse_optional_int, ConfigError};
+
+#[cfg(feature = "serde")]
+serde_with::with_prefix!(pub(crate) prefix_http2 "Http2");
+
+/// HTTP/2-level transport options, in the string form a caller supplies them in.
+///
+/// Read from an `Http2`-prefixed variable or JSON key, e.g. [`Self::keep_alive_interval`] is
+/// `Http2KeepAliveInterval`: see the module documentation for why.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "PascalCase", default))]
+#[non_exhaustive]
+pub struct Http2ConfigArgs {
+    /// HTTP/2 PING frame interval (e.g. `20s`), defaults to no keepalive. `Http2KeepAliveInterval`.
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
+    pub keep_alive_interval: String,
+    /// HTTP/2 PING timeout (e.g. `10s`), defaults to no timeout. `Http2KeepAliveTimeout`.
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
+    pub keep_alive_timeout: String,
+    /// Send HTTP/2 keepalive PINGs even when idle, empty for false. `Http2KeepAliveWhileIdle`. See
+    /// [`crate::TlsConfigArgs::allow_unsafe_connection`] for the accepted spellings.
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
+    pub keep_alive_while_idle: String,
+    /// HTTP/2 max header list size in bytes, defaults to no limit. `Http2MaxHeaderListSize`.
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
+    pub max_header_list_size: String,
+}
+
+/// The resolved form of [`Http2ConfigArgs`].
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct Http2Config {
+    /// HTTP/2 PING frame interval, defaults to no keepalive.
+    pub keep_alive_interval: Option<Duration>,
+    /// HTTP/2 PING timeout, defaults to no timeout.
+    pub keep_alive_timeout: Option<Duration>,
+    /// Send HTTP/2 keepalive PINGs even when idle, defaults to false.
+    pub keep_alive_while_idle: bool,
+    /// HTTP/2 max header list size in bytes, defaults to no limit.
+    pub max_header_list_size: Option<u32>,
+}
+
+impl Http2ConfigArgs {
+    pub(crate) fn resolve(self) -> Result<Http2Config, ConfigError> {
+        let Self {
+            keep_alive_interval,
+            keep_alive_timeout,
+            keep_alive_while_idle,
+            max_header_list_size,
+        } = self;
+
+        let keep_alive_interval =
+            parse_optional_duration("http2_keep_alive_interval", keep_alive_interval)?;
+        let keep_alive_timeout =
+            parse_optional_duration("http2_keep_alive_timeout", keep_alive_timeout)?;
+        let max_header_list_size =
+            parse_optional_int::<u32>("http2_max_header_list_size", max_header_list_size)?;
+
+        Ok(Http2Config {
+            keep_alive_interval,
+            keep_alive_timeout,
+            keep_alive_while_idle: crate::config::parse_bool(
+                "http2_keep_alive_while_idle",
+                &keep_alive_while_idle,
+            )?,
+            max_header_list_size,
+        })
+    }
+}

--- a/packages/rust/armonik-transport/src/lib.rs
+++ b/packages/rust/armonik-transport/src/lib.rs
@@ -18,6 +18,7 @@ mod connect;
 mod env;
 mod proxy;
 mod secret;
+mod tcp_config;
 mod utils;
 
 pub use config::{ConfigError, HttpConfig, HttpConfigArgs, ProxyConfig, ProxySource};
@@ -26,6 +27,7 @@ pub use connect::{connect, https_connector, ConnectionError};
 pub use env::EnvFieldError;
 pub use proxy::ProxyError;
 pub use secret::Secret;
+pub use tcp_config::{TcpConfig, TcpConfigArgs};
 // Snafu's context selectors, so a caller in another crate can build the error with the location
 // captured at its own call site. Hidden: this is how the error is built, not API to design against.
 #[doc(hidden)]

--- a/packages/rust/armonik-transport/src/lib.rs
+++ b/packages/rust/armonik-transport/src/lib.rs
@@ -16,6 +16,7 @@ mod config;
 mod connect;
 #[cfg(feature = "env")]
 mod env;
+mod http2_config;
 mod proxy;
 mod secret;
 mod tcp_config;
@@ -25,6 +26,7 @@ pub use config::{ConfigError, HttpConfig, HttpConfigArgs, ProxyConfig, ProxySour
 pub use connect::{connect, https_connector, ConnectionError};
 #[cfg(feature = "env")]
 pub use env::EnvFieldError;
+pub use http2_config::{Http2Config, Http2ConfigArgs};
 pub use proxy::ProxyError;
 pub use secret::Secret;
 pub use tcp_config::{TcpConfig, TcpConfigArgs};

--- a/packages/rust/armonik-transport/src/lib.rs
+++ b/packages/rust/armonik-transport/src/lib.rs
@@ -21,6 +21,7 @@ mod proxy;
 mod proxy_config;
 mod secret;
 mod tcp_config;
+mod tls_config;
 mod utils;
 
 pub use config::{ConfigError, HttpConfig, HttpConfigArgs};
@@ -32,6 +33,7 @@ pub use proxy::ProxyError;
 pub use proxy_config::{ProxyConfig, ProxyConfigArgs, ProxySource};
 pub use secret::Secret;
 pub use tcp_config::{TcpConfig, TcpConfigArgs};
+pub use tls_config::{TlsConfig, TlsConfigArgs};
 // Snafu's context selectors, so a caller in another crate can build the error with the location
 // captured at its own call site. Hidden: this is how the error is built, not API to design against.
 #[doc(hidden)]

--- a/packages/rust/armonik-transport/src/lib.rs
+++ b/packages/rust/armonik-transport/src/lib.rs
@@ -18,16 +18,18 @@ mod connect;
 mod env;
 mod http2_config;
 mod proxy;
+mod proxy_config;
 mod secret;
 mod tcp_config;
 mod utils;
 
-pub use config::{ConfigError, HttpConfig, HttpConfigArgs, ProxyConfig, ProxySource};
+pub use config::{ConfigError, HttpConfig, HttpConfigArgs};
 pub use connect::{connect, https_connector, ConnectionError};
 #[cfg(feature = "env")]
 pub use env::EnvFieldError;
 pub use http2_config::{Http2Config, Http2ConfigArgs};
 pub use proxy::ProxyError;
+pub use proxy_config::{ProxyConfig, ProxyConfigArgs, ProxySource};
 pub use secret::Secret;
 pub use tcp_config::{TcpConfig, TcpConfigArgs};
 // Snafu's context selectors, so a caller in another crate can build the error with the location

--- a/packages/rust/armonik-transport/src/proxy.rs
+++ b/packages/rust/armonik-transport/src/proxy.rs
@@ -202,7 +202,7 @@ fn decode_basic_auth(value: &HeaderValue) -> (String, String) {
 /// The rule both credential-merging call sites apply: a dedicated username or password set alone
 /// must not discard the other half of whatever the proxy URL carried, or the request fails as an
 /// unexplained 407. Used here for a proxy taken from the environment, and by
-/// `HttpConfig::from_config_args` for one configured explicitly.
+/// `ProxyConfigArgs::resolve` for one configured explicitly.
 pub(crate) fn prefer_dedicated<'a>(dedicated: &'a str, from_url: &'a str) -> &'a str {
     if dedicated.is_empty() {
         from_url
@@ -300,8 +300,7 @@ pub enum ProxyError {
         location: snafu::Location,
     },
     #[snafu(display(
-        "The proxy requires authentication; set `GrpcClient__ProxyUsername` and \
-         `GrpcClient__ProxyPassword` [{location}]"
+        "The proxy requires authentication; set `proxy_username` and `proxy_password` [{location}]"
     ))]
     #[non_exhaustive]
     AuthenticationRequired {

--- a/packages/rust/armonik-transport/src/proxy_config.rs
+++ b/packages/rust/armonik-transport/src/proxy_config.rs
@@ -1,0 +1,199 @@
+//! Everything about the HTTP proxy: where to find it, its resolved configuration, and the string
+//! form a caller supplies it in.
+//!
+//! [`ProxyConfigArgs`] holds all three fields together. `username`/`password` share the `Proxy`
+//! prefix uniformly (`ProxyUsername`, `ProxyPassword`), but `source` does not: it is `Proxy` alone,
+//! ArmoniK's own convention across every client. [`serde_with::with_prefix!`] can only apply the
+//! same prefix to every field of a group, so each field is renamed individually here instead.
+
+use hyper::Uri;
+
+#[cfg(feature = "serde")]
+use crate::config::{secret_text, text};
+use crate::config::{ConfigError, IncompatibleOptionsSnafu};
+use crate::secret::Secret;
+
+/// Where to find the HTTP proxy used to reach the endpoint.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ProxySource {
+    /// Connect directly, ignoring any proxy configured in the environment.
+    ///
+    /// The default: a client that asks for nothing connects directly.
+    #[default]
+    Disabled,
+    /// Read the proxy from the environment, on `hyper_util`'s rules: `ALL_PROXY`, `HTTPS_PROXY`,
+    /// `HTTP_PROXY` and `NO_PROXY`, in either case, with `NO_PROXY` matched as curl matches it.
+    ///
+    /// Read once, when `connect` builds the channel, so one that reconnects keeps the values it
+    /// started with. Every other option is read in [`crate::HttpConfigArgs::from_env`].
+    System,
+    /// Use this specific proxy.
+    Explicit(Uri),
+}
+
+/// Configuration of the HTTP proxy used to reach the endpoint.
+///
+/// Proxying uses a `CONNECT` tunnel, so TLS, mutual TLS included, is negotiated end to end with the
+/// real server and the proxy never sees the plaintext.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ProxyConfig {
+    /// Where to find the proxy.
+    pub source: ProxySource,
+    /// Username for proxy authentication, empty for none.
+    pub username: String,
+    /// Password for proxy authentication, empty for none.
+    pub password: Secret,
+}
+
+impl ProxyConfig {
+    /// Use this specific proxy.
+    ///
+    /// Credentials written into the URL are taken out of it and kept here, so the URI carries none
+    /// wherever it is rendered. The type is `#[non_exhaustive]`, so this is the way in.
+    pub fn explicit(uri: Uri) -> Self {
+        let (uri, credentials) = crate::proxy::split_credentials(uri);
+        let (username, password) = credentials.unwrap_or_default();
+        Self {
+            source: ProxySource::Explicit(uri),
+            username,
+            password: password.into(),
+        }
+    }
+
+    /// Read the proxy from the environment.
+    pub fn system() -> Self {
+        Self {
+            source: ProxySource::System,
+            ..Default::default()
+        }
+    }
+
+    /// Attach credentials for proxy authentication.
+    pub fn with_credentials(
+        mut self,
+        username: impl Into<String>,
+        password: impl Into<Secret>,
+    ) -> Self {
+        self.username = username.into();
+        self.password = password.into();
+        self
+    }
+
+    /// Credentials to present to the proxy, if any were configured.
+    pub fn credentials(&self) -> Option<(&str, &str)> {
+        if self.username.is_empty() && self.password.is_empty() {
+            None
+        } else {
+            Some((&self.username, self.password.expose_secret()))
+        }
+    }
+}
+
+/// Everything about the HTTP proxy, in the string form a caller supplies it in.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
+#[non_exhaustive]
+pub struct ProxyConfigArgs {
+    /// Where to find the proxy. `Proxy`.
+    ///
+    /// Empty for a direct connection, `none` to disable proxying explicitly, `system` to read the
+    /// environment (see [`ProxySource::System`]), otherwise the proxy URL, whose scheme has to be
+    /// `http`: the `CONNECT` handshake is written in the clear.
+    #[cfg_attr(feature = "serde", serde(rename = "Proxy", deserialize_with = "text"))]
+    pub source: String,
+    /// Username for proxy authentication. `ProxyUsername`.
+    ///
+    /// Empty falls back to the username `source` carried, if any.
+    #[cfg_attr(
+        feature = "serde",
+        serde(rename = "ProxyUsername", deserialize_with = "text")
+    )]
+    pub username: String,
+    /// Password for proxy authentication. `ProxyPassword`.
+    ///
+    /// Empty falls back to the password `source` carried, independently of the username, so setting
+    /// this one alone still uses that URL's username. Redacted wherever it is written; see
+    /// [`Secret`].
+    #[cfg_attr(
+        feature = "serde",
+        serde(rename = "ProxyPassword", deserialize_with = "secret_text")
+    )]
+    pub password: Secret,
+}
+
+impl ProxyConfigArgs {
+    /// Resolves `source`, then merges the dedicated credentials into it field by field rather than
+    /// pair by pair: a dedicated option set alone must not discard the other half of whatever
+    /// credentials `source` carried. See [`crate::proxy::prefer_dedicated`].
+    pub(crate) fn resolve(self) -> Result<ProxyConfig, ConfigError> {
+        let Self {
+            source,
+            username,
+            password,
+        } = self;
+
+        let proxy = match parse_proxy_source(&source)? {
+            // Through the constructor, so credentials written into the URL are taken out of it.
+            ProxySource::Explicit(uri) => ProxyConfig::explicit(uri),
+            ProxySource::System => ProxyConfig::system(),
+            ProxySource::Disabled => ProxyConfig::default(),
+        };
+
+        let username = crate::proxy::prefer_dedicated(&username, &proxy.username).to_owned();
+        let password = Secret::from(crate::proxy::prefer_dedicated(
+            password.expose_secret(),
+            proxy.password.expose_secret(),
+        ));
+        Ok(proxy.with_credentials(username, password))
+    }
+}
+
+/// As ArmoniK's other clients spell it: empty is a direct connection, `none` disables proxying,
+/// `system` reads the environment, anything else is a proxy URL, defaulting to the `http` scheme.
+fn parse_proxy_source(proxy: &str) -> Result<ProxySource, ConfigError> {
+    match proxy {
+        "" => Ok(ProxySource::Disabled),
+        _ if proxy.eq_ignore_ascii_case("none") => Ok(ProxySource::Disabled),
+        _ if proxy.eq_ignore_ascii_case("system") => Ok(ProxySource::System),
+        _ => {
+            let with_scheme = if proxy.contains("://") {
+                proxy.to_owned()
+            } else {
+                format!("http://{proxy}")
+            };
+            // Not reported through `UriSnafu`: its message names the endpoint, which would send
+            // whoever reads it looking at the wrong option.
+            let uri = Uri::try_from(&with_scheme).ok().filter(|uri| {
+                uri.authority()
+                    .is_some_and(|authority| !authority.host().is_empty())
+            });
+            match uri {
+                // Caught here rather than at connect time, so a mistyped option fails while the
+                // configuration is being read and names itself.
+                Some(uri) if uri.scheme_str().is_some_and(|scheme| scheme != "http") => {
+                    IncompatibleOptionsSnafu {
+                        msg: format!(
+                            "The `CONNECT` handshake is written in the clear, so only an `http` \
+                             proxy can be reached, and `proxy={}` names another scheme",
+                            crate::proxy::elide_userinfo(proxy)
+                        ),
+                    }
+                    .fail()
+                }
+                Some(uri) => Ok(ProxySource::Explicit(uri)),
+                None => IncompatibleOptionsSnafu {
+                    // Elided: a URL rejected for having no host can still have carried a password.
+                    msg: format!(
+                        "`proxy={}` is not a valid proxy URL. Expected `none`, \
+                         `system`, or a URL such as `http://proxy.example.com:3128`",
+                        crate::proxy::elide_userinfo(proxy)
+                    ),
+                }
+                .fail(),
+            }
+        }
+    }
+}

--- a/packages/rust/armonik-transport/src/tcp_config.rs
+++ b/packages/rust/armonik-transport/src/tcp_config.rs
@@ -1,0 +1,78 @@
+//! TCP-level socket options.
+//!
+//! Grouped because their names in the environment already share the `Tcp` prefix
+//! (`TcpKeepalive`, `TcpKeepaliveInterval`, ...): [`serde_with::with_prefix!`] reproduces that
+//! prefix from [`TcpConfigArgs`]'s own field names composed with `#[serde(flatten)]`, so grouping
+//! these fields changes no environment variable a deployment already sets.
+
+use std::time::Duration;
+
+#[cfg(feature = "serde")]
+use crate::config::text;
+use crate::config::{parse_optional_duration, parse_optional_int, ConfigError};
+
+#[cfg(feature = "serde")]
+serde_with::with_prefix!(pub(crate) prefix_tcp "Tcp");
+
+/// TCP-level socket options, in the string form a caller supplies them in.
+///
+/// Read from a `Tcp`-prefixed variable or JSON key, e.g. [`Self::keepalive`] is `TcpKeepalive`: see
+/// the module documentation for why.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "PascalCase", default))]
+#[non_exhaustive]
+pub struct TcpConfigArgs {
+    /// TCP keepalive duration (e.g. `30s`), defaults to no keepalive. `TcpKeepalive`.
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
+    pub keepalive: String,
+    /// Interval between TCP keepalive probes (e.g. `5s`), defaults to OS default.
+    /// `TcpKeepaliveInterval`.
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
+    pub keepalive_interval: String,
+    /// Number of TCP keepalive retries, defaults to OS default. `TcpKeepaliveRetries`.
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
+    pub keepalive_retries: String,
+    /// Enable Nagle's algorithm (disable TCP_NODELAY), empty for false. `TcpNagleAlgorithm`. See
+    /// [`crate::TlsConfigArgs::allow_unsafe_connection`] for the accepted spellings.
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
+    pub nagle_algorithm: String,
+}
+
+/// The resolved form of [`TcpConfigArgs`].
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct TcpConfig {
+    /// TCP keepalive duration, defaults to no keepalive.
+    pub keepalive: Option<Duration>,
+    /// Interval between TCP keepalive probes, defaults to OS default.
+    pub keepalive_interval: Option<Duration>,
+    /// Number of TCP keepalive retries, defaults to OS default.
+    pub keepalive_retries: Option<u32>,
+    /// Enable Nagle's algorithm (disable TCP_NODELAY), defaults to false.
+    pub nagle_algorithm: bool,
+}
+
+impl TcpConfigArgs {
+    pub(crate) fn resolve(self) -> Result<TcpConfig, ConfigError> {
+        let Self {
+            keepalive,
+            keepalive_interval,
+            keepalive_retries,
+            nagle_algorithm,
+        } = self;
+
+        let keepalive = parse_optional_duration("tcp_keepalive", keepalive)?;
+        let keepalive_interval =
+            parse_optional_duration("tcp_keepalive_interval", keepalive_interval)?;
+        let keepalive_retries =
+            parse_optional_int::<u32>("tcp_keepalive_retries", keepalive_retries)?;
+
+        Ok(TcpConfig {
+            keepalive,
+            keepalive_interval,
+            keepalive_retries,
+            nagle_algorithm: crate::config::parse_bool("tcp_nagle_algorithm", &nagle_algorithm)?,
+        })
+    }
+}

--- a/packages/rust/armonik-transport/src/tls_config.rs
+++ b/packages/rust/armonik-transport/src/tls_config.rs
@@ -1,0 +1,172 @@
+//! TLS and mTLS: the client's own identity, the server's CA, and the two options that change how
+//! verification behaves rather than what is verified.
+//!
+//! Unlike the `Tcp`/`Http2` units, these fields share no common prefix in the environment (`CertPem`,
+//! `CaCert`, `AllowUnsafeConnection`, `OverrideTargetName`, ...), so grouping them is a plain
+//! [`serde(flatten)`](serde::Deserialize), with no [`serde_with::with_prefix!`] needed: every name
+//! here already matches today's flat one exactly.
+
+use hyper::Uri;
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+
+#[cfg(feature = "serde")]
+use crate::config::text;
+use crate::config::{boxed, ConfigError, IncompatibleOptionsSnafu, IoSnafu, TlsSnafu, UriSnafu};
+use snafu::ResultExt;
+
+/// The client's TLS identity and the server's CA, in the string form a caller supplies them in.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "PascalCase", default))]
+#[non_exhaustive]
+pub struct TlsConfigArgs {
+    /// A file this crate reads: the client's own certificate, matching `key_pem`.
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
+    pub cert_pem: String,
+    /// A file this crate reads: the client's own key, matching `cert_pem`.
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
+    pub key_pem: String,
+    /// A file this crate reads: the Certificate Authority.
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
+    pub ca_cert: String,
+    /// Accept any server certificate instead of verifying it, empty for false.
+    ///
+    /// Spelled as any other ArmoniK client accepts it: `1`, `true`, `yes`, `enable`, `allow` or
+    /// `authorize`, and their negatives. A `serde` source may also give a real boolean.
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
+    pub allow_unsafe_connection: String,
+    /// Override the endpoint name during SSL verification
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
+    pub override_target_name: String,
+}
+
+/// The resolved form of [`TlsConfigArgs`].
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub struct TlsConfig {
+    /// Allow unsafe connections to the endpoint (without SSL), defaults to false.
+    pub allow_unsafe_connection: bool,
+    /// TLS identity of the client: key + cert, loaded from `cert_pem`/`key_pem`.
+    pub identity: Option<(CertificateDer<'static>, PrivateKeyDer<'static>)>,
+    /// CA certificate to authenticate the server.
+    pub cacert: Option<CertificateDer<'static>>,
+    /// Override the endpoint name during SSL verification.
+    pub override_target: Option<Uri>,
+}
+
+impl Clone for TlsConfig {
+    fn clone(&self) -> Self {
+        Self {
+            allow_unsafe_connection: self.allow_unsafe_connection,
+            identity: self
+                .identity
+                .as_ref()
+                .map(|(cert, key)| (cert.clone(), key.clone_key())),
+            cacert: self.cacert.clone(),
+            override_target: self.override_target.clone(),
+        }
+    }
+}
+
+/// Reads `path` and parses it as one PEM-encoded certificate.
+fn read_cert_pem(option: &'static str, path: &str) -> Result<CertificateDer<'static>, ConfigError> {
+    let pem = std::fs::read_to_string(path).context(IoSnafu { option, path })?;
+    CertificateDer::from_pem_slice(pem.as_bytes()).context(TlsSnafu {})
+}
+
+/// Reads `path`, `key_pem`'s own file, whose loaded bytes are as sensitive as the key they carry
+/// the moment they leave the filesystem.
+fn read_key_pem(option: &'static str, path: &str) -> Result<PrivateKeyDer<'static>, ConfigError> {
+    let pem = std::fs::read_to_string(path).context(IoSnafu { option, path })?;
+    PrivateKeyDer::from_pem_slice(pem.as_bytes()).context(TlsSnafu {})
+}
+
+impl TlsConfigArgs {
+    /// Resolves against `endpoint`: an override target given as a bare host keeps the endpoint's own
+    /// scheme and path, and is otherwise a full URI whose authority and path replace the endpoint's,
+    /// but never its scheme, since the connection is still made to the endpoint. Only the name it is
+    /// verified against changes.
+    pub(crate) fn resolve(self, endpoint: &Uri) -> Result<TlsConfig, ConfigError> {
+        let Self {
+            cert_pem,
+            key_pem,
+            ca_cert,
+            allow_unsafe_connection,
+            override_target_name,
+        } = self;
+
+        let cacert = if ca_cert.is_empty() {
+            None
+        } else {
+            Some(read_cert_pem("ca_cert", &ca_cert)?)
+        };
+
+        let identity = match (cert_pem.is_empty(), key_pem.is_empty()) {
+            (true, true) => None,
+            (false, false) => Some((
+                read_cert_pem("cert_pem", &cert_pem)?,
+                read_key_pem("key_pem", &key_pem)?,
+            )),
+            _ => {
+                return IncompatibleOptionsSnafu {
+                    msg: String::from(
+                        "`cert_pem` and `key_pem` must be either both empty or both set",
+                    ),
+                }
+                .fail()
+            }
+        };
+
+        let override_target = if override_target_name.is_empty() {
+            None
+        } else {
+            let authority;
+            let path_and_query;
+
+            if let Ok(auth) = override_target_name.parse::<hyper::http::uri::Authority>() {
+                authority = Some(auth);
+                path_and_query = endpoint.path_and_query().cloned();
+            } else {
+                hyper::http::uri::Parts {
+                    authority,
+                    path_and_query,
+                    ..
+                } = Uri::try_from(override_target_name.as_str())
+                    .map_err(boxed)
+                    .context(UriSnafu {
+                        option: "override_target_name",
+                        uri: override_target_name.clone(),
+                    })?
+                    .into_parts();
+            }
+
+            let mut uri = hyper::http::uri::Builder::new();
+
+            if let Some(scheme) = endpoint.scheme() {
+                uri = uri.scheme(scheme.clone());
+            }
+            if let Some(authority) = authority.or_else(|| endpoint.authority().cloned()) {
+                uri = uri.authority(authority);
+            }
+            if let Some(path_and_query) = path_and_query {
+                uri = uri.path_and_query(path_and_query);
+            }
+
+            Some(uri.build().map_err(boxed).context(UriSnafu {
+                option: "override_target_name",
+                uri: override_target_name,
+            })?)
+        };
+
+        Ok(TlsConfig {
+            allow_unsafe_connection: crate::config::parse_bool(
+                "allow_unsafe_connection",
+                &allow_unsafe_connection,
+            )?,
+            identity,
+            cacert,
+            override_target,
+        })
+    }
+}

--- a/packages/rust/armonik-transport/tests/common/mod.rs
+++ b/packages/rust/armonik-transport/tests/common/mod.rs
@@ -162,6 +162,34 @@ pub async fn call(
     Ok(response.into_inner())
 }
 
+/// Sets an environment variable for as long as the guard lives, restoring whatever it held before -
+/// absent included - on drop, panic included: a test failing before it would have removed the
+/// variable itself must not leak it into whichever `serial(env)` test runs next.
+pub struct EnvGuard {
+    name: String,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    pub fn set(name: &str, value: &str) -> Self {
+        let previous = std::env::var_os(name);
+        std::env::set_var(name, value);
+        Self {
+            name: name.to_owned(),
+            previous,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match self.previous.take() {
+            Some(previous) => std::env::set_var(&self.name, previous),
+            None => std::env::remove_var(&self.name),
+        }
+    }
+}
+
 /// Build a [`HttpConfig`] from the string form, applying `set` to the arguments first.
 ///
 /// Going through `HttpConfigArgs` keeps the parsing inside what is under test. It is a helper at all

--- a/packages/rust/armonik-transport/tests/common/mod.rs
+++ b/packages/rust/armonik-transport/tests/common/mod.rs
@@ -202,7 +202,7 @@ pub fn config(
 ) -> armonik_transport::HttpConfig {
     let mut args = armonik_transport::HttpConfigArgs::default();
     args.endpoint = endpoint.to_owned();
-    args.allow_unsafe_connection = "true".to_owned();
+    args.tls.allow_unsafe_connection = String::from("true");
     set(&mut args);
     armonik_transport::HttpConfig::from_config_args(args)
         .expect("the configuration should be valid")

--- a/packages/rust/armonik-transport/tests/proxy.rs
+++ b/packages/rust/armonik-transport/tests/proxy.rs
@@ -137,10 +137,10 @@ fn through_proxy(
     credentials: Option<(&str, &str)>,
 ) -> HttpConfig {
     common::config(endpoint, |args| {
-        args.proxy = format!("http://{proxy}");
+        args.proxy.source = format!("http://{proxy}");
         if let Some((username, password)) = credentials {
-            args.proxy_username = String::from(username);
-            args.proxy_password = password.into();
+            args.proxy.username = String::from(username);
+            args.proxy.password = password.into();
         }
     })
 }
@@ -231,7 +231,7 @@ async fn credentials_written_into_the_proxy_url_authenticate_the_tunnel() {
     // The conventional `HTTPS_PROXY` form. Accepting the URL and then not authenticating with it is
     // the failure this pins.
     let config = common::config(&server, |args| {
-        args.proxy = format!("http://user:secret@{proxy}");
+        args.proxy.source = format!("http://user:secret@{proxy}");
     });
 
     let answer = call_through(config)
@@ -260,7 +260,7 @@ async fn a_missing_credential_is_reported_as_such() {
         "unexpected error: {rendered}"
     );
     assert!(
-        rendered.contains("GrpcClient__ProxyUsername"),
+        rendered.contains("proxy_username"),
         "the error should say which options to set: {rendered}"
     );
     assert_eq!(stats.rejected.load(Ordering::SeqCst), 1);
@@ -340,12 +340,11 @@ async fn system_mode_takes_the_proxy_from_the_environment() {
     // The variable has to still be set when `connect` runs, not merely when the configuration is
     // built: `system` resolves the environment as the connection is made. Every other option is read
     // once, in `HttpConfigArgs::from_env`.
-    std::env::set_var("HTTP_PROXY", format!("http://{proxy}"));
+    let _http_proxy = common::EnvGuard::set("HTTP_PROXY", &format!("http://{proxy}"));
     let outcome = call_through(common::config(&server, |args| {
-        args.proxy = String::from("system")
+        args.proxy.source = String::from("system")
     }))
     .await;
-    std::env::remove_var("HTTP_PROXY");
 
     assert_eq!(
         outcome.expect("the call should go through the proxy the environment names"),
@@ -360,14 +359,12 @@ async fn no_proxy_bypasses_the_proxy_in_system_mode() {
     let server = spawn_server().await;
     let (proxy, stats) = spawn_proxy(ProxyAuth::None).await;
 
-    std::env::set_var("HTTP_PROXY", format!("http://{proxy}"));
-    std::env::set_var("NO_PROXY", "127.0.0.1");
+    let _http_proxy = common::EnvGuard::set("HTTP_PROXY", &format!("http://{proxy}"));
+    let _no_proxy = common::EnvGuard::set("NO_PROXY", "127.0.0.1");
     let outcome = call_through(common::config(&server, |args| {
-        args.proxy = String::from("system")
+        args.proxy.source = String::from("system")
     }))
     .await;
-    std::env::remove_var("HTTP_PROXY");
-    std::env::remove_var("NO_PROXY");
 
     assert_eq!(outcome.expect("a direct call succeeds"), common::REPLY);
     assert_eq!(
@@ -386,9 +383,8 @@ async fn no_proxy_does_not_apply_to_an_explicitly_configured_proxy() {
     // `NO_PROXY` belongs to the same environment convention as `HTTP_PROXY`, so it governs `system`
     // only. ArmoniK's other clients give an explicitly named proxy an empty bypass list, and diverging
     // would mean a request skipping the proxy here while using it there.
-    std::env::set_var("NO_PROXY", "127.0.0.1");
+    let _no_proxy = common::EnvGuard::set("NO_PROXY", "127.0.0.1");
     let outcome = call_through(through_proxy(&server, proxy, None)).await;
-    std::env::remove_var("NO_PROXY");
 
     assert_eq!(
         outcome.expect("an explicit proxy is used whatever NO_PROXY says"),
@@ -407,13 +403,12 @@ async fn a_dedicated_credential_in_system_mode_keeps_the_other_half_the_url_carr
     // The base64 of `url-user:new`, what the client is expected to send once the two are merged.
     let (proxy, stats) = spawn_proxy(ProxyAuth::Required("dXJsLXVzZXI6bmV3")).await;
 
-    std::env::set_var("HTTP_PROXY", format!("http://url-user:old@{proxy}"));
+    let _http_proxy = common::EnvGuard::set("HTTP_PROXY", &format!("http://url-user:old@{proxy}"));
     let outcome = call_through(common::config(&server, |args| {
-        args.proxy = String::from("system");
-        args.proxy_password = String::from("new").into();
+        args.proxy.source = String::from("system");
+        args.proxy.password = String::from("new").into();
     }))
     .await;
-    std::env::remove_var("HTTP_PROXY");
 
     assert_eq!(
         outcome.expect("the merged credentials should satisfy the proxy"),
@@ -534,12 +529,11 @@ async fn an_https_proxy_from_the_environment_is_refused_before_dialling() {
     // it would write the handshake in the clear to a proxy expecting TLS.
     let server = spawn_server().await;
 
-    std::env::set_var("HTTP_PROXY", "https://proxy.corp:3128");
+    let _http_proxy = common::EnvGuard::set("HTTP_PROXY", "https://proxy.corp:3128");
     let outcome = call_through(common::config(&server, |args| {
-        args.proxy = String::from("system")
+        args.proxy.source = String::from("system")
     }))
     .await;
-    std::env::remove_var("HTTP_PROXY");
 
     let error = error_chain(
         outcome


### PR DESCRIPTION
Second of three PRs replacing #705 (see wk/refactor/rust-config-figment for the first). Groups
the flat config fields into thematic units, each with its own `{Unit}ConfigArgs`/`{Unit}Config`
pair and `resolve()`, in a new file per unit.

- `tcp_config.rs`, `http2_config.rs`: grouped via `#[serde(flatten)]` +
  `serde_with::with_prefix!`, since their fields already share one literal prefix (`Tcp*`,
  `Http2*`). Every environment variable and JSON key stays exactly as it is today.
  `parse_optional_duration`/`parse_optional_int` land in `config.rs` as shared helpers,
  introduced here and reused by every field that needs "empty means None, else parse" from
  now on, so nothing later has to deduplicate copy-pasted parsing.
- `proxy_config.rs`: `ProxyConfigArgs { source, username, password }` in its final shape from
  the start, each field individually renamed since they do not share one prefix. Adds the
  `EnvGuard` RAII helper to `tests/common/mod.rs` so a proxy env-var test that panics between
  `set_var` and `remove_var` cannot leak state into the next `serial(env)` test.
- `tls_config.rs`: `TlsConfigArgs`/`TlsConfig`, grouped via plain `#[serde(flatten)]`. Fixes a
  real bug while moving this code: `override_target_name` that failed to parse named the
  endpoint in its error instead of the value that actually failed. `ConfigError::Uri` and
  `::Http` merge into one `Uri` variant parameterized by `option: &'static str`, the same
  convention every other variant already follows. `TlsConfig` gets a hand-written `Clone`
  (`PrivateKeyDer` has none, only `clone_key()`); `HttpConfig` switches from its own
  hand-written `Clone` to `#[derive(Clone)]` in the same commit, now that every field is
  `Clone` on its own. No PKCS12 yet - that is the third PR.

Stacked as: wk/refactor/rust-config-figment -> this PR -> wk/feat/rust-pkcs12.
