### PR TITLE
feat(rust): load a client certificate from a PKCS12 bundle

### DIFF
--- a/packages/rust/Cargo.lock
+++ b/packages/rust/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,7 +99,9 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "p12-keystore",
  "percent-encoding",
+ "rcgen",
  "rustls",
  "secrecy",
  "serde",
@@ -77,6 +114,45 @@ dependencies = [
  "tonic",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -183,10 +259,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
 
 [[package]]
 name = "bs58"
@@ -216,6 +325,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +350,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +371,41 @@ dependencies = [
  "serde",
  "windows-link",
 ]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "cms"
+version = "0.3.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758d5272932ff167e96ec9641a04d96ab1901cccc5ea9f47c15b4cbaa6f9ea53"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -260,12 +424,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "des"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "ctutils",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -336,6 +618,12 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "fnv"
@@ -457,8 +745,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
 ]
 
 [[package]]
@@ -514,6 +812,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +870,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -705,6 +1021,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +1129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +1152,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,10 +1171,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -841,6 +1202,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -854,6 +1224,29 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "p12-keystore"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02686a966a6d270eb3e87178c70323a30a62741e59b37e542ff029fb774afa47"
+dependencies = [
+ "cbc",
+ "cms",
+ "der",
+ "des",
+ "hex",
+ "hmac",
+ "pkcs12",
+ "pkcs5",
+ "pkcs8",
+ "rand",
+ "rc2",
+ "sha1",
+ "sha2",
+ "thiserror",
+ "x509-parser",
+]
 
 [[package]]
 name = "parking_lot"
@@ -879,6 +1272,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "pear"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +1302,25 @@ dependencies = [
  "proc-macro2-diagnostics",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -943,6 +1365,58 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs12"
+version = "0.2.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8059bd79345d1d1c125656025814704bab5cdd204b1cefd5fab59b0fdd7476d2"
+dependencies = [
+ "cms",
+ "const-oid",
+ "der",
+ "digest",
+ "spki",
+ "x509-cert",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d440a804ec8d6fafbb6b84471e013286658d373248927692ab3366686220ca"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "scrypt",
+ "sha2",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
+dependencies = [
+ "cpubits",
+ "cpufeatures",
+ "universal-hash",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1071,6 +1545,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rc2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceda21af1ae61033b63175653a1af86cae399d79cd03ca80ba347eb3a6c4a7fe"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,6 +1657,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,6 +1732,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "salsa20"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
+dependencies = [
+ "cfg-if",
+ "cipher",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,6 +1779,18 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
+dependencies = [
+ "cfg-if",
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "secrecy"
@@ -1373,6 +1918,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,6 +1998,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,6 +2042,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,6 +2063,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1770,6 +2378,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,6 +2409,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common",
+ "ctutils",
+]
 
 [[package]]
 name = "untrusted"
@@ -2162,10 +2786,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-cert"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
+]
 
 [[package]]
 name = "zeroize"

--- a/packages/rust/Cargo.toml
+++ b/packages/rust/Cargo.toml
@@ -31,9 +31,11 @@ humantime = "2.3.0"
 hyper = "1.10"
 hyper-rustls = { version = "0.27", default-features = false }
 hyper-util = "0.1"
+p12-keystore = "0.3"
 percent-encoding = "2.3"
 prost = "0.14"
 prost-types = "0.14"
+rcgen = "0.14"
 rustls = { version = "0.23", default-features = false }
 secrecy = "0.10"
 # `std` as well as `derive`: without it `String` implements neither `Serialize` nor `Deserialize`, so

--- a/packages/rust/armonik-transport/Cargo.toml
+++ b/packages/rust/armonik-transport/Cargo.toml
@@ -53,6 +53,9 @@ serde = { workspace = true, optional = true }
 # keeping the option's own definition in its own thematic file. `std` because `with_prefix!` is
 # gated behind it.
 serde_with = { workspace = true, optional = true, default-features = false, features = ["std"] }
+# Reads a client certificate bundled with its key as a PKCS#12 file, the form Windows and most
+# certificate authorities hand out; pure Rust, so it does not pull in an OpenSSL of its own.
+p12-keystore.workspace = true
 humantime.workspace = true
 # `Proxy-Authorization: Basic` needs it. Already in the tree through `tonic`, so declaring it adds
 # nothing to the build.
@@ -73,8 +76,10 @@ secrecy.workspace = true
 serial_test.workspace = true
 # Only to round-trip `HttpConfigArgs` in the test that pins the `serde` feature.
 serde_json.workspace = true
-# A real file for the certificate-loading tests to read: garbage content that is not a valid PEM.
+# A real file for the certificate-loading tests to read: a PEM, or a garbage PKCS#12 bundle.
 tempfile.workspace = true
+# A self-signed certificate and key, generated fresh in the PKCS#12 test rather than committed.
+rcgen.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 # The integration tests serve a gRPC service to call, which the regular build never does; these features
 # union with the `channel`/`codegen` above for test builds only.

--- a/packages/rust/armonik-transport/README.md
+++ b/packages/rust/armonik-transport/README.md
@@ -7,6 +7,23 @@ Depend on it when you need the connection layer without generated protobuf types
 `protoc`/`tonic-prost-build` build step. [`armonik`](../armonik) re-exports all of it, so a client that
 wants the services as well needs only that one.
 
+## TLS and mutual TLS
+
+`ca_cert` authenticates the server; `cert_pem` and `key_pem` together are the client's own identity
+for mutual TLS, and must be either both set or both empty. All three are files this crate reads
+itself.
+
+`cert_p12` is an alternative to `cert_pem`/`key_pem`: the client's certificate and key bundled
+together in one PKCS#12 file, the form Windows and most certificate authorities hand out, optionally
+protected by `cert_p12_password`. Mutually exclusive with `cert_pem`/`key_pem` - set one identity or
+the other, never both.
+
+`cert_p12_password` is `Secret`, redacted by `Debug` and by serialisation; the other paths are not
+secrets themselves, only what they lead to is. `allow_unsafe_connection` accepts any server
+certificate instead of verifying it, for a self-signed endpoint; it has no effect on a plain `http://`
+endpoint, which never negotiates TLS at all. `override_target_name` overrides the name checked during
+verification, for an endpoint reached by an address that does not match its certificate.
+
 ## Reaching the endpoint through a proxy
 
 `proxy` takes four forms, the same ArmoniK uses everywhere else: empty for a direct connection,

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -192,7 +192,7 @@ pub(crate) fn text<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<
     deserializer.deserialize_any(AnyScalar)
 }
 
-/// [`text`], for the one field whose value is a [`Secret`] rather than a plain `String`.
+/// [`text`], for the two fields whose value is a [`Secret`] rather than a plain `String`.
 #[cfg(feature = "serde")]
 pub(crate) fn secret_text<'de, D: serde::Deserializer<'de>>(
     deserializer: D,
@@ -208,6 +208,9 @@ impl HttpConfig {
             args.tls.cert_pem,
             args.tls.key_pem,
             args.tls.ca_cert,
+            args.tls.cert_p12,
+            // `cert_p12_password` left out entirely, the same as `proxy_password` below: a path
+            // names no secret, but a password does.
             args.tls.allow_unsafe_connection,
             args.tls.override_target_name,
             args.connect_timeout,
@@ -357,6 +360,24 @@ pub enum ConfigError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+    #[snafu(display("`cert_p12`'s file `{path}` is not a valid PKCS#12 bundle [{location}]"))]
+    #[non_exhaustive]
+    Pkcs12 {
+        #[snafu(source(from(p12_keystore::error::Error, Box::new)))]
+        source: Box<p12_keystore::error::Error>,
+        path: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display(
+        "`cert_p12`'s file `{path}` carries no private key and certificate chain [{location}]"
+    ))]
+    #[non_exhaustive]
+    EmptyPkcs12 {
+        path: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
     #[snafu(display("{msg} [{location}]"))]
     #[non_exhaustive]
     IncompatibleOptions {
@@ -415,8 +436,11 @@ pub enum ConfigError {
 
 #[cfg(test)]
 mod tests {
+    use rustls::pki_types::PrivateKeyDer;
+
     use super::*;
     use crate::proxy_config::ProxySource;
+    use crate::secret::Secret;
 
     /// The minimum viable arguments: an endpoint, and nothing else set.
     fn args() -> HttpConfigArgs {
@@ -640,12 +664,15 @@ mod tests {
     #[test]
     fn half_an_identity_is_rejected_and_names_both_variables() {
         // Half an identity is silent on a plain-TLS endpoint and only surfaces as a rejected handshake
-        // on an mTLS one. Neither path is read from disk before the check, so this needs no fixture.
-        for (cert, key) in [("cert.pem", ""), ("", "key.pem")] {
+        // on an mTLS one, so it is caught before either half is parsed.
+        for (cert, key) in [
+            (String::from("cert.pem"), String::new()),
+            (String::new(), String::from("key.pem")),
+        ] {
             let error = HttpConfig::from_config_args(HttpConfigArgs {
                 tls: TlsConfigArgs {
-                    cert_pem: String::from(cert),
-                    key_pem: String::from(key),
+                    cert_pem: cert,
+                    key_pem: key,
                     ..Default::default()
                 },
                 ..args()
@@ -747,6 +774,127 @@ mod tests {
         .expect_err("this file holds no certificate");
 
         assert!(matches!(error, ConfigError::Tls { .. }), "{error:?}");
+    }
+
+    #[test]
+    fn cert_p12_and_the_pem_pair_are_mutually_exclusive() {
+        let error = HttpConfig::from_config_args(HttpConfigArgs {
+            tls: TlsConfigArgs {
+                cert_pem: String::from("cert.pem"),
+                key_pem: String::from("key.pem"),
+                cert_p12: String::from("identity.p12"),
+                ..Default::default()
+            },
+            ..args()
+        })
+        .expect_err("both forms of identity must be rejected");
+
+        assert!(
+            matches!(error, ConfigError::IncompatibleOptions { .. }),
+            "{error:?}"
+        );
+        let rendered = chain(&error);
+        assert!(rendered.contains("cert_p12"), "{rendered}");
+    }
+
+    #[test]
+    fn a_p12_password_without_a_p12_is_rejected() {
+        let error = HttpConfig::from_config_args(HttpConfigArgs {
+            tls: TlsConfigArgs {
+                cert_p12_password: Secret::from("s3cr3t"),
+                ..Default::default()
+            },
+            ..args()
+        })
+        .expect_err("a password naming no file must be rejected");
+
+        assert!(
+            matches!(error, ConfigError::IncompatibleOptions { .. }),
+            "{error:?}"
+        );
+        let rendered = chain(&error);
+        assert!(rendered.contains("cert_p12_password"), "{rendered}");
+        assert!(!rendered.contains("s3cr3t"), "{rendered}");
+    }
+
+    #[test]
+    fn a_p12_file_is_read_into_the_same_identity_a_pem_pair_would_be() {
+        // A self-signed certificate and its PKCS#8 key, generated fresh here rather than read from
+        // a fixture, then bundled into a PKCS#12 file with `p12-keystore`'s own writer.
+        const PASSWORD: &str = "s3cr3t";
+
+        let rcgen::CertifiedKey { cert, signing_key } =
+            rcgen::generate_simple_self_signed(["test".to_owned()]).expect("a self-signed cert");
+        let cert_der = cert.der().to_vec();
+        let key_der = signing_key.serialize_der();
+
+        let chain = p12_keystore::PrivateKeyChain::new(
+            [1u8].as_slice(),
+            p12_keystore::PrivateKey::from_der(&key_der).expect("a valid PKCS#8 key"),
+            [p12_keystore::Certificate::from_der(&cert_der).expect("a valid X.509 certificate")],
+        );
+        let mut keystore = p12_keystore::KeyStore::new();
+        keystore.add_entry(
+            "identity",
+            p12_keystore::KeyStoreEntry::PrivateKeyChain(chain),
+        );
+        let pfx = keystore.writer(PASSWORD).write().expect("write the bundle");
+
+        let mut p12 = tempfile::NamedTempFile::new().expect("temp file");
+        std::io::Write::write_all(&mut p12, &pfx).expect("write");
+
+        let config = HttpConfig::from_config_args(HttpConfigArgs {
+            tls: TlsConfigArgs {
+                cert_p12: p12.path().to_str().expect("utf8 path").to_owned(),
+                cert_p12_password: Secret::from(PASSWORD),
+                ..Default::default()
+            },
+            ..args()
+        })
+        .expect("a valid PKCS#12 bundle");
+
+        let (cert, key) = config.tls.identity.expect("an identity was bundled");
+        assert_eq!(cert.as_ref(), cert_der, "the leaf certificate round-trips");
+        let PrivateKeyDer::Pkcs8(key) = key else {
+            panic!("expected the PKCS#8 variant, since that is what the bundle carried");
+        };
+        assert_eq!(
+            key.secret_pkcs8_der(),
+            key_der.as_slice(),
+            "the key round-trips"
+        );
+    }
+
+    #[test]
+    fn a_p12_that_leads_nowhere_names_the_path() {
+        let error = HttpConfig::from_config_args(HttpConfigArgs {
+            tls: TlsConfigArgs {
+                cert_p12: String::from("no/such/identity.p12"),
+                ..Default::default()
+            },
+            ..args()
+        })
+        .expect_err("a missing file must be reported");
+
+        assert!(matches!(error, ConfigError::Io { .. }), "{error:?}");
+        assert!(chain(&error).contains("no/such/"), "{}", chain(&error));
+    }
+
+    #[test]
+    fn a_p12_file_that_is_not_pkcs12_is_rejected_as_such() {
+        let mut p12 = tempfile::NamedTempFile::new().expect("temp file");
+        std::io::Write::write_all(&mut p12, b"clearly not a pkcs12 bundle").expect("write");
+
+        let error = HttpConfig::from_config_args(HttpConfigArgs {
+            tls: TlsConfigArgs {
+                cert_p12: p12.path().to_str().expect("utf8 path").to_owned(),
+                ..Default::default()
+            },
+            ..args()
+        })
+        .expect_err("garbage is not a pkcs12 bundle");
+
+        assert!(matches!(error, ConfigError::Pkcs12 { .. }), "{error:?}");
     }
 
     // --- override target ---

--- a/packages/rust/armonik-transport/src/tls_config.rs
+++ b/packages/rust/armonik-transport/src/tls_config.rs
@@ -8,12 +8,16 @@
 
 use hyper::Uri;
 use rustls::pki_types::pem::PemObject;
-use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use snafu::{OptionExt, ResultExt};
 
+use crate::config::{
+    boxed, ConfigError, EmptyPkcs12Snafu, IncompatibleOptionsSnafu, IoSnafu, Pkcs12Snafu, TlsSnafu,
+    UriSnafu,
+};
 #[cfg(feature = "serde")]
-use crate::config::text;
-use crate::config::{boxed, ConfigError, IncompatibleOptionsSnafu, IoSnafu, TlsSnafu, UriSnafu};
-use snafu::ResultExt;
+use crate::config::{secret_text, text};
+use crate::secret::Secret;
 
 /// The client's TLS identity and the server's CA, in the string form a caller supplies them in.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
@@ -21,15 +25,25 @@ use snafu::ResultExt;
 #[cfg_attr(feature = "serde", serde(rename_all = "PascalCase", default))]
 #[non_exhaustive]
 pub struct TlsConfigArgs {
-    /// A file this crate reads: the client's own certificate, matching `key_pem`.
+    /// A file this crate reads: the client's own certificate, matching `key_pem`. Mutually exclusive
+    /// with `cert_p12`.
     #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
     pub cert_pem: String,
-    /// A file this crate reads: the client's own key, matching `cert_pem`.
+    /// A file this crate reads: the client's own key, matching `cert_pem`. Mutually exclusive with
+    /// `cert_p12`.
     #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
     pub key_pem: String,
     /// A file this crate reads: the Certificate Authority.
     #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
     pub ca_cert: String,
+    /// A file this crate reads: the client's own certificate and key bundled together, the form
+    /// Windows and most certificate authorities hand out. Mutually exclusive with `cert_pem`/`key_pem`.
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "text"))]
+    pub cert_p12: String,
+    /// The password protecting `cert_p12`, empty for none. Meaningless, and rejected, without
+    /// `cert_p12`.
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "secret_text"))]
+    pub cert_p12_password: Secret,
     /// Accept any server certificate instead of verifying it, empty for false.
     ///
     /// Spelled as any other ArmoniK client accepts it: `1`, `true`, `yes`, `enable`, `allow` or
@@ -47,7 +61,8 @@ pub struct TlsConfigArgs {
 pub struct TlsConfig {
     /// Allow unsafe connections to the endpoint (without SSL), defaults to false.
     pub allow_unsafe_connection: bool,
-    /// TLS identity of the client: key + cert, loaded from `cert_pem`/`key_pem`.
+    /// TLS identity of the client: key + cert, loaded from whichever of `cert_pem`/`key_pem` or
+    /// `cert_p12` named it.
     pub identity: Option<(CertificateDer<'static>, PrivateKeyDer<'static>)>,
     /// CA certificate to authenticate the server.
     pub cacert: Option<CertificateDer<'static>>,
@@ -82,6 +97,38 @@ fn read_key_pem(option: &'static str, path: &str) -> Result<PrivateKeyDer<'stati
     PrivateKeyDer::from_pem_slice(pem.as_bytes()).context(TlsSnafu {})
 }
 
+/// Reads `path` as a PKCS#12 bundle and returns the client identity it names, the leaf certificate of
+/// its chain and its private key, re-encoded as the same DER shapes a PEM pair produces.
+fn read_cert_p12(
+    path: &str,
+    password: &Secret,
+) -> Result<(CertificateDer<'static>, PrivateKeyDer<'static>), ConfigError> {
+    let data = std::fs::read(path).context(IoSnafu {
+        option: "cert_p12",
+        path,
+    })?;
+    let keystore = p12_keystore::KeyStore::from_pkcs12(
+        &data,
+        password.expose_secret(),
+        p12_keystore::Pkcs12ImportPolicy::Strict,
+    )
+    .context(Pkcs12Snafu { path })?;
+    let (_, chain) = keystore
+        .private_key_chain()
+        .context(EmptyPkcs12Snafu { path })?;
+    let cert = chain
+        .certs()
+        .first()
+        .context(EmptyPkcs12Snafu { path })?
+        .as_der()
+        .to_vec();
+    let key = chain.key().as_der().to_vec();
+    Ok((
+        CertificateDer::from(cert),
+        PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key)),
+    ))
+}
+
 impl TlsConfigArgs {
     /// Resolves against `endpoint`: an override target given as a bare host keeps the endpoint's own
     /// scheme and path, and is otherwise a full URI whose authority and path replace the endpoint's,
@@ -92,6 +139,8 @@ impl TlsConfigArgs {
             cert_pem,
             key_pem,
             ca_cert,
+            cert_p12,
+            cert_p12_password,
             allow_unsafe_connection,
             override_target_name,
         } = self;
@@ -102,19 +151,40 @@ impl TlsConfigArgs {
             Some(read_cert_pem("ca_cert", &ca_cert)?)
         };
 
-        let identity = match (cert_pem.is_empty(), key_pem.is_empty()) {
-            (true, true) => None,
-            (false, false) => Some((
-                read_cert_pem("cert_pem", &cert_pem)?,
-                read_key_pem("key_pem", &key_pem)?,
-            )),
-            _ => {
-                return IncompatibleOptionsSnafu {
-                    msg: String::from(
-                        "`cert_pem` and `key_pem` must be either both empty or both set",
-                    ),
+        let has_pem_pair = !cert_pem.is_empty() || !key_pem.is_empty();
+        if !cert_p12.is_empty() && has_pem_pair {
+            return IncompatibleOptionsSnafu {
+                msg: String::from(
+                    "`cert_p12` and `cert_pem`/`key_pem` name the client identity two different \
+                     ways; set only one",
+                ),
+            }
+            .fail();
+        }
+        if cert_p12.is_empty() && !cert_p12_password.is_empty() {
+            return IncompatibleOptionsSnafu {
+                msg: String::from("`cert_p12_password` is set without `cert_p12`"),
+            }
+            .fail();
+        }
+
+        let identity = if !cert_p12.is_empty() {
+            Some(read_cert_p12(&cert_p12, &cert_p12_password)?)
+        } else {
+            match (cert_pem.is_empty(), key_pem.is_empty()) {
+                (true, true) => None,
+                (false, false) => Some((
+                    read_cert_pem("cert_pem", &cert_pem)?,
+                    read_key_pem("key_pem", &key_pem)?,
+                )),
+                _ => {
+                    return IncompatibleOptionsSnafu {
+                        msg: String::from(
+                            "`cert_pem` and `key_pem` must be either both empty or both set",
+                        ),
+                    }
+                    .fail()
                 }
-                .fail()
             }
         };
 


### PR DESCRIPTION
Third of three PRs replacing #705 (see wk/refactor/rust-config-figment and
wk/refactor/rust-config-units for the first two). Adds PKCS12 as a second way to load the
client's certificate and key.

- `cert_p12` (a bundle path) and `cert_p12_password` (`Secret`) on `TlsConfigArgs`/
  `TlsConfig`, mutually exclusive with `cert_pem`/`key_pem`: the client's certificate and key
  bundled together, the form Windows and most certificate authorities hand out. Read via
  `p12-keystore` and re-encoded as the same DER shapes a PEM pair produces.
  `ConfigError` gains `Pkcs12` and `EmptyPkcs12`, naming the file on a read or parse failure.
- Documents the TLS/mTLS options in the crate README, which never had this section:
  `cert_pem`/`key_pem`/`ca_cert`, `cert_p12`/`cert_p12_password`, `allow_unsafe_connection`,
  `override_target_name`.
