### PR TITLE
feat(rust): reach the endpoint through an HTTP CONNECT proxy

### DIFF
--- a/packages/rust/armonik-transport/Cargo.toml
+++ b/packages/rust/armonik-transport/Cargo.toml
@@ -20,7 +20,15 @@ tonic = { workspace = true, features = ["channel", "codegen"] }
 snafu.workspace = true
 tracing.workspace = true
 hyper = { workspace = true, features = ["client", "http1", "http2"] }
-hyper-util = { workspace = true, features = ["client", "http1"] }
+# `client-legacy` for `HttpConnector` and for the `Tunnel` connector that performs the `CONNECT`
+# handshake; `tokio` for `TokioIo` and the runtime side of both. Each is named here even though
+# `hyper-rustls` happens to turn it on: depending on that would break the day it stops.
+hyper-util = { workspace = true, features = [
+  "client",
+  "client-legacy",
+  "http1",
+  "tokio",
+] }
 hyper-rustls = { workspace = true, features = [
   "http1",
   "http2",
@@ -40,6 +48,10 @@ percent-encoding.workspace = true
 # `SecretString`, so the proxy password is redacted by `Debug` and zeroized on drop, which a plain
 # `String` field is not.
 secrecy.workspace = true
+# The tunnel handshake is bounded in time, and the tunnel hands back a TCP stream.
+tokio = { workspace = true, features = ["net", "time"] }
+# The proxy connector is a `tower` service, so that it composes with the connectors around it.
+tower-service.workspace = true
 
 [dev-dependencies]
 # The boolean options are read straight from the environment, so testing which spellings they accept
@@ -51,7 +63,6 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 # The integration tests serve a gRPC service to call, which the regular build never does; these features
 # union with the `channel`/`codegen` above for test builds only.
 tonic = { workspace = true, features = ["server", "router"] }
-# The test service is a `tower` service and its codec moves raw `Bytes`; production code here needs
-# neither, since it hands whole channels to its caller rather than framing messages itself.
-tower-service.workspace = true
+# The test service's codec moves raw `Bytes`; production code here hands whole channels to its caller
+# rather than framing messages itself.
 bytes.workspace = true

--- a/packages/rust/armonik-transport/README.md
+++ b/packages/rust/armonik-transport/README.md
@@ -7,6 +7,17 @@ Depend on it when you need the connection layer without generated protobuf types
 `protoc`/`tonic-prost-build` build step. [`armonik`](../armonik) re-exports all of it, so a client that
 wants the services as well needs only that one.
 
+## Reaching the endpoint through a proxy
+
+`ClientConfig::proxy` decides how the connection goes out: directly, the default, or through the
+proxy `ProxyConfig::explicit(uri)` names. `with_credentials` authenticates to it, half by half: a
+half left empty keeps what the proxy URL itself carried.
+
+The connection is an HTTP `CONNECT` tunnel: TLS, mutual TLS included, is negotiated end to end with
+the real server, and the proxy only forwards opaque bytes. Because the `CONNECT` handshake itself goes
+out in the clear, the proxy's own URL has to be `http`. The handshake is bounded by
+`ClientConfig::connect_timeout`, 30 seconds when none is set.
+
 ## Publishing
 
 **This crate has to be published before `armonik`.** `armonik` depends on it by `path`, and a `path`

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -4,6 +4,8 @@ use hyper::{http::HeaderValue, Uri};
 use rustls::pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer};
 use snafu::{ResultExt, Snafu};
 
+use crate::proxy::ProxyConfig;
+
 /// Options for creating a gRPC Client
 #[derive(Debug, Default)]
 #[non_exhaustive]
@@ -42,6 +44,8 @@ pub struct ClientConfig {
     pub http2_max_header_list_size: Option<u32>,
     /// User-Agent header value sent with each request
     pub user_agent: Option<HeaderValue>,
+    /// HTTP proxy used to reach the endpoint, defaults to a direct connection
+    pub proxy: ProxyConfig,
 }
 
 impl Clone for ClientConfig {
@@ -67,6 +71,7 @@ impl Clone for ClientConfig {
             http2_keep_alive_while_idle: self.http2_keep_alive_while_idle,
             http2_max_header_list_size: self.http2_max_header_list_size,
             user_agent: self.user_agent.clone(),
+            proxy: self.proxy.clone(),
         }
     }
 }
@@ -434,6 +439,7 @@ impl ClientConfig {
             http2_keep_alive_while_idle,
             http2_max_header_list_size,
             user_agent,
+            proxy: ProxyConfig::default(),
         })
     }
 }

--- a/packages/rust/armonik-transport/src/connect.rs
+++ b/packages/rust/armonik-transport/src/connect.rs
@@ -11,6 +11,7 @@ use rustls::pki_types::ServerName;
 use snafu::{ResultExt, Snafu};
 
 use crate::config::ConfigError;
+use crate::proxy::ProxyConnector;
 use crate::ClientConfig;
 
 /// Connect to the endpoint described by `config`, eagerly: this resolves once the connection is
@@ -72,7 +73,7 @@ pub async fn connect(config: ClientConfig) -> Result<tonic::transport::Channel, 
 #[doc(hidden)]
 pub async fn https_connector(
     config: ClientConfig,
-) -> Result<HttpsConnector<HttpConnector>, ConnectionError> {
+) -> Result<HttpsConnector<ProxyConnector<HttpConnector>>, ConnectionError> {
     let endpoint = config.endpoint;
 
     // Get the default crypto provider or fallback to the ring crypto provider
@@ -141,6 +142,10 @@ pub async fn https_connector(
     if let Some(timeout) = config.connect_timeout {
         http.set_connect_timeout(Some(timeout));
     }
+
+    // Tunnelling sits below TLS, so the handshake above still targets the real server. With no proxy
+    // configured this delegates straight to the connector it wraps, settings and all.
+    let http = ProxyConnector::new(http, config.proxy, config.connect_timeout);
 
     Ok(https.enable_http1().enable_http2().wrap_connector(http))
 }

--- a/packages/rust/armonik-transport/src/lib.rs
+++ b/packages/rust/armonik-transport/src/lib.rs
@@ -11,7 +11,7 @@ mod utils;
 
 pub use config::{ClientConfig, ClientConfigArgs, ConfigError};
 pub use connect::{connect, https_connector, ConnectionError};
-pub use proxy::{ProxyConfig, ProxySource};
+pub use proxy::{ProxyConfig, ProxyError, ProxySource};
 // The password's own type, so a caller can build a `ProxyConfig` without declaring a dependency on
 // the `secrecy` crate this one happens to use.
 pub use secrecy::SecretString;

--- a/packages/rust/armonik-transport/src/proxy.rs
+++ b/packages/rust/armonik-transport/src/proxy.rs
@@ -379,7 +379,9 @@ pub enum ProxyError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
-    #[snafu(display("The proxy requires authentication; configure proxy credentials [{location}]"))]
+    #[snafu(display(
+        "The proxy requires authentication; configure proxy credentials [{location}]"
+    ))]
     #[non_exhaustive]
     AuthenticationRequired {
         #[snafu(implicit)]

--- a/packages/rust/armonik-transport/src/proxy.rs
+++ b/packages/rust/armonik-transport/src/proxy.rs
@@ -1,15 +1,32 @@
-//! Configuration for reaching the endpoint through an HTTP proxy.
+//! Reaching the endpoint through an HTTP proxy.
 //!
-//! Proxying uses a `CONNECT` tunnel rather than an absolute-form request, so TLS stays end to end
-//! with the real server. These are the types that describe the proxy and the credential handling
-//! they guarantee: whatever form credentials arrive in, they end up in dedicated fields, never in
-//! a URI that a log line or an error display would render.
+//! A `CONNECT` tunnel rather than an absolute-form request, so TLS stays end to end with the real
+//! server: [`ProxyConnector`] sits below the TLS connector and hands back the stream a direct
+//! connection would. The handshake itself is `hyper_util`'s own [`Tunnel`], not one written here.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
 
 use base64::Engine;
 use hyper::http::uri::Scheme;
 use hyper::http::HeaderValue;
 use hyper::Uri;
+use hyper_util::client::legacy::connect::proxy::Tunnel;
+use hyper_util::rt::TokioIo;
 use secrecy::{ExposeSecret, SecretString};
+use snafu::{IntoError, Snafu};
+use tokio::net::TcpStream;
+use tower_service::Service;
+
+/// What a connector reports when it fails, which every layer here has to be able to carry.
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Upper bound on the tunnel handshake when no connect timeout is configured, so a proxy that
+/// accepts the connection and then goes quiet fails instead of hanging. `Tunnel` has no timeout of
+/// its own.
+const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Where to find the HTTP proxy used to reach the endpoint.
 #[derive(Clone, Default, PartialEq, Eq)]
@@ -135,7 +152,6 @@ impl ProxyConfig {
     /// Resolved from the fields as they are, not as a constructor left them: an `Explicit` URI is
     /// stripped of any userinfo even when it bypassed [`ProxyConfig::explicit`], so a password
     /// never reaches a log line or an error display through the URI.
-    #[allow(dead_code)]
     pub(crate) fn fixed_route(&self) -> RouteResult {
         match &self.source {
             ProxySource::Disabled => Ok(None),
@@ -181,8 +197,232 @@ impl ProxyConfig {
 /// connection. The error carries the proxy that cannot be routed through - a scheme that cannot
 /// carry the cleartext handshake, or the placeholder for a URI with no sanitized form - so
 /// whoever reports it names the offending URI once, and that URI never holds a password.
-#[allow(dead_code)]
 pub(crate) type RouteResult = Result<Option<(Uri, Option<HeaderValue>)>, Uri>;
+
+/// Wraps a TCP connector so that it tunnels through an HTTP proxy when one is configured.
+///
+/// A request that must not be proxied goes straight to the inner connector, leaving that path as it
+/// was. Generic over the connector because all this layer needs is something that turns a [`Uri`]
+/// into a TCP stream; which one is knowledge it has no use for.
+#[derive(Debug, Clone)]
+pub struct ProxyConnector<S> {
+    inner: S,
+    prepared: Prepared,
+    /// Upper bound on the tunnel handshake alone; the dial to the proxy is the inner connector's,
+    /// bounded by its own connect timeout.
+    handshake_timeout: Duration,
+}
+
+/// What [`ProxyConnector::new`] resolves once, so a connection pays no route work when the route
+/// cannot change.
+#[derive(Debug, Clone)]
+enum Prepared {
+    /// Connect directly.
+    Direct,
+    /// Tunnel through this proxy, presenting this ready `Proxy-Authorization` value.
+    Via {
+        proxy: Uri,
+        auth: Option<HeaderValue>,
+    },
+    /// Refuse every connection: this proxy's scheme cannot carry the cleartext handshake.
+    Unsupported(Uri),
+}
+
+impl<S> ProxyConnector<S> {
+    /// Wrap a TCP connector with the given proxy configuration.
+    ///
+    /// `connect_timeout` bounds the tunnel handshake, so the knob that governs how long connecting
+    /// may take governs the proxied path too; without one, a 30-second default keeps a proxy that
+    /// accepts the connection and then goes quiet from hanging the client.
+    pub(crate) fn new(inner: S, proxy: ProxyConfig, connect_timeout: Option<Duration>) -> Self {
+        let prepared = match proxy.fixed_route() {
+            Ok(None) => Prepared::Direct,
+            Ok(Some((uri, auth))) => Prepared::Via { proxy: uri, auth },
+            Err(unsupported) => Prepared::Unsupported(unsupported),
+        };
+        Self {
+            inner,
+            prepared,
+            handshake_timeout: connect_timeout.unwrap_or(DEFAULT_HANDSHAKE_TIMEOUT),
+        }
+    }
+}
+
+impl<S> Service<Uri> for ProxyConnector<S>
+where
+    S: Service<Uri, Response = TokioIo<TcpStream>> + Clone + Send + 'static,
+    S::Error: Into<BoxError> + Send + Sync + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = TokioIo<TcpStream>;
+    type Error = BoxError;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, target: Uri) -> Self::Future {
+        let (proxy_uri, auth) = match &self.prepared {
+            // Nothing to tunnel through: keep the original behaviour untouched.
+            Prepared::Direct => {
+                let future = self.inner.call(target);
+                return Box::pin(async move { future.await.map_err(Into::into) });
+            }
+            Prepared::Via { proxy, auth } => (proxy.clone(), auth.clone()),
+            Prepared::Unsupported(proxy) => {
+                let error = UnsupportedProxySnafu {
+                    proxy: proxy.clone(),
+                }
+                .build();
+                return Box::pin(std::future::ready(Err(error.into())));
+            }
+        };
+
+        // Dial the proxy with the inner connector, so a failure to reach it is classified by
+        // construction rather than by matching upstream error text; `Tunnel` then handshakes over
+        // the stream it is handed and only the handshake is upstream's.
+        let connect = self.inner.call(proxy_uri.clone());
+        let timeout = self.handshake_timeout;
+        Box::pin(async move {
+            let stream = connect.await.map_err(|error| {
+                ConnectSnafu {
+                    proxy: proxy_uri.clone(),
+                }
+                .into_error(error.into())
+            })?;
+
+            let mut tunnel = Tunnel::new(proxy_uri.clone(), Connected(Some(stream)));
+            if let Some(auth) = auth {
+                tunnel = tunnel.with_auth(auth);
+            }
+
+            let handshake = tunnel.call(target.clone());
+            let stream = tokio::time::timeout(timeout, handshake)
+                .await
+                .map_err(|_| {
+                    HandshakeTimeoutSnafu {
+                        proxy: proxy_uri.clone(),
+                        timeout,
+                    }
+                    .build()
+                })?
+                .map_err(|error| translate(proxy_uri.clone(), error))?;
+
+            tracing::debug!(proxy = %proxy_uri, %target, "Established proxy tunnel");
+
+            Ok(stream)
+        })
+    }
+}
+
+/// A connector that hands out one stream, already connected.
+///
+/// What [`Tunnel`] dials through: the proxy was dialled by the real connector before the tunnel
+/// was built, so the errors of reaching it and of handshaking over it stay distinguishable without
+/// looking at either one's text.
+struct Connected(Option<TokioIo<TcpStream>>);
+
+impl Service<Uri> for Connected {
+    type Response = TokioIo<TcpStream>;
+    type Error = BoxError;
+    type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _proxy: Uri) -> Self::Future {
+        std::future::ready(
+            self.0
+                .take()
+                .ok_or_else(|| BoxError::from("the tunnel opens once per connection")),
+        )
+    }
+}
+
+/// Turn what `Tunnel` reports into an error naming the proxy.
+///
+/// The proxy was dialled before the tunnel was built, so everything arriving here is the handshake
+/// itself. One case still gets a better message than "did not open the tunnel", detected by text:
+/// `hyper_util`'s `TunnelError` lives in a private module of that crate with no public path, only
+/// trait bounds reach it, so its 407 variant cannot be matched. Brittle in principle; pinned by an
+/// integration test, so a wording change upstream breaks loudly instead of silently losing the
+/// hint.
+fn translate(proxy: Uri, error: impl std::error::Error + Send + Sync + 'static) -> ProxyError {
+    if error.to_string().contains("proxy authorization required") {
+        return AuthenticationRequiredSnafu {}.build();
+    }
+    TunnelFailedSnafu { proxy }.into_error(BoxError::from(error))
+}
+
+/// Failure to reach the endpoint through the proxy.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum ProxyError {
+    #[snafu(display("Could not connect to the proxy {proxy} [{location}]"))]
+    #[non_exhaustive]
+    Connect {
+        proxy: Uri,
+        source: BoxError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display(
+        "The proxy {proxy} did not complete the tunnel within {timeout:?} [{location}]"
+    ))]
+    #[non_exhaustive]
+    HandshakeTimeout {
+        proxy: Uri,
+        timeout: Duration,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("The proxy requires authentication; configure proxy credentials [{location}]"))]
+    #[non_exhaustive]
+    AuthenticationRequired {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("The proxy {proxy} did not open the tunnel [{location}]"))]
+    #[non_exhaustive]
+    TunnelFailed {
+        proxy: Uri,
+        source: BoxError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display(
+        "The `CONNECT` handshake is written in the clear, so only an `http` proxy can be reached, \
+         not {proxy} [{location}]"
+    ))]
+    #[non_exhaustive]
+    UnsupportedProxy {
+        proxy: Uri,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+impl ProxyError {
+    /// The `ProxyError` buried in `error`'s source chain, if any.
+    ///
+    /// [`crate::connect`] returns the transport's own error type, which carries this one as an
+    /// anonymous boxed cause. This walk is how a caller reacts to a proxy failure in particular,
+    /// e.g. prompting for credentials on [`ProxyError::AuthenticationRequired`], without matching
+    /// on rendered text.
+    pub fn find_in<'a>(error: &'a (dyn std::error::Error + 'static)) -> Option<&'a ProxyError> {
+        let mut current = Some(error);
+        while let Some(error) = current {
+            if let Some(proxy) = error.downcast_ref::<ProxyError>() {
+                return Some(proxy);
+            }
+            current = error.source();
+        }
+        None
+    }
+}
 
 /// A whole `Proxy-Authorization` value for the `Basic` scheme, marked sensitive so it is never
 /// logged.
@@ -503,5 +743,51 @@ mod tests {
             .expect("routing should succeed")
             .expect("an explicit proxy routes through it");
         assert_eq!(auth, None);
+    }
+
+    // --- the connector dials the proxy, not the target ---
+
+    /// A connector that records what it was asked to reach, and refuses.
+    #[derive(Clone)]
+    struct Recorder(std::sync::Arc<std::sync::Mutex<Vec<Uri>>>);
+
+    impl Service<Uri> for Recorder {
+        type Response = TokioIo<TcpStream>;
+        type Error = BoxError;
+        type Future =
+            Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, target: Uri) -> Self::Future {
+            self.0.lock().expect("lock").push(target);
+            Box::pin(std::future::ready(Err(BoxError::from("recorder"))))
+        }
+    }
+
+    #[tokio::test]
+    async fn an_explicit_proxy_is_dialled_whatever_the_target_looks_like() {
+        // The caller named this proxy, so it is dialled even for a target scheme no environment
+        // convention would proxy; connecting straight to the target instead would silently ignore
+        // the configuration.
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let proxy = Uri::try_from("http://proxy.corp:3128").expect("a valid proxy URI");
+        let mut connector = ProxyConnector::new(
+            Recorder(std::sync::Arc::clone(&seen)),
+            ProxyConfig::explicit(proxy.clone()),
+            None,
+        );
+
+        let target = Uri::try_from("grpc://armonik.example.com:5001").expect("a valid target");
+        let _ = connector.call(target.clone()).await;
+
+        let seen = seen.lock().expect("lock");
+        assert_eq!(
+            seen.as_slice(),
+            &[proxy],
+            "the proxy should have been dialled, not {target}"
+        );
     }
 }

--- a/packages/rust/armonik-transport/tests/common/mod.rs
+++ b/packages/rust/armonik-transport/tests/common/mod.rs
@@ -162,6 +162,38 @@ pub async fn call(
     Ok(response.into_inner())
 }
 
+/// Read up to the blank line that ends an HTTP head.
+///
+/// One byte at a time on purpose: the socket is used for the tunnel afterwards, so reading past the
+/// head would swallow tunnelled bytes. Test heads are a few hundred bytes, so the cost is nothing.
+#[allow(dead_code)] // not every test binary drives a proxy
+pub async fn read_head(stream: &mut tokio::net::TcpStream) -> std::io::Result<String> {
+    use tokio::io::AsyncReadExt;
+
+    let mut head = Vec::new();
+    loop {
+        let mut byte = [0u8; 1];
+        stream.read_exact(&mut byte).await?;
+        head.push(byte[0]);
+        if head.ends_with(b"\r\n\r\n") {
+            return Ok(String::from_utf8_lossy(&head).into_owned());
+        }
+        if head.len() > 8 * 1024 {
+            return Err(std::io::Error::other("head too large"));
+        }
+    }
+}
+
+/// The request-target of a `CONNECT` request's start line, e.g. `proxy.corp:3128`.
+#[allow(dead_code)] // not every test binary drives a proxy
+pub fn request_target(head: &str) -> String {
+    head.lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or_default()
+        .to_owned()
+}
+
 /// Build a [`ClientConfig`] from the string form, applying `set` to the arguments first.
 ///
 /// Going through `ClientConfigArgs` keeps the parsing inside what is under test. It is a helper at all

--- a/packages/rust/armonik-transport/tests/proxy.rs
+++ b/packages/rust/armonik-transport/tests/proxy.rs
@@ -1,0 +1,311 @@
+//! End-to-end tests for HTTP `CONNECT` tunnelling.
+//!
+//! A real client, through a real proxy, to a real gRPC server over loopback sockets. The proxy is a
+//! few dozen lines below rather than an external binary, so the tests run wherever CI does.
+
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use armonik_transport::{ClientConfig, ProxyConfig};
+use tokio::io::AsyncWriteExt;
+use tokio::net::{TcpListener, TcpStream};
+
+mod common;
+
+use common::SlowService;
+
+/// Serve the gRPC service the tests call, on an ephemeral loopback port.
+async fn spawn_server() -> String {
+    common::serve(SlowService::new(Duration::ZERO)).await
+}
+
+/// What a test proxy should demand of its clients.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProxyAuth {
+    /// Accept every tunnel request.
+    None,
+    /// Reject with `407` unless the expected `Proxy-Authorization` header is present.
+    Required(&'static str),
+}
+
+/// How many `CONNECT` requests a test proxy accepted and tunnelled.
+type Tunnels = Arc<AtomicUsize>;
+
+/// A minimal HTTP proxy that only implements `CONNECT`, answering 200.
+async fn spawn_proxy(auth: ProxyAuth) -> (SocketAddr, Tunnels) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind proxy");
+    let address = listener.local_addr().expect("proxy address");
+    let tunnels = Tunnels::default();
+
+    let accepted = Arc::clone(&tunnels);
+    tokio::spawn(async move {
+        loop {
+            let Ok((client, _)) = listener.accept().await else {
+                return;
+            };
+            let tunnels = Arc::clone(&accepted);
+            tokio::spawn(async move {
+                // A failing tunnel is a normal outcome in these tests; the client asserts on it.
+                let _ = serve_tunnel(client, auth, tunnels).await;
+            });
+        }
+    });
+
+    (address, tunnels)
+}
+
+async fn serve_tunnel(
+    mut client: TcpStream,
+    auth: ProxyAuth,
+    tunnels: Tunnels,
+) -> std::io::Result<()> {
+    let head = common::read_head(&mut client).await?;
+    let target = common::request_target(&head);
+
+    if let ProxyAuth::Required(expected) = auth {
+        let presented = head.lines().find_map(|line| {
+            line.strip_prefix("Proxy-Authorization: Basic ")
+                .or_else(|| line.strip_prefix("proxy-authorization: Basic "))
+        });
+
+        if presented != Some(expected) {
+            client
+                .write_all(b"HTTP/1.1 407 Proxy Authentication Required\r\n\r\n")
+                .await?;
+            return client.flush().await;
+        }
+    }
+
+    let mut upstream = TcpStream::connect(&target).await?;
+    client
+        .write_all(b"HTTP/1.1 200 Connection established\r\n\r\n")
+        .await?;
+    client.flush().await?;
+    tunnels.fetch_add(1, Ordering::SeqCst);
+
+    tokio::io::copy_bidirectional(&mut client, &mut upstream)
+        .await
+        .map(|_| ())
+}
+
+/// A client reaching `endpoint` through `proxy`, configured through the API.
+fn through_proxy(
+    endpoint: &str,
+    proxy: SocketAddr,
+    credentials: Option<(&str, &str)>,
+) -> ClientConfig {
+    let mut config = common::config(endpoint, |_| {});
+    let mut proxy = ProxyConfig::explicit(
+        hyper::Uri::try_from(format!("http://{proxy}")).expect("a valid proxy URI"),
+    );
+    if let Some((username, password)) = credentials {
+        proxy = proxy.with_credentials(username, password);
+    }
+    config.proxy = proxy;
+    config
+}
+
+/// A client that connects directly, whatever proxy the tests happen to be running.
+fn direct(endpoint: &str) -> ClientConfig {
+    common::config(endpoint, |_| {})
+}
+
+/// Connect and make one call, returning what the server answered.
+async fn call_through(config: ClientConfig) -> Result<bytes::Bytes, Box<dyn std::error::Error>> {
+    let channel = armonik_transport::connect(config).await?;
+    Ok(common::call(channel).await?)
+}
+
+/// Render an error and everything it was caused by.
+///
+/// The transport error that wraps a proxy failure has a generic message, so an assertion has to look
+/// at the whole chain.
+fn error_chain(error: &dyn std::error::Error) -> String {
+    let mut rendered = vec![error.to_string()];
+    let mut current = error.source();
+    while let Some(source) = current {
+        rendered.push(source.to_string());
+        current = source.source();
+    }
+    rendered.join(" -> ")
+}
+
+#[tokio::test]
+async fn request_reaches_the_server_through_the_tunnel() {
+    let server = spawn_server().await;
+    let (proxy, tunnels) = spawn_proxy(ProxyAuth::None).await;
+
+    let answer = call_through(through_proxy(&server, proxy, None))
+        .await
+        .expect("the call should succeed through the proxy");
+
+    assert_eq!(answer, common::REPLY);
+    assert_eq!(
+        tunnels.load(Ordering::SeqCst),
+        1,
+        "the request must have gone through the proxy, not around it"
+    );
+}
+
+#[tokio::test]
+async fn credentials_are_presented_when_the_proxy_demands_them() {
+    let server = spawn_server().await;
+    // The base64 of `user:secret`, which is what the client is expected to send.
+    let (proxy, tunnels) = spawn_proxy(ProxyAuth::Required("dXNlcjpzZWNyZXQ=")).await;
+
+    let answer = call_through(through_proxy(&server, proxy, Some(("user", "secret"))))
+        .await
+        .expect("the call should succeed once credentials are supplied");
+
+    assert_eq!(answer, common::REPLY);
+    assert_eq!(tunnels.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn credentials_written_into_the_proxy_url_authenticate_the_tunnel() {
+    let server = spawn_server().await;
+    let (proxy, tunnels) = spawn_proxy(ProxyAuth::Required("dXNlcjpzZWNyZXQ=")).await;
+
+    // The conventional `HTTPS_PROXY` form. Accepting the URL and then not authenticating with it is
+    // the failure this pins.
+    let mut config = direct(&server);
+    config.proxy = ProxyConfig::explicit(
+        hyper::Uri::try_from(format!("http://user:secret@{proxy}")).expect("a valid proxy URI"),
+    );
+
+    let answer = call_through(config)
+        .await
+        .expect("the credentials in the URL should have been used");
+
+    assert_eq!(answer, common::REPLY);
+    assert_eq!(tunnels.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn a_missing_credential_is_reported_as_such() {
+    let server = spawn_server().await;
+    let (proxy, tunnels) = spawn_proxy(ProxyAuth::Required("dXNlcjpzZWNyZXQ=")).await;
+
+    let error = call_through(through_proxy(&server, proxy, None))
+        .await
+        .expect_err("the proxy should have refused the tunnel");
+
+    // The message has to say credentials are what is missing, otherwise a 407 is a dead end for
+    // whoever hits it.
+    let rendered = error_chain(error.as_ref());
+    assert!(
+        rendered.contains("requires authentication"),
+        "unexpected error: {rendered}"
+    );
+    // And the failure has to be matchable by type, not only by text: `find_in` is how a caller
+    // reacts to this case in particular, e.g. by prompting for credentials.
+    let typed = armonik_transport::ProxyError::find_in(error.as_ref());
+    assert!(
+        matches!(
+            typed,
+            Some(armonik_transport::ProxyError::AuthenticationRequired { .. })
+        ),
+        "expected AuthenticationRequired in the chain, got {typed:?}"
+    );
+    assert_eq!(tunnels.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn wrong_credentials_are_rejected() {
+    let server = spawn_server().await;
+    let (proxy, tunnels) = spawn_proxy(ProxyAuth::Required("dXNlcjpzZWNyZXQ=")).await;
+
+    let error = call_through(through_proxy(&server, proxy, Some(("user", "wrong"))))
+        .await
+        .expect_err("the proxy should have refused the tunnel");
+
+    let rendered = error_chain(error.as_ref());
+    assert!(
+        rendered.contains("requires authentication"),
+        "unexpected error: {rendered}"
+    );
+    assert_eq!(tunnels.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn a_dead_proxy_fails_instead_of_bypassing_it() {
+    let server = spawn_server().await;
+
+    // Bind a port and drop it, so nothing is listening there.
+    let dead = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind")
+        .local_addr()
+        .expect("address");
+    drop(TcpListener::bind(dead).await);
+
+    let error = call_through(through_proxy(&server, dead, None))
+        .await
+        .expect_err("an unreachable proxy must fail the call");
+
+    // Silently falling back to a direct connection would defeat the point of configuring a proxy.
+    let rendered = error_chain(error.as_ref());
+    assert!(
+        rendered.contains("Could not connect to the proxy"),
+        "the error should name the proxy: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn no_proxy_is_used_when_proxying_is_disabled() {
+    let server = spawn_server().await;
+    let (proxy, tunnels) = spawn_proxy(ProxyAuth::None).await;
+
+    let answer = call_through(direct(&server))
+        .await
+        .expect("a direct call should succeed");
+
+    assert_eq!(answer, common::REPLY);
+    assert_eq!(
+        tunnels.load(Ordering::SeqCst),
+        0,
+        "the proxy must not be involved when it is disabled"
+    );
+    let _ = proxy;
+}
+
+// --- the handshake is bounded in time ---
+
+#[tokio::test]
+async fn a_proxy_that_goes_quiet_fails_within_the_connect_timeout() {
+    // `Tunnel` has no timeout of its own, so without this bound a proxy that accepts the connection
+    // and never answers would hang the client. The configured connect timeout is the knob that
+    // governs how long connecting may take, so it governs the proxied path too.
+    let server = spawn_server().await;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind proxy");
+    let proxy = listener.local_addr().expect("proxy address");
+    tokio::spawn(async move {
+        // Accept and hold the socket without ever answering.
+        let Ok((client, _)) = listener.accept().await else {
+            return;
+        };
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        drop(client);
+    });
+
+    let mut config = through_proxy(&server, proxy, None);
+    config.connect_timeout = Some(Duration::from_millis(200));
+
+    let started = std::time::Instant::now();
+    let error = call_through(config)
+        .await
+        .expect_err("a quiet proxy must time out");
+
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "the timeout should be the configured one, not a hang"
+    );
+    let rendered = error_chain(error.as_ref());
+    assert!(
+        rendered.contains("did not complete the tunnel"),
+        "unexpected error: {rendered}"
+    );
+}

--- a/packages/rust/armonik/src/client/mod.rs
+++ b/packages/rust/armonik/src/client/mod.rs
@@ -8,8 +8,8 @@ use snafu::{ResultExt, Snafu};
 use armonik_transport::ConfigSnafu;
 #[cfg(feature = "_gen-client")]
 pub use armonik_transport::{
-    ClientConfig, ClientConfigArgs, ConfigError, ConnectionError, ProxyConfig, ProxySource,
-    ReadEnvError, SecretString,
+    ClientConfig, ClientConfigArgs, ConfigError, ConnectionError, ProxyConfig, ProxyError,
+    ProxySource, ReadEnvError, SecretString,
 };
 
 #[cfg(feature = "worker")]


### PR DESCRIPTION
# Motivation

The proxy configuration types exist; nothing dials the proxy they describe.

# Description

A `ProxyConnector` between the TCP connector and the TLS one. It opens an HTTP `CONNECT` tunnel,
so TLS, mutual TLS included, is negotiated end to end with the real server and the proxy only
forwards opaque bytes. The handshake itself is `hyper_util`'s `Tunnel`, not code written here.

The route is prepared once at construction, `Proxy-Authorization` value included. The connector
dials the proxy itself and hands `Tunnel` the connected stream, so failing to reach the proxy is
classified as such by construction rather than by matching upstream error text; only the 407 hint
still rests on the rendered message, and an integration test pins that wording.
`ProxyError::find_in` walks a returned error's source chain, so a caller can react to
`AuthenticationRequired` by prompting for credentials instead of string-matching. The dial is
bounded by the connector's own connect timeout and the handshake by the same configured knob,
30 seconds when none is set.

# Testing

`cargo test -p armonik-transport --all-features`: 50 passed, of which 8 drive a real client
through a real `CONNECT` proxy to a real gRPC server over loopback sockets: the tunnel,
credentials demanded, presented, in the URL, missing and wrong, an unreachable proxy, proxying
off, and a proxy that goes quiet. The run is in the commit message.

# Impact

No behaviour change: the default stays a direct connection, and the connector delegates straight
through when proxying is off. `hyper-util` gains the `client-legacy` and `tokio` features, both
already enabled transitively and now named; `tokio` (net, time) and `tower-service` become regular
dependencies of the crate.

# Additional Information

Stacks on `wk/feat/rust-proxy-types`; merge that first.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI. (locally yes; CI runs on this PR)
- [x] I have assessed the performance impact of my modifications.
