### PR TITLE
test(rust): pin hyper-util's tunnel defects as tripwires

### DIFF
--- a/packages/rust/armonik-transport/README.md
+++ b/packages/rust/armonik-transport/README.md
@@ -29,6 +29,26 @@ capitalised: this crate accepts any casing, C# treats `NONE` as a proxy URL. And
 URL, which C# passes to the runtime, is refused here: the `CONNECT` handshake would go out in the
 clear to a proxy expecting TLS.
 
+### Known issues
+
+The tunnel handshake is `hyper_util::client::legacy::connect::proxy::Tunnel`, not code written in
+this crate, and as shipped in `hyper-util` 0.1.20 it gets four cases wrong. None are ours to fix
+directly; [hyperium/hyper-util#300](https://github.com/hyperium/hyper-util/pull/300) tracks the
+first two upstream. All but the second are pinned by a tripwire in `tests/upstream_tunnel.rs`, so a
+`hyper-util` release that fixes one turns that test red rather than letting the fix pass unnoticed.
+
+- **Only an exact `200` opens the tunnel.** RFC 9110 says any `2xx` should. A proxy answering `201`
+  or `204` is treated as a refusal.
+- **A status line split across two reads is rejected**, even though the connection is fine. Legal
+  HTTP, and likelier with a slow proxy or a small MSS. Not pinned by a tripwire: asserting on how
+  reads land needs timing assumptions that make the test flaky on a loaded runner.
+- **An `HTTP/1.0 407` is not recognised as a request for credentials.** Only `HTTP/1.1 407` is; the
+  older version falls into the same generic refusal as any other failure, so the message naming
+  which two options to set is not shown for it.
+- **A target with no port is dialled on `443`, whatever its scheme**, rather than the scheme
+  deciding between `80` and `443`. ArmoniK deployments always name a port, so this is unlikely to
+  matter in practice.
+
 The connection is an HTTP `CONNECT` tunnel: TLS, mutual TLS included, is negotiated end to end with
 the real server, and the proxy only forwards opaque bytes. Because the `CONNECT` handshake itself goes
 out in the clear, the proxy's own URL has to be `http`. The handshake is bounded by

--- a/packages/rust/armonik-transport/tests/common/mod.rs
+++ b/packages/rust/armonik-transport/tests/common/mod.rs
@@ -194,6 +194,98 @@ pub fn request_target(head: &str) -> String {
         .to_owned()
 }
 
+/// What a test proxy should demand of its clients.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // not every test binary drives a proxy
+pub enum ProxyAuth {
+    /// Accept every tunnel request.
+    None,
+    /// Reject with `407` unless the expected `Proxy-Authorization` header is present.
+    Required(&'static str),
+}
+
+/// How many `CONNECT` requests a test proxy accepted and tunnelled.
+pub type Tunnels = std::sync::Arc<std::sync::atomic::AtomicUsize>;
+
+/// A minimal HTTP proxy that only implements `CONNECT`, answering `success` when it accepts one.
+#[allow(dead_code)] // not every test binary drives a proxy
+pub async fn spawn_proxy(auth: ProxyAuth, success: u16) -> (std::net::SocketAddr, Tunnels) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind proxy");
+    let address = listener.local_addr().expect("proxy address");
+    let tunnels = Tunnels::default();
+
+    let accepted = std::sync::Arc::clone(&tunnels);
+    tokio::spawn(async move {
+        loop {
+            let Ok((client, _)) = listener.accept().await else {
+                return;
+            };
+            let tunnels = std::sync::Arc::clone(&accepted);
+            tokio::spawn(async move {
+                // A failing tunnel is a normal outcome in these tests; the client asserts on it.
+                let _ = serve_tunnel(client, auth, success, tunnels).await;
+            });
+        }
+    });
+
+    (address, tunnels)
+}
+
+#[allow(dead_code)] // reached only through spawn_proxy
+async fn serve_tunnel(
+    mut client: tokio::net::TcpStream,
+    auth: ProxyAuth,
+    success: u16,
+    tunnels: Tunnels,
+) -> std::io::Result<()> {
+    use tokio::io::AsyncWriteExt;
+
+    let head = read_head(&mut client).await?;
+    let target = request_target(&head);
+
+    if let ProxyAuth::Required(expected) = auth {
+        let presented = head.lines().find_map(|line| {
+            line.strip_prefix("Proxy-Authorization: Basic ")
+                .or_else(|| line.strip_prefix("proxy-authorization: Basic "))
+        });
+
+        if presented != Some(expected) {
+            client
+                .write_all(b"HTTP/1.1 407 Proxy Authentication Required\r\n\r\n")
+                .await?;
+            return client.flush().await;
+        }
+    }
+
+    let mut upstream = tokio::net::TcpStream::connect(&target).await?;
+    client
+        .write_all(format!("HTTP/1.1 {success} Connection established\r\n\r\n").as_bytes())
+        .await?;
+    client.flush().await?;
+    tunnels.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+    tokio::io::copy_bidirectional(&mut client, &mut upstream)
+        .await
+        .map(|_| ())
+}
+
+/// Render an error and everything it was caused by.
+///
+/// The transport error that wraps a proxy failure has a generic message, so an assertion has to look
+/// at the whole chain.
+#[allow(dead_code)] // not every test binary drives a proxy
+pub fn error_chain(error: &dyn std::error::Error) -> String {
+    let mut rendered = vec![error.to_string()];
+    let mut current = error.source();
+    while let Some(source) = current {
+        rendered.push(source.to_string());
+        current = source.source();
+    }
+    rendered.join(" -> ")
+}
+
 /// Build a [`ClientConfig`] from the string form, applying `set` to the arguments first.
 ///
 /// Going through `ClientConfigArgs` keeps the parsing inside what is under test. It is a helper at all

--- a/packages/rust/armonik-transport/tests/proxy.rs
+++ b/packages/rust/armonik-transport/tests/proxy.rs
@@ -4,90 +4,24 @@
 //! few dozen lines below rather than an external binary, so the tests run wherever CI does.
 
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use armonik_transport::{ClientConfig, ProxyConfig};
-use tokio::io::AsyncWriteExt;
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::TcpListener;
 
 mod common;
 
-use common::SlowService;
+use common::{ProxyAuth, SlowService, Tunnels};
 
 /// Serve the gRPC service the tests call, on an ephemeral loopback port.
 async fn spawn_server() -> String {
     common::serve(SlowService::new(Duration::ZERO)).await
 }
 
-/// What a test proxy should demand of its clients.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ProxyAuth {
-    /// Accept every tunnel request.
-    None,
-    /// Reject with `407` unless the expected `Proxy-Authorization` header is present.
-    Required(&'static str),
-}
-
-/// How many `CONNECT` requests a test proxy accepted and tunnelled.
-type Tunnels = Arc<AtomicUsize>;
-
 /// A minimal HTTP proxy that only implements `CONNECT`, answering 200.
 async fn spawn_proxy(auth: ProxyAuth) -> (SocketAddr, Tunnels) {
-    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind proxy");
-    let address = listener.local_addr().expect("proxy address");
-    let tunnels = Tunnels::default();
-
-    let accepted = Arc::clone(&tunnels);
-    tokio::spawn(async move {
-        loop {
-            let Ok((client, _)) = listener.accept().await else {
-                return;
-            };
-            let tunnels = Arc::clone(&accepted);
-            tokio::spawn(async move {
-                // A failing tunnel is a normal outcome in these tests; the client asserts on it.
-                let _ = serve_tunnel(client, auth, tunnels).await;
-            });
-        }
-    });
-
-    (address, tunnels)
-}
-
-async fn serve_tunnel(
-    mut client: TcpStream,
-    auth: ProxyAuth,
-    tunnels: Tunnels,
-) -> std::io::Result<()> {
-    let head = common::read_head(&mut client).await?;
-    let target = common::request_target(&head);
-
-    if let ProxyAuth::Required(expected) = auth {
-        let presented = head.lines().find_map(|line| {
-            line.strip_prefix("Proxy-Authorization: Basic ")
-                .or_else(|| line.strip_prefix("proxy-authorization: Basic "))
-        });
-
-        if presented != Some(expected) {
-            client
-                .write_all(b"HTTP/1.1 407 Proxy Authentication Required\r\n\r\n")
-                .await?;
-            return client.flush().await;
-        }
-    }
-
-    let mut upstream = TcpStream::connect(&target).await?;
-    client
-        .write_all(b"HTTP/1.1 200 Connection established\r\n\r\n")
-        .await?;
-    client.flush().await?;
-    tunnels.fetch_add(1, Ordering::SeqCst);
-
-    tokio::io::copy_bidirectional(&mut client, &mut upstream)
-        .await
-        .map(|_| ())
+    common::spawn_proxy(auth, 200).await
 }
 
 /// A client reaching `endpoint` through `proxy`, configured through the API.
@@ -125,19 +59,7 @@ async fn call_through(config: ClientConfig) -> Result<bytes::Bytes, Box<dyn std:
     Ok(common::call(channel).await?)
 }
 
-/// Render an error and everything it was caused by.
-///
-/// The transport error that wraps a proxy failure has a generic message, so an assertion has to look
-/// at the whole chain.
-fn error_chain(error: &dyn std::error::Error) -> String {
-    let mut rendered = vec![error.to_string()];
-    let mut current = error.source();
-    while let Some(source) = current {
-        rendered.push(source.to_string());
-        current = source.source();
-    }
-    rendered.join(" -> ")
-}
+use common::error_chain;
 
 #[tokio::test]
 async fn request_reaches_the_server_through_the_tunnel() {

--- a/packages/rust/armonik-transport/tests/upstream_tunnel.rs
+++ b/packages/rust/armonik-transport/tests/upstream_tunnel.rs
@@ -1,0 +1,143 @@
+//! Tripwires for what `hyper_util`'s `Tunnel`, which the proxy connector drives, gets wrong.
+//!
+//! Each test asserts that a known upstream defect is still there; the crate README's "Known
+//! issues" section describes them all. A `hyper-util` release that fixes one turns its tripwire
+//! red: read the failure as the notice that the fix has landed, delete the tripwire, and update
+//! the README. A dependency bump turning CI red is the point; read the failure before assuming it
+//! is a regression.
+
+use std::time::Duration;
+
+use armonik_transport::{ClientConfig, ProxyConfig};
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+
+mod common;
+
+use common::{error_chain, ProxyAuth, SlowService};
+
+/// A client reaching `endpoint` through `proxy`.
+fn through_proxy(endpoint: &str, proxy: std::net::SocketAddr) -> ClientConfig {
+    let mut config = common::config(endpoint, |_| {});
+    config.proxy = ProxyConfig::explicit(
+        hyper::Uri::try_from(format!("http://{proxy}")).expect("a valid proxy URI"),
+    );
+    config
+}
+
+/// Connect and make one call, returning what the server answered.
+async fn call_through(config: ClientConfig) -> Result<bytes::Bytes, Box<dyn std::error::Error>> {
+    let channel = armonik_transport::connect(config).await?;
+    Ok(common::call(channel).await?)
+}
+
+/// The control. Without it, a broken fixture would read as upstream still being broken.
+#[tokio::test]
+async fn control_a_plain_200_opens_the_tunnel() {
+    let server = common::serve(SlowService::new(Duration::ZERO)).await;
+    let (proxy, tunnels) = common::spawn_proxy(ProxyAuth::None, 200).await;
+
+    let answer = call_through(through_proxy(&server, proxy))
+        .await
+        .expect("the fixture itself must let an ordinary 200 through");
+
+    assert_eq!(answer, common::REPLY);
+    assert_eq!(tunnels.load(std::sync::atomic::Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn known_issue_a_success_other_than_200_does_not_open_the_tunnel() {
+    // RFC 9110: any 2xx switches the connection to tunnel mode. `Tunnel` checks for exactly `200`,
+    // so a proxy answering 201 is a tunnel that should open and does not.
+    //
+    // Not asserted on the fixture's tunnel counter: the fake proxy counts a tunnel as soon as it
+    // has written its own response, before learning whether the client accepted it, so that counter
+    // answers a different question from the one this test asks.
+    let server = common::serve(SlowService::new(Duration::ZERO)).await;
+    let (proxy, _tunnels) = common::spawn_proxy(ProxyAuth::None, 201).await;
+
+    let error = call_through(through_proxy(&server, proxy))
+        .await
+        .expect_err(
+            "201 unexpectedly opened the tunnel: hyper-util now accepts any 2xx. \
+             Delete this tripwire and update the README's Known issues section.",
+        );
+
+    assert!(
+        error_chain(error.as_ref()).contains("did not open the tunnel"),
+        "unexpected error: {}",
+        error_chain(error.as_ref())
+    );
+}
+
+#[tokio::test]
+async fn known_issue_an_http_1_0_407_is_not_recognised_as_authentication_required() {
+    // `Tunnel` only special-cases `HTTP/1.1 407`, so a proxy that answers in `HTTP/1.0` (legal, and
+    // how an old or minimal proxy might reply) falls into its generic refusal, and this crate's
+    // error translation never sees the "proxy authorization required" text it looks for. The
+    // message naming which two options to set is not shown for it.
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind proxy");
+    let proxy = listener.local_addr().expect("proxy address");
+    tokio::spawn(async move {
+        let Ok((mut client, _)) = listener.accept().await else {
+            return;
+        };
+        let _ = common::read_head(&mut client).await;
+        let _ = client
+            .write_all(b"HTTP/1.0 407 Proxy Authentication Required\r\n\r\n")
+            .await;
+        let _ = client.flush().await;
+    });
+
+    let server = common::serve(SlowService::new(Duration::ZERO)).await;
+    let error = call_through(through_proxy(&server, proxy))
+        .await
+        .expect_err("the proxy should have refused the tunnel");
+
+    let rendered = error_chain(error.as_ref());
+    assert!(
+        !rendered.contains("requires authentication"),
+        "hyper-util now recognises an HTTP/1.0 407 too: delete this tripwire and update the \
+         README's Known issues section. Got: {rendered}"
+    );
+    assert!(
+        rendered.contains("did not open the tunnel"),
+        "unexpected error: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn known_issue_a_portless_http_target_is_dialled_on_443_not_80() {
+    // `Tunnel::call` defaults to 443 unconditionally when the target carries no port, regardless of
+    // scheme, rather than the scheme deciding between 80 and 443. ArmoniK deployments always name a
+    // port, so this is unlikely to bite in practice; still worth a tripwire.
+    //
+    // This listener records the `CONNECT` authority and closes without ever trying to reach it: the
+    // recorded target, not a connection, is what the test asserts on.
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind proxy");
+    let proxy = listener.local_addr().expect("proxy address");
+    let requested_target = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let captured = std::sync::Arc::clone(&requested_target);
+    tokio::spawn(async move {
+        let Ok((mut client, _)) = listener.accept().await else {
+            return;
+        };
+        let Ok(head) = common::read_head(&mut client).await else {
+            return;
+        };
+        *captured.lock().expect("lock") = Some(common::request_target(&head));
+        // No response: the client only needs to have sent the request to be observed here, and this
+        // address would never answer regardless.
+    });
+
+    // Not a real server, and not dialled: 192.0.2.0/24 is reserved for documentation by RFC 5737,
+    // so it needs no resolver.
+    let _ = call_through(through_proxy("http://192.0.2.1", proxy)).await;
+
+    assert_eq!(
+        requested_target.lock().expect("lock").as_deref(),
+        Some("192.0.2.1:443"),
+        "if this now reads :80, hyper-util has fixed its default: delete this tripwire and update \
+         the README's Known issues section"
+    );
+}


### PR DESCRIPTION
# Motivation

`hyper_util`'s `Tunnel`, which the proxy connector drives, gets four cases wrong in 0.1.20. A
release that fixes one should turn CI red rather than let the fix pass unnoticed, so the README's
"Known issues" section stays honest.

# Description

Three tripwire tests in `tests/upstream_tunnel.rs` assert that a known upstream defect is still
there: only an exact 200 opens the tunnel where RFC 9110 says any 2xx, an `HTTP/1.0 407` is not
recognised as a request for credentials, and a portless target is dialled on 443 whatever its
scheme. Each failure message says what to do when it fires. The fourth defect, a status line split
across reads being rejected, is documented in the README only: pinning it needs timing assumptions
that make a test flaky on a loaded runner.

The `CONNECT` proxy fixture moves to `tests/common`, shared between the main suite and the
tripwires rather than written twice.

# Testing

Adds 4 tests: the three tripwires and the control proving the fixture lets an ordinary 200
through. `cargo test -p armonik-transport --all-features` passes at this branch's head; the run
is in the commit message.

# Impact

A `hyper-util` version bump can turn CI red by design; the failure message names the tripwire and
the README section to update. No production code is touched.

# Additional Information

Stacks on `wk/feat/rust-proxy-config`; merge that first. The series works without this PR: reject
it alone if pinning upstream defects in the suite is unwanted.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI. (locally yes; CI runs on this PR)
- [x] I have assessed the performance impact of my modifications.
