### PR TITLE
test(rust): name the test service's reply instead of repeating a literal

### DIFF
--- a/packages/rust/armonik-transport/tests/common/mod.rs
+++ b/packages/rust/armonik-transport/tests/common/mod.rs
@@ -19,6 +19,10 @@ use tower_service::Service;
 /// The one method the test service answers to.
 pub const METHOD_PATH: &str = "/armonik_transport.test.Slow/Call";
 
+/// What the service answers once it has finished sleeping, so a test can tell a real reply from an
+/// empty one.
+pub const REPLY: &[u8] = b"served";
+
 /// A codec whose wire representation *is* the message: no framing beyond what gRPC already adds.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct BytesCodec;
@@ -90,7 +94,7 @@ impl Service<Request<Bytes>> for SlowService {
         let delay = self.delay;
         Box::pin(async move {
             tokio::time::sleep(delay).await;
-            Ok(Response::new(Bytes::from_static(b"late")))
+            Ok(Response::new(Bytes::from_static(REPLY)))
         })
     }
 }

--- a/packages/rust/armonik-transport/tests/timeout.rs
+++ b/packages/rust/armonik-transport/tests/timeout.rs
@@ -49,7 +49,7 @@ async fn no_timeout_lets_a_slow_call_finish() {
         .expect("connecting should succeed");
 
     let answer = call(channel).await.expect("the call should complete");
-    assert_eq!(answer.as_ref(), b"late");
+    assert_eq!(answer.as_ref(), common::REPLY);
 }
 
 #[tokio::test]
@@ -69,7 +69,7 @@ async fn a_rate_limit_is_accepted_and_still_lets_calls_through() {
             .await
             .expect("the call should complete")
             .as_ref(),
-        b"late"
+        common::REPLY
     );
 }
 


### PR DESCRIPTION
# Motivation

The integration tests assert on the bytes the test service answers, spelled `b"late"` at the
producer and at each consumer. A change to one spot can silently miss the others.

# Description

A `REPLY` constant in `tests/common` names the bytes once; the service and both assertions use it.
It also reads as what it is: proof that a real reply arrived rather than an empty one.

# Testing

`cargo test -p armonik-transport --all-features`: 28 passed; the run is in the commit message.

# Impact

Test-only; no production code is touched.

# Additional Information

First of the Rust proxy series; nothing depends on it and it depends on nothing.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation. (none needed: test-only)
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI. (locally yes; CI runs on this PR)
- [x] I have assessed the performance impact of my modifications.
