### PR TITLE
feat(rust): configure the proxy through the GrpcClient__Proxy options

### DIFF
--- a/packages/rust/Cargo.lock
+++ b/packages/rust/Cargo.lock
@@ -994,6 +994,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
+ "serde",
  "zeroize",
 ]
 

--- a/packages/rust/armonik-transport/Cargo.toml
+++ b/packages/rust/armonik-transport/Cargo.toml
@@ -11,7 +11,9 @@ version.workspace = true
 include = ["**/*.rs", "Cargo.toml", "README.md"]
 
 [features]
-serde = ["dep:serde"]
+# `secrecy/serde` so the proxy password deserialises with the rest of the arguments. There is no
+# Serialize half to turn on: the type refuses to be written out.
+serde = ["dep:serde", "secrecy/serde"]
 
 [dependencies]
 # `channel` for `tonic::transport::Endpoint`, which is what `connect` builds; `codegen` for the

--- a/packages/rust/armonik-transport/README.md
+++ b/packages/rust/armonik-transport/README.md
@@ -17,6 +17,18 @@ connection; `ProxyConfig::explicit(uri)` names a proxy, which is then used whate
 `with_credentials` authenticates to it, half by half: a half left empty keeps what the proxy URL
 itself carried.
 
+In the string form, `GrpcClient__Proxy` takes the same four values as ArmoniK's C# client: empty
+and `system` follow the environment, `none` forces a direct connection, anything else is the
+proxy's URL, defaulting to the `http` scheme. `GrpcClient__ProxyUsername` and
+`GrpcClient__ProxyPassword` authenticate to it, falling back to whatever the URL itself carried. A
+URL that cannot be dialled as written, no host, a port that is not one, or a scheme other than
+`http`, is refused while the configuration is being read.
+
+Two divergences from the C# client are deliberate. Spell `none` and `system` exactly so, or
+capitalised: this crate accepts any casing, C# treats `NONE` as a proxy URL. And an `https` proxy
+URL, which C# passes to the runtime, is refused here: the `CONNECT` handshake would go out in the
+clear to a proxy expecting TLS.
+
 The connection is an HTTP `CONNECT` tunnel: TLS, mutual TLS included, is negotiated end to end with
 the real server, and the proxy only forwards opaque bytes. Because the `CONNECT` handshake itself goes
 out in the clear, the proxy's own URL has to be `http`. The handshake is bounded by

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use hyper::{http::HeaderValue, Uri};
 use rustls::pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer};
+use secrecy::ExposeSecret as _;
 use snafu::{ResultExt, Snafu};
 
 use crate::proxy::{ProxyConfig, ProxySource};
@@ -144,8 +145,11 @@ pub struct ClientConfigArgs {
     /// direct connection, otherwise the proxy URL, whose scheme has to be `http`: the `CONNECT`
     /// handshake is written in the clear. `none` and `system` are the spellings every ArmoniK
     /// client understands; other casings are accepted here but not everywhere.
+    ///
+    /// A URL can carry credentials (`http://user:password@host`), so the whole value is redacted
+    /// by `Debug` and zeroized on drop, like `proxy_password`.
     #[cfg_attr(feature = "serde", serde(default))]
-    pub proxy: String,
+    pub proxy: secrecy::SecretString,
     /// Username for proxy authentication.
     ///
     /// Empty falls back to the username the `proxy` URL carried, if any.
@@ -187,7 +191,7 @@ impl ClientConfigArgs {
             http2_max_header_list_size: read_env("GrpcClient__Http2MaxHeaderListSize")
                 .context(ctx)?,
             user_agent: read_env("GrpcClient__UserAgent").context(ctx)?,
-            proxy: read_env("GrpcClient__Proxy").context(ctx)?,
+            proxy: read_env("GrpcClient__Proxy").context(ctx)?.into(),
             proxy_username: read_env("GrpcClient__ProxyUsername").context(ctx)?,
             proxy_password: read_env("GrpcClient__ProxyPassword").context(ctx)?.into(),
         })
@@ -222,7 +226,7 @@ impl ClientConfig {
             // Elided, and `proxy_password` left out entirely: this span is recorded at debug level,
             // and a proxy URL carries credentials as often as the dedicated option does. Do not
             // complete the list.
-            proxy = %crate::proxy::elide_userinfo(&args.proxy),
+            proxy = %crate::proxy::elide_userinfo(args.proxy.expose_secret()),
             args.proxy_username,
         );
 
@@ -476,7 +480,8 @@ impl ClientConfig {
             user_agent,
             // A dedicated credential half wins over the URL's; `with_credentials` leaves an empty
             // half to what the URL carried.
-            proxy: parse_proxy_source(&proxy)?.with_credentials(proxy_username, proxy_password),
+            proxy: parse_proxy_source(proxy.expose_secret())?
+                .with_credentials(proxy_username, proxy_password),
         })
     }
 }
@@ -1014,7 +1019,7 @@ mod tests {
         // The same reading as ArmoniK's C# client, where an unset option leaves the handler
         // following the environment.
         for value in ["", "system", "System", "SYSTEM"] {
-            let config = proxy_config(|args| args.proxy = String::from(value));
+            let config = proxy_config(|args| args.proxy = value.into());
             assert_eq!(config.proxy.source, ProxySource::System, "{value:?}");
         }
     }
@@ -1022,15 +1027,15 @@ mod tests {
     #[test]
     fn proxy_none_forces_a_direct_connection() {
         for value in ["none", "None", "NONE"] {
-            let config = proxy_config(|args| args.proxy = String::from(value));
+            let config = proxy_config(|args| args.proxy = value.into());
             assert_eq!(config.proxy.source, ProxySource::Disabled, "{value:?}");
         }
     }
 
     #[test]
     fn proxy_url_defaults_to_the_http_scheme() {
-        let with_scheme = proxy_config(|args| args.proxy = String::from("http://proxy.corp:3128"));
-        let without_scheme = proxy_config(|args| args.proxy = String::from("proxy.corp:3128"));
+        let with_scheme = proxy_config(|args| args.proxy = "http://proxy.corp:3128".into());
+        let without_scheme = proxy_config(|args| args.proxy = "proxy.corp:3128".into());
 
         assert_eq!(with_scheme.proxy.source, without_scheme.proxy.source);
         let ProxySource::Explicit(uri) = with_scheme.proxy.source else {
@@ -1042,8 +1047,7 @@ mod tests {
 
     #[test]
     fn proxy_credentials_in_the_url_are_honoured_and_removed_from_it() {
-        let config =
-            proxy_config(|args| args.proxy = String::from("http://user:secret@proxy.corp:3128"));
+        let config = proxy_config(|args| args.proxy = "http://user:secret@proxy.corp:3128".into());
 
         assert_eq!(config.proxy.username, "user");
         assert_eq!(config.proxy.password.expose_secret(), "secret");
@@ -1059,7 +1063,7 @@ mod tests {
     #[test]
     fn the_dedicated_proxy_options_win_over_the_url() {
         let config = proxy_config(|args| {
-            args.proxy = String::from("http://url-user:url-secret@proxy.corp:3128");
+            args.proxy = "http://url-user:url-secret@proxy.corp:3128".into();
             args.proxy_username = String::from("option-user");
             args.proxy_password = "option-secret".into();
         });
@@ -1073,7 +1077,7 @@ mod tests {
         // Replacing the pair rather than each half would leave an empty username here, and the proxy
         // would answer 407 with nothing to explain it.
         let config = proxy_config(|args| {
-            args.proxy = String::from("http://url-user:url-secret@proxy.corp:3128");
+            args.proxy = "http://url-user:url-secret@proxy.corp:3128".into();
             args.proxy_password = "option-secret".into();
         });
 
@@ -1086,7 +1090,7 @@ mod tests {
         // These are what a caller inspects before handing them over, and what a panic message or a
         // log line would render.
         let arguments = ClientConfigArgs {
-            proxy: String::from("http://user:url-secret@proxy.corp:3128"),
+            proxy: "http://user:url-secret@proxy.corp:3128".into(),
             proxy_password: "option-secret".into(),
             ..args()
         };
@@ -1096,6 +1100,11 @@ mod tests {
             !rendered.contains("option-secret"),
             "password rendered: {rendered}"
         );
+        // The URL form carries a password too, which is why the whole `proxy` value is a secret.
+        assert!(
+            !rendered.contains("url-secret"),
+            "URL password rendered: {rendered}"
+        );
     }
 
     #[test]
@@ -1103,7 +1112,7 @@ mod tests {
         // A URL can be rejected for having no host, or for a "port" that is really a password
         // whose `@host` part went missing, and still have carried a credential.
         for value in ["http://user:s3cr3t@", "http://admin:hunter2"] {
-            let error = proxy_error(|args| args.proxy = String::from(value));
+            let error = proxy_error(|args| args.proxy = value.into());
             assert!(
                 !error.contains("s3cr3t") && !error.contains("hunter2"),
                 "password echoed for {value:?}: {error}"
@@ -1116,7 +1125,7 @@ mod tests {
         // The `CONNECT` handshake goes out unencrypted, so a proxy expecting TLS would see gibberish.
         // Accepting the URL and failing at connect time would report it as an unreachable proxy.
         for value in ["https://proxy.corp:3128", "socks5://proxy.corp:1080"] {
-            let error = proxy_error(|args| args.proxy = String::from(value));
+            let error = proxy_error(|args| args.proxy = value.into());
             assert!(error.contains("only an `http` proxy"), "{value}: {error}");
         }
     }
@@ -1126,7 +1135,7 @@ mod tests {
         // Reporting these through the endpoint's URI error would send whoever reads it looking at the
         // wrong setting.
         for value in ["http:///no-host", "http://", "http://:3128", "://"] {
-            let error = proxy_error(|args| args.proxy = String::from(value));
+            let error = proxy_error(|args| args.proxy = value.into());
             assert!(
                 error.contains("is not a valid proxy URL"),
                 "unexpected error for {value:?}: {error}"
@@ -1144,7 +1153,7 @@ mod tests {
             "proxy.corp:31z8",
             "http://admin:hunter2",
         ] {
-            let error = proxy_error(|args| args.proxy = String::from(value));
+            let error = proxy_error(|args| args.proxy = value.into());
             assert!(
                 error.contains("does not name a valid port"),
                 "unexpected error for {value:?}: {error}"
@@ -1156,7 +1165,7 @@ mod tests {
     fn an_ipv6_proxy_is_accepted_with_and_without_a_port() {
         // The port check must not mistake the colons of an IPv6 literal for an invalid port.
         for (value, port) in [("http://[::1]:3128", Some(3128)), ("http://[::1]", None)] {
-            let config = proxy_config(|args| args.proxy = String::from(value));
+            let config = proxy_config(|args| args.proxy = value.into());
             let ProxySource::Explicit(uri) = &config.proxy.source else {
                 panic!("expected an explicit proxy for {value:?}");
             };

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -4,7 +4,7 @@ use hyper::{http::HeaderValue, Uri};
 use rustls::pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer};
 use snafu::{ResultExt, Snafu};
 
-use crate::proxy::ProxyConfig;
+use crate::proxy::{ProxyConfig, ProxySource};
 
 /// Options for creating a gRPC Client
 #[derive(Debug, Default)]
@@ -77,8 +77,12 @@ impl Clone for ClientConfig {
 }
 
 /// Options for creating a gRPC Client (as given in the environment)
-#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+///
+/// Deserializable but deliberately not serializable: the proxy password is a secret, and a type
+/// that cannot be written out cannot leak it through a configuration dump. `Debug` redacts it for
+/// the same reason.
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[non_exhaustive]
 pub struct ClientConfigArgs {
     /// Endpoint for sending requests
@@ -134,6 +138,26 @@ pub struct ClientConfigArgs {
     /// User-Agent header value sent with each request
     #[cfg_attr(feature = "serde", serde(default))]
     pub user_agent: String,
+    /// HTTP proxy to reach the endpoint through.
+    ///
+    /// Empty or `system` follows the environment (see [`ProxySource::System`]), `none` forces a
+    /// direct connection, otherwise the proxy URL, whose scheme has to be `http`: the `CONNECT`
+    /// handshake is written in the clear. `none` and `system` are the spellings every ArmoniK
+    /// client understands; other casings are accepted here but not everywhere.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub proxy: String,
+    /// Username for proxy authentication.
+    ///
+    /// Empty falls back to the username the `proxy` URL carried, if any.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub proxy_username: String,
+    /// Password for proxy authentication.
+    ///
+    /// Empty falls back to the password the `proxy` URL carried, independently of the username, so
+    /// setting this one alone still uses that URL's username. Redacted by `Debug` and zeroized on
+    /// drop.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub proxy_password: secrecy::SecretString,
 }
 
 impl ClientConfigArgs {
@@ -163,6 +187,9 @@ impl ClientConfigArgs {
             http2_max_header_list_size: read_env("GrpcClient__Http2MaxHeaderListSize")
                 .context(ctx)?,
             user_agent: read_env("GrpcClient__UserAgent").context(ctx)?,
+            proxy: read_env("GrpcClient__Proxy").context(ctx)?,
+            proxy_username: read_env("GrpcClient__ProxyUsername").context(ctx)?,
+            proxy_password: read_env("GrpcClient__ProxyPassword").context(ctx)?.into(),
         })
     }
 }
@@ -192,6 +219,11 @@ impl ClientConfig {
             args.http2_keep_alive_while_idle,
             args.http2_max_header_list_size,
             args.user_agent,
+            // Elided, and `proxy_password` left out entirely: this span is recorded at debug level,
+            // and a proxy URL carries credentials as often as the dedicated option does. Do not
+            // complete the list.
+            proxy = %crate::proxy::elide_userinfo(&args.proxy),
+            args.proxy_username,
         );
 
         let ClientConfigArgs {
@@ -213,6 +245,9 @@ impl ClientConfig {
             http2_keep_alive_while_idle,
             http2_max_header_list_size,
             user_agent,
+            proxy,
+            proxy_username,
+            proxy_password,
         } = args;
 
         // Read CAcert file
@@ -439,9 +474,91 @@ impl ClientConfig {
             http2_keep_alive_while_idle,
             http2_max_header_list_size,
             user_agent,
-            proxy: ProxyConfig::default(),
+            // A dedicated credential half wins over the URL's; `with_credentials` leaves an empty
+            // half to what the URL carried.
+            proxy: parse_proxy_source(&proxy)?.with_credentials(proxy_username, proxy_password),
         })
     }
+}
+
+/// Interpret the `GrpcClient__Proxy` value.
+///
+/// Empty and `system` follow the environment, `none` forces a direct connection, anything else is a
+/// proxy URL, defaulting to the `http` scheme. A URL that cannot be dialled as written, a missing
+/// host, a port that is not one, or a scheme the `CONNECT` handshake cannot use, fails here, while
+/// the configuration is being read and can name itself, rather than at connect time.
+fn parse_proxy_source(proxy: &str) -> Result<ProxyConfig, ConfigError> {
+    if proxy.is_empty() || proxy.eq_ignore_ascii_case("system") {
+        return Ok(ProxyConfig::system());
+    }
+    if proxy.eq_ignore_ascii_case("none") {
+        return Ok(ProxyConfig::disabled());
+    }
+
+    let with_scheme = if proxy.contains("://") {
+        proxy.to_owned()
+    } else {
+        format!("http://{proxy}")
+    };
+    // Not reported through `UriSnafu`: its message names the endpoint, which would send
+    // whoever reads it looking at the wrong option.
+    let uri = Uri::try_from(&with_scheme).ok().filter(|uri| {
+        uri.authority()
+            .is_some_and(|authority| !authority.host().is_empty())
+    });
+    let Some(uri) = uri else {
+        return IncompatibleOptionsSnafu {
+            // Elided: a URL rejected for having no host can still have carried a password.
+            msg: format!(
+                "`GrpcClient__Proxy={}` is not a valid proxy URL. Expected `none`, \
+                 `system`, or a URL such as `http://proxy.example.com:3128`",
+                crate::proxy::elide_userinfo(proxy)
+            ),
+        }
+        .fail();
+    };
+
+    if uri.scheme_str().is_some_and(|scheme| scheme != "http") {
+        return IncompatibleOptionsSnafu {
+            msg: format!(
+                "{}, and `GrpcClient__Proxy={}` names another scheme",
+                crate::proxy::HTTP_ONLY_RULE,
+                crate::proxy::elide_userinfo(proxy)
+            ),
+        }
+        .fail();
+    }
+
+    let config = ProxyConfig::explicit(uri);
+    let ProxySource::Explicit(stripped) = &config.source else {
+        return IncompatibleOptionsSnafu {
+            msg: String::from("`GrpcClient__Proxy`: an explicit proxy should stay explicit"),
+        }
+        .fail();
+    };
+
+    // `http::Uri` keeps the port as text and parses it lazily, so `proxy.corp:99999` or
+    // `proxy.corp:31z8` would otherwise be accepted here and silently dialled on port 80. Checked
+    // on the credential-stripped form, where the only `:` left outside an IPv6 literal is a port's.
+    let authority = stripped
+        .authority()
+        .expect("checked above to have a host");
+    let written_port = authority
+        .as_str()
+        .rsplit_once(':')
+        .map(|(_, tail)| tail)
+        .filter(|tail| !tail.contains(']'));
+    if written_port.is_some() && stripped.port_u16().is_none() {
+        return IncompatibleOptionsSnafu {
+            msg: format!(
+                "`GrpcClient__Proxy={}` does not name a valid port",
+                crate::proxy::elide_userinfo(proxy)
+            ),
+        }
+        .fail();
+    }
+
+    Ok(config)
 }
 
 impl TryFrom<&ClientConfig> for tonic::transport::Endpoint {
@@ -542,6 +659,8 @@ pub enum ConfigError {
 
 #[cfg(test)]
 mod tests {
+    use secrecy::ExposeSecret as _;
+
     use super::*;
 
     /// The minimum viable arguments: an endpoint, and nothing else set.
@@ -857,21 +976,189 @@ mod tests {
 
     #[cfg(feature = "serde")]
     #[test]
-    fn arguments_round_trip_through_serde_with_absent_fields_defaulted() {
+    fn arguments_deserialise_with_absent_fields_defaulted() {
         // Every field but the endpoint carries `serde(default)`, so a configuration file need only name
         // what it changes. The feature is off by default, so nothing else here would notice it breaking.
-        let deserialised: ClientConfigArgs =
-            serde_json::from_str(r#"{"endpoint":"http://localhost:5001","timeout":"30s"}"#)
-                .expect("absent fields should default");
+        // Deserialise only: the type deliberately has no `Serialize`, so a proxy password cannot leak
+        // through a configuration dump.
+        let deserialised: ClientConfigArgs = serde_json::from_str(
+            r#"{"endpoint":"http://localhost:5001","timeout":"30s","proxy_password":"s3cr3t"}"#,
+        )
+        .expect("absent fields should default");
 
         assert_eq!(deserialised.endpoint, "http://localhost:5001");
         assert_eq!(deserialised.timeout, "30s");
         assert_eq!(deserialised.cert_pem, "", "an absent field defaults");
         assert!(!deserialised.allow_unsafe_connection);
+        assert_eq!(deserialised.proxy_password.expose_secret(), "s3cr3t");
+    }
 
-        let round_tripped: ClientConfigArgs =
-            serde_json::from_str(&serde_json::to_string(&deserialised).expect("serialise"))
-                .expect("deserialise");
-        assert_eq!(round_tripped, deserialised);
+    // --- the proxy ---
+
+    /// The configuration `set` produces, expected to be valid.
+    fn proxy_config(set: impl FnOnce(&mut ClientConfigArgs)) -> ClientConfig {
+        let mut arguments = args();
+        set(&mut arguments);
+        ClientConfig::from_config_args(arguments).expect("a valid configuration")
+    }
+
+    /// The error message `set` produces, expected to be a rejection.
+    fn proxy_error(set: impl FnOnce(&mut ClientConfigArgs)) -> String {
+        let mut arguments = args();
+        set(&mut arguments);
+        ClientConfig::from_config_args(arguments)
+            .expect_err("the configuration should be rejected")
+            .to_string()
+    }
+
+    #[test]
+    fn proxy_empty_and_system_follow_the_environment() {
+        // The same reading as ArmoniK's C# client, where an unset option leaves the handler
+        // following the environment.
+        for value in ["", "system", "System", "SYSTEM"] {
+            let config = proxy_config(|args| args.proxy = String::from(value));
+            assert_eq!(config.proxy.source, ProxySource::System, "{value:?}");
+        }
+    }
+
+    #[test]
+    fn proxy_none_forces_a_direct_connection() {
+        for value in ["none", "None", "NONE"] {
+            let config = proxy_config(|args| args.proxy = String::from(value));
+            assert_eq!(config.proxy.source, ProxySource::Disabled, "{value:?}");
+        }
+    }
+
+    #[test]
+    fn proxy_url_defaults_to_the_http_scheme() {
+        let with_scheme = proxy_config(|args| args.proxy = String::from("http://proxy.corp:3128"));
+        let without_scheme = proxy_config(|args| args.proxy = String::from("proxy.corp:3128"));
+
+        assert_eq!(with_scheme.proxy.source, without_scheme.proxy.source);
+        let ProxySource::Explicit(uri) = with_scheme.proxy.source else {
+            panic!("expected an explicit proxy");
+        };
+        assert_eq!(uri.host(), Some("proxy.corp"));
+        assert_eq!(uri.port_u16(), Some(3128));
+    }
+
+    #[test]
+    fn proxy_credentials_in_the_url_are_honoured_and_removed_from_it() {
+        let config =
+            proxy_config(|args| args.proxy = String::from("http://user:secret@proxy.corp:3128"));
+
+        assert_eq!(config.proxy.username, "user");
+        assert_eq!(config.proxy.password.expose_secret(), "secret");
+        let ProxySource::Explicit(uri) = &config.proxy.source else {
+            panic!("expected an explicit proxy");
+        };
+        assert!(
+            !uri.to_string().contains("secret"),
+            "the URI is rendered in errors and logs: {uri}"
+        );
+    }
+
+    #[test]
+    fn the_dedicated_proxy_options_win_over_the_url() {
+        let config = proxy_config(|args| {
+            args.proxy = String::from("http://url-user:url-secret@proxy.corp:3128");
+            args.proxy_username = String::from("option-user");
+            args.proxy_password = "option-secret".into();
+        });
+
+        assert_eq!(config.proxy.username, "option-user");
+        assert_eq!(config.proxy.password.expose_secret(), "option-secret");
+    }
+
+    #[test]
+    fn a_dedicated_password_alone_keeps_the_username_the_url_carried() {
+        // Replacing the pair rather than each half would leave an empty username here, and the proxy
+        // would answer 407 with nothing to explain it.
+        let config = proxy_config(|args| {
+            args.proxy = String::from("http://url-user:url-secret@proxy.corp:3128");
+            args.proxy_password = "option-secret".into();
+        });
+
+        assert_eq!(config.proxy.username, "url-user");
+        assert_eq!(config.proxy.password.expose_secret(), "option-secret");
+    }
+
+    #[test]
+    fn the_arguments_keep_the_password_out_of_their_debug_output() {
+        // These are what a caller inspects before handing them over, and what a panic message or a
+        // log line would render.
+        let arguments = ClientConfigArgs {
+            proxy: String::from("http://user:url-secret@proxy.corp:3128"),
+            proxy_password: "option-secret".into(),
+            ..args()
+        };
+
+        let rendered = format!("{arguments:?}");
+        assert!(
+            !rendered.contains("option-secret"),
+            "password rendered: {rendered}"
+        );
+    }
+
+    #[test]
+    fn a_rejected_proxy_url_does_not_echo_its_password() {
+        // A URL can be rejected for having no host, or for a "port" that is really a password
+        // whose `@host` part went missing, and still have carried a credential.
+        for value in ["http://user:s3cr3t@", "http://admin:hunter2"] {
+            let error = proxy_error(|args| args.proxy = String::from(value));
+            assert!(
+                !error.contains("s3cr3t") && !error.contains("hunter2"),
+                "password echoed for {value:?}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_proxy_that_is_not_http_is_rejected_rather_than_reached_in_the_clear() {
+        // The `CONNECT` handshake goes out unencrypted, so a proxy expecting TLS would see gibberish.
+        // Accepting the URL and failing at connect time would report it as an unreachable proxy.
+        for value in ["https://proxy.corp:3128", "socks5://proxy.corp:1080"] {
+            let error = proxy_error(|args| args.proxy = String::from(value));
+            assert!(error.contains("only an `http` proxy"), "{value}: {error}");
+        }
+    }
+
+    #[test]
+    fn proxy_without_a_host_is_rejected_and_names_its_own_option() {
+        // Reporting these through the endpoint's URI error would send whoever reads it looking at the
+        // wrong setting.
+        for value in ["http:///no-host", "http://", "http://:3128", "://"] {
+            let error = proxy_error(|args| args.proxy = String::from(value));
+            assert!(
+                error.contains("is not a valid proxy URL"),
+                "unexpected error for {value:?}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_port_that_is_not_one_is_rejected_rather_than_dialled_on_80() {
+        // `http::Uri` keeps the port as text and parses it lazily, so without the explicit check a
+        // typo would pass validation and the connector would quietly fall back to the scheme
+        // default.
+        for value in ["proxy.corp:99999", "proxy.corp:31z8", "http://admin:hunter2"] {
+            let error = proxy_error(|args| args.proxy = String::from(value));
+            assert!(
+                error.contains("does not name a valid port"),
+                "unexpected error for {value:?}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_ipv6_proxy_is_accepted_with_and_without_a_port() {
+        // The port check must not mistake the colons of an IPv6 literal for an invalid port.
+        for (value, port) in [("http://[::1]:3128", Some(3128)), ("http://[::1]", None)] {
+            let config = proxy_config(|args| args.proxy = String::from(value));
+            let ProxySource::Explicit(uri) = &config.proxy.source else {
+                panic!("expected an explicit proxy for {value:?}");
+            };
+            assert_eq!(uri.port_u16(), port, "{value:?}");
+        }
     }
 }

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -540,9 +540,7 @@ fn parse_proxy_source(proxy: &str) -> Result<ProxyConfig, ConfigError> {
     // `http::Uri` keeps the port as text and parses it lazily, so `proxy.corp:99999` or
     // `proxy.corp:31z8` would otherwise be accepted here and silently dialled on port 80. Checked
     // on the credential-stripped form, where the only `:` left outside an IPv6 literal is a port's.
-    let authority = stripped
-        .authority()
-        .expect("checked above to have a host");
+    let authority = stripped.authority().expect("checked above to have a host");
     let written_port = authority
         .as_str()
         .rsplit_once(':')
@@ -1141,7 +1139,11 @@ mod tests {
         // `http::Uri` keeps the port as text and parses it lazily, so without the explicit check a
         // typo would pass validation and the connector would quietly fall back to the scheme
         // default.
-        for value in ["proxy.corp:99999", "proxy.corp:31z8", "http://admin:hunter2"] {
+        for value in [
+            "proxy.corp:99999",
+            "proxy.corp:31z8",
+            "http://admin:hunter2",
+        ] {
             let error = proxy_error(|args| args.proxy = String::from(value));
             assert!(
                 error.contains("does not name a valid port"),

--- a/packages/rust/armonik-transport/src/proxy.rs
+++ b/packages/rust/armonik-transport/src/proxy.rs
@@ -746,7 +746,9 @@ mod tests {
             let elided = elide_userinfo(written);
             assert_eq!(elided, expected, "{written}");
             assert!(
-                !elided.contains("secret") && !elided.contains("pass") && !elided.contains("hunter"),
+                !elided.contains("secret")
+                    && !elided.contains("pass")
+                    && !elided.contains("hunter"),
                 "{written} still shows its password as {elided}"
             );
         }

--- a/packages/rust/armonik-transport/src/proxy.rs
+++ b/packages/rust/armonik-transport/src/proxy.rs
@@ -423,6 +423,45 @@ fn translate(proxy: Uri, error: impl std::error::Error + Send + Sync + 'static) 
     TunnelFailedSnafu { proxy }.into_error(BoxError::from(error))
 }
 
+/// The one statement of the scheme rule, shared between the connect-time check and the
+/// configuration-time one so the two messages cannot drift apart.
+pub(crate) const HTTP_ONLY_RULE: &str =
+    "The `CONNECT` handshake is written in the clear, so only an `http` proxy can be reached";
+
+/// Render a proxy URL with any credentials elided, for a message or a log line.
+///
+/// Textual rather than through [`Uri`], because the values that most need eliding are the ones that
+/// failed to parse in the first place. Every ambiguity elides rather than shows: over-eliding loses
+/// a detail from a message, under-eliding prints a password.
+pub(crate) fn elide_userinfo(value: &str) -> String {
+    let (scheme, rest) = match value.split_once("://") {
+        Some((scheme, rest)) => (Some(scheme), rest),
+        None => (None, value),
+    };
+    let elided = |body: String| match scheme {
+        Some(scheme) => format!("{scheme}://{body}"),
+        None => body,
+    };
+
+    // The last `@` in the whole of the rest, not just up to the first `/`. A password containing an
+    // unescaped `/` is malformed, which is exactly the input that reaches this function, and looking
+    // only at the authority would leave such a password rendered in full.
+    if let Some((_, remainder)) = rest.rsplit_once('@') {
+        return elided(format!("***@{remainder}"));
+    }
+
+    // No `@`, but a `:` whose tail is not a port: userinfo written without a host
+    // (`http://admin:hunter2`), and the tail is the password. An IPv6 literal also lands here and
+    // is over-elided; nothing leaks.
+    if let Some((head, tail)) = rest.split_once(':') {
+        if !tail.is_empty() && tail.parse::<u16>().is_err() {
+            return elided(format!("{head}:***"));
+        }
+    }
+
+    String::from(value)
+}
+
 /// Failure to reach the endpoint through the proxy.
 #[derive(Debug, Snafu)]
 #[non_exhaustive]
@@ -446,7 +485,8 @@ pub enum ProxyError {
         location: snafu::Location,
     },
     #[snafu(display(
-        "The proxy requires authentication; configure proxy credentials [{location}]"
+        "The proxy requires authentication; set `GrpcClient__ProxyUsername` and \
+         `GrpcClient__ProxyPassword` [{location}]"
     ))]
     #[non_exhaustive]
     AuthenticationRequired {
@@ -461,10 +501,7 @@ pub enum ProxyError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
-    #[snafu(display(
-        "The `CONNECT` handshake is written in the clear, so only an `http` proxy can be reached, \
-         not {proxy} [{location}]"
-    ))]
+    #[snafu(display("{HTTP_ONLY_RULE}, not {proxy} [{location}]"))]
     #[non_exhaustive]
     UnsupportedProxy {
         proxy: Uri,
@@ -676,6 +713,50 @@ mod tests {
             credentials,
             Some((String::from("[user"), String::from("s3cr3t")))
         );
+    }
+
+    #[test]
+    fn eliding_hides_the_credentials_and_keeps_the_rest() {
+        for (written, expected) in [
+            (
+                "http://user:secret@proxy.corp:3128",
+                "http://***@proxy.corp:3128",
+            ),
+            ("http://user@proxy.corp", "http://***@proxy.corp"),
+            // Rejected for having no host, and still worth eliding.
+            ("http://user:secret@", "http://***@"),
+            ("user:secret@proxy.corp", "***@proxy.corp"),
+            (
+                "http://user:secret@proxy.corp/path",
+                "http://***@proxy.corp/path",
+            ),
+            // A `/` inside the password is malformed, which is how such a value reaches this function
+            // at all, and is why the split is on the last `@` rather than on the authority.
+            (
+                "http://user:my/pass@proxy.corp:3128",
+                "http://***@proxy.corp:3128",
+            ),
+            // Several `@`: the last one wins, so nothing before it survives.
+            ("http://user:p@ss@proxy.corp", "http://***@proxy.corp"),
+            // Credentials with the `@host` part missing entirely: the tail is not a port, so it is
+            // a password.
+            ("http://admin:hunter2", "http://admin:***"),
+            ("admin:hunter2", "admin:***"),
+        ] {
+            let elided = elide_userinfo(written);
+            assert_eq!(elided, expected, "{written}");
+            assert!(
+                !elided.contains("secret") && !elided.contains("pass") && !elided.contains("hunter"),
+                "{written} still shows its password as {elided}"
+            );
+        }
+    }
+
+    #[test]
+    fn eliding_leaves_a_url_without_credentials_untouched() {
+        for value in ["http://proxy.corp:3128", "proxy.corp:3128", "", "none"] {
+            assert_eq!(elide_userinfo(value), value, "{value}");
+        }
     }
 
     #[test]

--- a/packages/rust/armonik-transport/tests/common/mod.rs
+++ b/packages/rust/armonik-transport/tests/common/mod.rs
@@ -211,7 +211,10 @@ pub fn config(
     // An unset proxy option follows the machine's environment; a test has to name its proxy
     // deliberately, or a developer's own HTTP_PROXY would route these loopback calls somewhere
     // real.
-    let follow_environment = args.proxy.is_empty();
+    let follow_environment = {
+        use armonik_transport::reexports::secrecy::ExposeSecret as _;
+        args.proxy.expose_secret().is_empty()
+    };
     let mut config = armonik_transport::ClientConfig::from_config_args(args)
         .expect("the configuration should be valid");
     if follow_environment {

--- a/packages/rust/armonik-transport/tests/common/mod.rs
+++ b/packages/rust/armonik-transport/tests/common/mod.rs
@@ -208,10 +208,14 @@ pub fn config(
     args.endpoint = endpoint.to_owned();
     args.allow_unsafe_connection = true;
     set(&mut args);
+    // An unset proxy option follows the machine's environment; a test has to name its proxy
+    // deliberately, or a developer's own HTTP_PROXY would route these loopback calls somewhere
+    // real.
+    let follow_environment = args.proxy.is_empty();
     let mut config = armonik_transport::ClientConfig::from_config_args(args)
         .expect("the configuration should be valid");
-    // The default follows the machine's environment; a test has to opt back in deliberately, or a
-    // developer's own HTTP_PROXY would route these loopback calls somewhere real.
-    config.proxy = armonik_transport::ProxyConfig::disabled();
+    if follow_environment {
+        config.proxy = armonik_transport::ProxyConfig::disabled();
+    }
     config
 }

--- a/packages/rust/armonik-transport/tests/proxy.rs
+++ b/packages/rust/armonik-transport/tests/proxy.rs
@@ -199,12 +199,16 @@ async fn a_missing_credential_is_reported_as_such() {
         .await
         .expect_err("the proxy should have refused the tunnel");
 
-    // The message has to say credentials are what is missing, otherwise a 407 is a dead end for
-    // whoever hits it.
+    // The message has to name the options to set, otherwise a 407 is a dead end for whoever hits
+    // it.
     let rendered = error_chain(error.as_ref());
     assert!(
         rendered.contains("requires authentication"),
         "unexpected error: {rendered}"
+    );
+    assert!(
+        rendered.contains("GrpcClient__ProxyUsername"),
+        "the error should say which options to set: {rendered}"
     );
     // And the failure has to be matchable by type, not only by text: `find_in` is how a caller
     // reacts to this case in particular, e.g. by prompting for credentials.
@@ -442,6 +446,50 @@ async fn an_https_proxy_from_the_environment_is_refused_before_dialling() {
             .as_ref(),
     );
     assert!(error.contains("only an `http` proxy"), "{error}");
+}
+
+// --- the string-form options, from the words to the tunnel ---
+
+#[tokio::test]
+async fn the_proxy_options_reach_the_tunnel() {
+    // Through `ClientConfigArgs` on purpose, so the parsing is under test along with the
+    // tunnelling: accepting the options and then not proxying is the defect the whole feature
+    // exists to fix.
+    let server = spawn_server().await;
+    let (proxy, tunnels) = spawn_proxy(ProxyAuth::Required("dXNlcjpzZWNyZXQ=")).await;
+
+    let config = common::config(&server, |args| {
+        args.proxy = format!("http://{proxy}");
+        args.proxy_username = String::from("user");
+        args.proxy_password = "secret".into();
+    });
+
+    let answer = call_through(config)
+        .await
+        .expect("the call should succeed through the proxy the options name");
+
+    assert_eq!(answer, common::REPLY);
+    assert_eq!(tunnels.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+#[serial_test::serial(env)]
+async fn the_system_option_takes_the_proxy_from_the_environment() {
+    let server = spawn_server().await;
+    let (proxy, tunnels) = spawn_proxy(ProxyAuth::None).await;
+
+    std::env::set_var("HTTP_PROXY", format!("http://{proxy}"));
+    let outcome = call_through(common::config(&server, |args| {
+        args.proxy = String::from("system");
+    }))
+    .await;
+    std::env::remove_var("HTTP_PROXY");
+
+    assert_eq!(
+        outcome.expect("the call should go through the proxy the environment names"),
+        common::REPLY
+    );
+    assert_eq!(tunnels.load(Ordering::SeqCst), 1);
 }
 
 // --- the handshake is bounded in time ---

--- a/packages/rust/armonik-transport/tests/proxy.rs
+++ b/packages/rust/armonik-transport/tests/proxy.rs
@@ -459,7 +459,7 @@ async fn the_proxy_options_reach_the_tunnel() {
     let (proxy, tunnels) = spawn_proxy(ProxyAuth::Required("dXNlcjpzZWNyZXQ=")).await;
 
     let config = common::config(&server, |args| {
-        args.proxy = format!("http://{proxy}");
+        args.proxy = format!("http://{proxy}").into();
         args.proxy_username = String::from("user");
         args.proxy_password = "secret".into();
     });
@@ -480,7 +480,7 @@ async fn the_system_option_takes_the_proxy_from_the_environment() {
 
     std::env::set_var("HTTP_PROXY", format!("http://{proxy}"));
     let outcome = call_through(common::config(&server, |args| {
-        args.proxy = String::from("system");
+        args.proxy = "system".into();
     }))
     .await;
     std::env::remove_var("HTTP_PROXY");


### PR DESCRIPTION
# Motivation

The proxy machinery is configurable through the API alone; the `GrpcClient__Proxy*` options that
every other ArmoniK client understands still do nothing here.

# Description

`GrpcClient__Proxy` takes the same four values as the C# client: empty and `system` follow the
environment, `none` forces a direct connection, anything else is the proxy URL, defaulting to the
`http` scheme. `GrpcClient__ProxyUsername` and `GrpcClient__ProxyPassword` authenticate to it,
each half falling back to what the URL itself carried.

A value that cannot be dialled as written fails while the configuration is being read and names
its own option: a missing host, a scheme other than `http`, and a port that is not one, since
`http::Uri` parses the port lazily and the connector would otherwise quietly dial the scheme
default. Error messages elide credentials, including a password left dangling by a missing
`@host` part. The 407 error now names the two options to set.

# Testing

Adds 16 tests: the option vocabulary and its rejections (host, scheme, port, credential eliding),
`Debug` redaction of the arguments, and end-to-end tests that go from the option strings to an
authenticated tunnel. `cargo test -p armonik-transport --all-features` passes at this branch's
head; the run is in the commit message, along with a clean `cargo clippy --all-targets` and
`cargo check -p armonik --all-features`.

# Impact

Breaking: `ClientConfigArgs` no longer implements `Serialize`, `PartialEq`, `Eq` or `Hash`. The
proxy password is a `SecretString`, which offers none of them, and a type that cannot be written
out cannot leak the password through a configuration dump; `Debug` redacts it. `Deserialize`
stays, so configuration files read as before.

Two deliberate divergences from the C# client, documented in the README: any casing of `none` and
`system` is accepted where C# is exact, and an `https` proxy URL is refused at configuration time
rather than handed to the runtime.

# Additional Information

Stacks on `wk/feat/rust-proxy-system`; merge that first.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI. (locally yes; CI runs on this PR)
- [x] I have assessed the performance impact of my modifications.
