### PR TITLE
feat(rust): follow the environment's proxy settings by default

### DIFF
--- a/packages/rust/Cargo.lock
+++ b/packages/rust/Cargo.lock
@@ -522,13 +522,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -559,6 +562,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "itertools"

--- a/packages/rust/armonik-transport/Cargo.toml
+++ b/packages/rust/armonik-transport/Cargo.toml
@@ -23,9 +23,12 @@ hyper = { workspace = true, features = ["client", "http1", "http2"] }
 # `client-legacy` for `HttpConnector` and for the `Tunnel` connector that performs the `CONNECT`
 # handshake; `tokio` for `TokioIo` and the runtime side of both. Each is named here even though
 # `hyper-rustls` happens to turn it on: depending on that would break the day it stops.
+# `client-proxy` for the proxy matcher: the `*_PROXY` convention, `NO_PROXY` on curl's rules, and
+# taking credentials out of a proxy URL, none of which is worth writing again here.
 hyper-util = { workspace = true, features = [
   "client",
   "client-legacy",
+  "client-proxy",
   "http1",
   "tokio",
 ] }

--- a/packages/rust/armonik-transport/README.md
+++ b/packages/rust/armonik-transport/README.md
@@ -9,9 +9,13 @@ wants the services as well needs only that one.
 
 ## Reaching the endpoint through a proxy
 
-`ClientConfig::proxy` decides how the connection goes out: directly, the default, or through the
-proxy `ProxyConfig::explicit(uri)` names. `with_credentials` authenticates to it, half by half: a
-half left empty keeps what the proxy URL itself carried.
+`ClientConfig::proxy` decides how the connection goes out. The default is `ProxySource::System`, the
+same as ArmoniK's C# client: `ALL_PROXY`/`HTTPS_PROXY`/`HTTP_PROXY` are honoured and `NO_PROXY` is
+matched the way curl matches it, so a client that configures nothing follows its environment and
+connects directly when the environment names no proxy. `ProxyConfig::disabled()` forces a direct
+connection; `ProxyConfig::explicit(uri)` names a proxy, which is then used whatever `NO_PROXY` says.
+`with_credentials` authenticates to it, half by half: a half left empty keeps what the proxy URL
+itself carried.
 
 The connection is an HTTP `CONNECT` tunnel: TLS, mutual TLS included, is negotiated end to end with
 the real server, and the proxy only forwards opaque bytes. Because the `CONNECT` handshake itself goes

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -44,7 +44,7 @@ pub struct ClientConfig {
     pub http2_max_header_list_size: Option<u32>,
     /// User-Agent header value sent with each request
     pub user_agent: Option<HeaderValue>,
-    /// HTTP proxy used to reach the endpoint, defaults to a direct connection
+    /// HTTP proxy used to reach the endpoint, defaults to following the environment
     pub proxy: ProxyConfig,
 }
 

--- a/packages/rust/armonik-transport/src/proxy.rs
+++ b/packages/rust/armonik-transport/src/proxy.rs
@@ -14,6 +14,7 @@ use hyper::http::uri::Scheme;
 use hyper::http::HeaderValue;
 use hyper::Uri;
 use hyper_util::client::legacy::connect::proxy::Tunnel;
+use hyper_util::client::proxy::matcher::Matcher;
 use hyper_util::rt::TokioIo;
 use secrecy::{ExposeSecret, SecretString};
 use snafu::{IntoError, Snafu};
@@ -32,12 +33,19 @@ const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
 #[derive(Clone, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ProxySource {
-    /// Connect directly.
+    /// Read the proxy from the environment, on `hyper_util`'s rules: `ALL_PROXY`, `HTTPS_PROXY`,
+    /// `HTTP_PROXY` and `NO_PROXY`, in either case, with `NO_PROXY` matched as curl matches it.
     ///
-    /// The default: a client that asks for nothing connects directly.
+    /// The default, as it is for ArmoniK's C# client: a client that asks for nothing follows the
+    /// environment, and connects directly when the environment names no proxy.
+    ///
+    /// Read once, when `connect` builds the channel, so one that reconnects keeps the values it
+    /// started with.
     #[default]
+    System,
+    /// Connect directly, ignoring any proxy configured in the environment.
     Disabled,
-    /// Use this specific proxy.
+    /// Use this specific proxy, whatever the environment says: `NO_PROXY` does not apply to it.
     Explicit(Uri),
 }
 
@@ -47,6 +55,7 @@ impl std::fmt::Debug for ProxySource {
     /// is redacted here rather than trusted to have been stripped.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::System => f.write_str("System"),
             Self::Disabled => f.write_str("Disabled"),
             Self::Explicit(uri) => f
                 .debug_tuple("Explicit")
@@ -121,9 +130,17 @@ impl ProxyConfig {
         }
     }
 
-    /// Connect directly.
-    pub fn disabled() -> Self {
+    /// Read the proxy from the environment.
+    pub fn system() -> Self {
         Self::default()
+    }
+
+    /// Connect directly, ignoring any proxy configured in the environment.
+    pub fn disabled() -> Self {
+        Self {
+            source: ProxySource::Disabled,
+            ..Self::default()
+        }
     }
 
     /// Attach credentials for proxy authentication.
@@ -147,26 +164,49 @@ impl ProxyConfig {
         self
     }
 
-    /// The route every connection through this configuration takes.
+    /// The route every connection takes when it does not depend on the target: everything but
+    /// `System`, which reads the environment per connection and answers `None` here.
     ///
     /// Resolved from the fields as they are, not as a constructor left them: an `Explicit` URI is
     /// stripped of any userinfo even when it bypassed [`ProxyConfig::explicit`], so a password
     /// never reaches a log line or an error display through the URI.
-    pub(crate) fn fixed_route(&self) -> RouteResult {
+    pub(crate) fn fixed_route(&self) -> Option<RouteResult> {
         match &self.source {
-            ProxySource::Disabled => Ok(None),
+            ProxySource::System => None,
+            ProxySource::Disabled => Some(Ok(None)),
             // Straight through, whatever the target looks like: the caller named this proxy, so
             // failing to reach it has to be an error rather than a quiet direct connection.
             ProxySource::Explicit(uri) => {
                 let (uri, credentials) = split_credentials(uri.clone());
                 let (username, password) = credentials.unwrap_or_default();
-                match uri {
-                    Ok(uri) => self.finish_route(uri, username, password),
+                Some(match uri {
+                    Ok(uri) => self.finish_route(uri, username, password, None),
                     // No sanitized form exists, and the original must not come back: it is the
                     // one URI that still holds the password.
                     Err(elided) => Err(elided),
-                }
+                })
             }
+        }
+    }
+
+    /// The route to `target` when the environment decides, `Ok(None)` for a direct connection.
+    fn env_route(&self, matcher: &Matcher, target: &Uri) -> RouteResult {
+        let Some(intercept) = matcher.intercept(target) else {
+            return Ok(None);
+        };
+        // The matcher takes credentials out of the proxy URL itself; anything it left behind (a
+        // malformed URL with several `@`) is stripped here so it never renders.
+        let (uri, _leftovers) = split_credentials(intercept.uri().clone());
+        match uri {
+            Ok(uri) => self.finish_route(
+                uri,
+                String::new(),
+                String::new(),
+                intercept.basic_auth().cloned(),
+            ),
+            // No sanitized form exists, and the original must not come back: it is the one URI
+            // that still holds the password.
+            Err(elided) => Err(elided),
         }
     }
 
@@ -177,17 +217,32 @@ impl ProxyConfig {
         proxy_uri: Uri,
         url_username: String,
         url_password: String,
+        ready_auth: Option<HeaderValue>,
     ) -> RouteResult {
         if proxy_uri.scheme() != Some(&Scheme::HTTP) {
             return Err(proxy_uri);
         }
 
-        // A dedicated half wins; the other half falls back to the URL's, so setting only the
-        // password keeps the username the URL carried.
-        let username = prefer_dedicated(&self.username, &url_username);
-        let password = prefer_dedicated(self.password.expose_secret(), &url_password);
-        let auth = (!username.is_empty() || !password.is_empty())
-            .then(|| basic_auth_header(username, password));
+        let auth = if self.username.is_empty() && self.password.expose_secret().is_empty() {
+            // Nothing to merge: what the URL carried is used as is. For `system` that is the
+            // header the matcher already built, sensitive flag included.
+            match ready_auth {
+                Some(header) => Some(header),
+                None if url_username.is_empty() && url_password.is_empty() => None,
+                None => Some(basic_auth_header(&url_username, &url_password)),
+            }
+        } else {
+            // A dedicated half wins; the other half falls back to the URL's, so setting only the
+            // password keeps the username the URL carried. `Basic` forbids `:` in the username
+            // (RFC 7617), which is what makes decoding the matcher's header unambiguous.
+            let (url_username, url_password) = match ready_auth.as_ref() {
+                Some(header) => decode_basic_auth(header),
+                None => (url_username, url_password),
+            };
+            let username = prefer_dedicated(&self.username, &url_username);
+            let password = prefer_dedicated(self.password.expose_secret(), &url_password);
+            Some(basic_auth_header(username, password))
+        };
 
         Ok(Some((proxy_uri, auth)))
     }
@@ -207,6 +262,7 @@ pub(crate) type RouteResult = Result<Option<(Uri, Option<HeaderValue>)>, Uri>;
 #[derive(Debug, Clone)]
 pub struct ProxyConnector<S> {
     inner: S,
+    proxy: ProxyConfig,
     prepared: Prepared,
     /// Upper bound on the tunnel handshake alone; the dial to the proxy is the inner connector's,
     /// bounded by its own connect timeout.
@@ -226,6 +282,10 @@ enum Prepared {
     },
     /// Refuse every connection: this proxy's scheme cannot carry the cleartext handshake.
     Unsupported(Uri),
+    /// Resolve per connection: the environment's rules, read once here so a channel that
+    /// reconnects keeps the values it started with. Behind an `Arc` because a `tower` connector is
+    /// cloned per connection and `Matcher` is not `Clone`.
+    PerCall(std::sync::Arc<Matcher>),
 }
 
 impl<S> ProxyConnector<S> {
@@ -236,12 +296,14 @@ impl<S> ProxyConnector<S> {
     /// accepts the connection and then goes quiet from hanging the client.
     pub(crate) fn new(inner: S, proxy: ProxyConfig, connect_timeout: Option<Duration>) -> Self {
         let prepared = match proxy.fixed_route() {
-            Ok(None) => Prepared::Direct,
-            Ok(Some((uri, auth))) => Prepared::Via { proxy: uri, auth },
-            Err(unsupported) => Prepared::Unsupported(unsupported),
+            None => Prepared::PerCall(std::sync::Arc::new(Matcher::from_env())),
+            Some(Ok(None)) => Prepared::Direct,
+            Some(Ok(Some((uri, auth)))) => Prepared::Via { proxy: uri, auth },
+            Some(Err(unsupported)) => Prepared::Unsupported(unsupported),
         };
         Self {
             inner,
+            proxy,
             prepared,
             handshake_timeout: connect_timeout.unwrap_or(DEFAULT_HANDSHAKE_TIMEOUT),
         }
@@ -264,20 +326,24 @@ where
     }
 
     fn call(&mut self, target: Uri) -> Self::Future {
-        let (proxy_uri, auth) = match &self.prepared {
-            // Nothing to tunnel through: keep the original behaviour untouched.
-            Prepared::Direct => {
-                let future = self.inner.call(target);
-                return Box::pin(async move { future.await.map_err(Into::into) });
-            }
-            Prepared::Via { proxy, auth } => (proxy.clone(), auth.clone()),
-            Prepared::Unsupported(proxy) => {
-                let error = UnsupportedProxySnafu {
-                    proxy: proxy.clone(),
-                }
-                .build();
+        let route = match &self.prepared {
+            Prepared::Direct => Ok(None),
+            Prepared::Via { proxy, auth } => Ok(Some((proxy.clone(), auth.clone()))),
+            Prepared::Unsupported(proxy) => Err(proxy.clone()),
+            Prepared::PerCall(matcher) => self.proxy.env_route(matcher, &target),
+        };
+        let route = match route {
+            Ok(route) => route,
+            Err(proxy) => {
+                let error = UnsupportedProxySnafu { proxy }.build();
                 return Box::pin(std::future::ready(Err(error.into())));
             }
+        };
+
+        // Nothing to tunnel through: keep the original behaviour untouched.
+        let Some((proxy_uri, auth)) = route else {
+            let future = self.inner.call(target);
+            return Box::pin(async move { future.await.map_err(Into::into) });
         };
 
         // Dial the proxy with the inner connector, so a failure to reach it is classified by
@@ -440,6 +506,28 @@ fn basic_auth_header(username: &str, password: &str) -> HeaderValue {
     value
 }
 
+/// The username and password a `Basic` `Proxy-Authorization` value carries.
+///
+/// The inverse of [`basic_auth_header`], needed only when a dedicated credential half has to merge
+/// with what a proxy URL carried. The split is at the first `:`, which RFC 7617 makes unambiguous
+/// by forbidding `:` in the username. Malformed input, which `hyper_util` itself never produces,
+/// decodes as an empty pair rather than panicking: worst case a proxy that needed credentials
+/// rejects the tunnel, which is what an absent value already does.
+fn decode_basic_auth(value: &HeaderValue) -> (String, String) {
+    let encoded = value
+        .to_str()
+        .unwrap_or_default()
+        .trim_start_matches("Basic ");
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .unwrap_or_default();
+    let decoded = String::from_utf8_lossy(&decoded).into_owned();
+    match decoded.split_once(':') {
+        Some((user, password)) => (user.to_owned(), password.to_owned()),
+        None => (decoded, String::new()),
+    }
+}
+
 /// Prefer `dedicated` unless it is empty, in which case fall back to `from_url`.
 ///
 /// A dedicated username or password set alone must not discard the other half of whatever the
@@ -510,9 +598,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn the_default_is_a_direct_connection() {
-        assert_eq!(ProxySource::default(), ProxySource::Disabled);
-        assert_eq!(ProxyConfig::default().source, ProxySource::Disabled);
+    fn the_default_source_follows_the_environment() {
+        // The same default as ArmoniK's C# client: unset means the environment decides.
+        assert_eq!(ProxySource::default(), ProxySource::System);
+        assert_eq!(ProxyConfig::default().source, ProxySource::System);
     }
 
     #[test]
@@ -669,7 +758,12 @@ mod tests {
 
     #[test]
     fn disabled_routes_directly() {
-        assert_eq!(ProxyConfig::disabled().fixed_route(), Ok(None));
+        assert_eq!(ProxyConfig::disabled().fixed_route(), Some(Ok(None)));
+    }
+
+    #[test]
+    fn system_resolves_per_connection_rather_than_at_construction() {
+        assert_eq!(ProxyConfig::system().fixed_route(), None);
     }
 
     #[test]
@@ -687,6 +781,7 @@ mod tests {
 
         let (uri, auth) = config
             .fixed_route()
+            .expect("a source fixed at construction")
             .expect("routing should succeed")
             .expect("an explicit proxy routes through it");
 
@@ -702,7 +797,7 @@ mod tests {
 
         assert_eq!(
             config.fixed_route(),
-            Err(uri),
+            Some(Err(uri)),
             "the route should carry the refused proxy back"
         );
     }
@@ -732,6 +827,7 @@ mod tests {
             );
             let refused = config
                 .fixed_route()
+                .expect("a source fixed at construction")
                 .expect_err("nothing sane to route through");
             assert!(!refused.to_string().contains("s3cr3t"), "leaked: {refused}");
         }
@@ -742,6 +838,7 @@ mod tests {
         let config = ProxyConfig::explicit(Uri::try_from("http://proxy.corp:3128").expect("uri"));
         let (_, auth) = config
             .fixed_route()
+            .expect("a source fixed at construction")
             .expect("routing should succeed")
             .expect("an explicit proxy routes through it");
         assert_eq!(auth, None);

--- a/packages/rust/armonik-transport/tests/common/mod.rs
+++ b/packages/rust/armonik-transport/tests/common/mod.rs
@@ -208,6 +208,10 @@ pub fn config(
     args.endpoint = endpoint.to_owned();
     args.allow_unsafe_connection = true;
     set(&mut args);
-    armonik_transport::ClientConfig::from_config_args(args)
-        .expect("the configuration should be valid")
+    let mut config = armonik_transport::ClientConfig::from_config_args(args)
+        .expect("the configuration should be valid");
+    // The default follows the machine's environment; a test has to opt back in deliberately, or a
+    // developer's own HTTP_PROXY would route these loopback calls somewhere real.
+    config.proxy = armonik_transport::ProxyConfig::disabled();
+    config
 }

--- a/packages/rust/armonik-transport/tests/proxy.rs
+++ b/packages/rust/armonik-transport/tests/proxy.rs
@@ -281,19 +281,76 @@ async fn no_proxy_is_used_when_proxying_is_disabled() {
 // --- what the environment decides, through the real connector ---
 //
 // `hyper_util`'s matcher does the reading; these pin how this crate maps its configuration onto it,
-// which is ours to get right. They set process-wide variables, hence `serial`.
+// which is ours to get right. They set process-wide variables, hence `serial`; and the host may
+// already export proxy variables of its own, hence [`ProxyEnvironment`].
+
+/// Every variable `Matcher::from_env` reads, in both spellings.
+const PROXY_VARIABLES: [&str; 8] = [
+    "HTTP_PROXY",
+    "http_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+    "NO_PROXY",
+    "no_proxy",
+];
+
+/// The proxy-related environment, cleared for the duration of a test.
+///
+/// `serial` keeps these tests from racing each other, but does nothing about what the host already
+/// exports: a runner with `NO_PROXY=127.0.0.1` would bypass the proxy a test just configured. The
+/// guard saves and clears [`PROXY_VARIABLES`] on creation and restores them on drop - also when the
+/// test panics, so one failure cannot contaminate the next.
+struct ProxyEnvironment {
+    saved: Vec<(&'static str, Option<std::ffi::OsString>)>,
+}
+
+impl ProxyEnvironment {
+    fn cleared() -> Self {
+        let saved = PROXY_VARIABLES
+            .iter()
+            .map(|&name| {
+                let value = std::env::var_os(name);
+                std::env::remove_var(name);
+                (name, value)
+            })
+            .collect();
+        Self { saved }
+    }
+
+    /// Set a variable the guard restores on drop.
+    fn set(&self, name: &str, value: impl AsRef<std::ffi::OsStr>) {
+        assert!(
+            PROXY_VARIABLES.contains(&name),
+            "`{name}` is not a variable this guard restores"
+        );
+        std::env::set_var(name, value);
+    }
+}
+
+impl Drop for ProxyEnvironment {
+    fn drop(&mut self) {
+        for (name, value) in self.saved.drain(..) {
+            match value {
+                Some(value) => std::env::set_var(name, value),
+                None => std::env::remove_var(name),
+            }
+        }
+    }
+}
 
 #[tokio::test]
 #[serial_test::serial(env)]
 async fn system_mode_takes_the_proxy_from_the_environment() {
+    let environment = ProxyEnvironment::cleared();
     let server = spawn_server().await;
     let (proxy, tunnels) = spawn_proxy(ProxyAuth::None).await;
 
     // The variable has to still be set when `connect` runs, not merely when the configuration is
     // built: `system` resolves the environment as the connection is made.
-    std::env::set_var("HTTP_PROXY", format!("http://{proxy}"));
+    environment.set("HTTP_PROXY", format!("http://{proxy}"));
     let outcome = call_through(following_the_environment(&server)).await;
-    std::env::remove_var("HTTP_PROXY");
 
     assert_eq!(
         outcome.expect("the call should go through the proxy the environment names"),
@@ -305,14 +362,13 @@ async fn system_mode_takes_the_proxy_from_the_environment() {
 #[tokio::test]
 #[serial_test::serial(env)]
 async fn no_proxy_bypasses_the_proxy_in_system_mode() {
+    let environment = ProxyEnvironment::cleared();
     let server = spawn_server().await;
     let (proxy, tunnels) = spawn_proxy(ProxyAuth::None).await;
 
-    std::env::set_var("HTTP_PROXY", format!("http://{proxy}"));
-    std::env::set_var("NO_PROXY", "127.0.0.1");
+    environment.set("HTTP_PROXY", format!("http://{proxy}"));
+    environment.set("NO_PROXY", "127.0.0.1");
     let outcome = call_through(following_the_environment(&server)).await;
-    std::env::remove_var("HTTP_PROXY");
-    std::env::remove_var("NO_PROXY");
 
     assert_eq!(outcome.expect("a direct call succeeds"), common::REPLY);
     assert_eq!(
@@ -325,15 +381,15 @@ async fn no_proxy_bypasses_the_proxy_in_system_mode() {
 #[tokio::test]
 #[serial_test::serial(env)]
 async fn no_proxy_does_not_apply_to_an_explicitly_configured_proxy() {
+    let environment = ProxyEnvironment::cleared();
     let server = spawn_server().await;
     let (proxy, tunnels) = spawn_proxy(ProxyAuth::None).await;
 
     // `NO_PROXY` belongs to the same environment convention as `HTTP_PROXY`, so it governs `system`
     // only. ArmoniK's other clients give an explicitly named proxy an empty bypass list, and diverging
     // would mean a request skipping the proxy here while using it there.
-    std::env::set_var("NO_PROXY", "127.0.0.1");
+    environment.set("NO_PROXY", "127.0.0.1");
     let outcome = call_through(through_proxy(&server, proxy, None)).await;
-    std::env::remove_var("NO_PROXY");
 
     assert_eq!(
         outcome.expect("an explicit proxy is used whatever NO_PROXY says"),
@@ -348,15 +404,15 @@ async fn a_dedicated_credential_in_system_mode_keeps_the_other_half_the_url_carr
     // A dedicated half alone must not discard the other half of whatever the intercepted proxy
     // URL carried: setting only the password while `HTTP_PROXY` names a username must still send
     // that username, paired with the new password, not an empty one.
+    let environment = ProxyEnvironment::cleared();
     let server = spawn_server().await;
     // The base64 of `url-user:new`, what the client is expected to send once the two are merged.
     let (proxy, tunnels) = spawn_proxy(ProxyAuth::Required("dXJsLXVzZXI6bmV3")).await;
 
-    std::env::set_var("HTTP_PROXY", format!("http://url-user:old@{proxy}"));
+    environment.set("HTTP_PROXY", format!("http://url-user:old@{proxy}"));
     let mut config = direct(&server);
     config.proxy = ProxyConfig::system().with_credentials("", "new");
     let outcome = call_through(config).await;
-    std::env::remove_var("HTTP_PROXY");
 
     assert_eq!(
         outcome.expect("the merged credentials should satisfy the proxy"),
@@ -374,11 +430,11 @@ async fn a_dedicated_credential_in_system_mode_keeps_the_other_half_the_url_carr
 async fn an_https_proxy_from_the_environment_is_refused_before_dialling() {
     // `system` resolves at connect time, so that is the only place its scheme can be checked. Dialling
     // it would write the handshake in the clear to a proxy expecting TLS.
+    let environment = ProxyEnvironment::cleared();
     let server = spawn_server().await;
 
-    std::env::set_var("HTTP_PROXY", "https://proxy.corp:3128");
+    environment.set("HTTP_PROXY", "https://proxy.corp:3128");
     let outcome = call_through(following_the_environment(&server)).await;
-    std::env::remove_var("HTTP_PROXY");
 
     let error = error_chain(
         outcome

--- a/packages/rust/armonik-transport/tests/proxy.rs
+++ b/packages/rust/armonik-transport/tests/proxy.rs
@@ -112,6 +112,13 @@ fn direct(endpoint: &str) -> ClientConfig {
     common::config(endpoint, |_| {})
 }
 
+/// The same client, following the environment.
+fn following_the_environment(endpoint: &str) -> ClientConfig {
+    let mut config = common::config(endpoint, |_| {});
+    config.proxy = ProxyConfig::system();
+    config
+}
+
 /// Connect and make one call, returning what the server answered.
 async fn call_through(config: ClientConfig) -> Result<bytes::Bytes, Box<dyn std::error::Error>> {
     let channel = armonik_transport::connect(config).await?;
@@ -269,6 +276,116 @@ async fn no_proxy_is_used_when_proxying_is_disabled() {
         "the proxy must not be involved when it is disabled"
     );
     let _ = proxy;
+}
+
+// --- what the environment decides, through the real connector ---
+//
+// `hyper_util`'s matcher does the reading; these pin how this crate maps its configuration onto it,
+// which is ours to get right. They set process-wide variables, hence `serial`.
+
+#[tokio::test]
+#[serial_test::serial(env)]
+async fn system_mode_takes_the_proxy_from_the_environment() {
+    let server = spawn_server().await;
+    let (proxy, tunnels) = spawn_proxy(ProxyAuth::None).await;
+
+    // The variable has to still be set when `connect` runs, not merely when the configuration is
+    // built: `system` resolves the environment as the connection is made.
+    std::env::set_var("HTTP_PROXY", format!("http://{proxy}"));
+    let outcome = call_through(following_the_environment(&server)).await;
+    std::env::remove_var("HTTP_PROXY");
+
+    assert_eq!(
+        outcome.expect("the call should go through the proxy the environment names"),
+        common::REPLY
+    );
+    assert_eq!(tunnels.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+#[serial_test::serial(env)]
+async fn no_proxy_bypasses_the_proxy_in_system_mode() {
+    let server = spawn_server().await;
+    let (proxy, tunnels) = spawn_proxy(ProxyAuth::None).await;
+
+    std::env::set_var("HTTP_PROXY", format!("http://{proxy}"));
+    std::env::set_var("NO_PROXY", "127.0.0.1");
+    let outcome = call_through(following_the_environment(&server)).await;
+    std::env::remove_var("HTTP_PROXY");
+    std::env::remove_var("NO_PROXY");
+
+    assert_eq!(outcome.expect("a direct call succeeds"), common::REPLY);
+    assert_eq!(
+        tunnels.load(Ordering::SeqCst),
+        0,
+        "NO_PROXY named the target, so the proxy must not have been used"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(env)]
+async fn no_proxy_does_not_apply_to_an_explicitly_configured_proxy() {
+    let server = spawn_server().await;
+    let (proxy, tunnels) = spawn_proxy(ProxyAuth::None).await;
+
+    // `NO_PROXY` belongs to the same environment convention as `HTTP_PROXY`, so it governs `system`
+    // only. ArmoniK's other clients give an explicitly named proxy an empty bypass list, and diverging
+    // would mean a request skipping the proxy here while using it there.
+    std::env::set_var("NO_PROXY", "127.0.0.1");
+    let outcome = call_through(through_proxy(&server, proxy, None)).await;
+    std::env::remove_var("NO_PROXY");
+
+    assert_eq!(
+        outcome.expect("an explicit proxy is used whatever NO_PROXY says"),
+        common::REPLY
+    );
+    assert_eq!(tunnels.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+#[serial_test::serial(env)]
+async fn a_dedicated_credential_in_system_mode_keeps_the_other_half_the_url_carried() {
+    // A dedicated half alone must not discard the other half of whatever the intercepted proxy
+    // URL carried: setting only the password while `HTTP_PROXY` names a username must still send
+    // that username, paired with the new password, not an empty one.
+    let server = spawn_server().await;
+    // The base64 of `url-user:new`, what the client is expected to send once the two are merged.
+    let (proxy, tunnels) = spawn_proxy(ProxyAuth::Required("dXJsLXVzZXI6bmV3")).await;
+
+    std::env::set_var("HTTP_PROXY", format!("http://url-user:old@{proxy}"));
+    let mut config = direct(&server);
+    config.proxy = ProxyConfig::system().with_credentials("", "new");
+    let outcome = call_through(config).await;
+    std::env::remove_var("HTTP_PROXY");
+
+    assert_eq!(
+        outcome.expect("the merged credentials should satisfy the proxy"),
+        common::REPLY
+    );
+    assert_eq!(
+        tunnels.load(Ordering::SeqCst),
+        1,
+        "a rejection means the URL's username was dropped instead of kept"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(env)]
+async fn an_https_proxy_from_the_environment_is_refused_before_dialling() {
+    // `system` resolves at connect time, so that is the only place its scheme can be checked. Dialling
+    // it would write the handshake in the clear to a proxy expecting TLS.
+    let server = spawn_server().await;
+
+    std::env::set_var("HTTP_PROXY", "https://proxy.corp:3128");
+    let outcome = call_through(following_the_environment(&server)).await;
+    std::env::remove_var("HTTP_PROXY");
+
+    let error = error_chain(
+        outcome
+            .expect_err("an https proxy cannot be reached")
+            .as_ref(),
+    );
+    assert!(error.contains("only an `http` proxy"), "{error}");
 }
 
 // --- the handshake is bounded in time ---


### PR DESCRIPTION
# Motivation

ArmoniK's C# client, left unconfigured, follows the environment: `HTTPS_PROXY` set in the pod
means the proxy is used. The Rust client always connects directly, so the same deployment routes
oppositely depending on the language.

# Description

`ProxySource::System` reads `ALL_PROXY`/`HTTPS_PROXY`/`HTTP_PROXY` and matches `NO_PROXY` the way
curl does, through `hyper_util`'s matcher behind its `client-proxy` feature. The environment is
resolved as each connection is made, with the rules read once when the channel is built, so a
channel that reconnects keeps the values it started with. Credentials the intercepted URL carries
are used as the matcher prepared them; a dedicated half merges in field by field. An explicitly
named proxy stays exempt: `NO_PROXY` governs system mode alone.

`System` becomes the default. That behaviour change is the point of this PR, and it is separated
from the machinery so it can be judged on its own.

# Testing

`cargo test -p armonik-transport --all-features`: 56 passed, of which 5 set `HTTP_PROXY`/`NO_PROXY`
for real (serialized) and drive the connector through them. The run is in the commit message.

# Impact

Behaviour change: a Rust client that configures nothing now honours `*_PROXY` and `NO_PROXY` from
its environment, as the C# client does, instead of always connecting directly.
`ProxyConfig::disabled()` restores the old behaviour explicitly, and the test helpers pin it so
loopback tests stay hermetic on a developer machine with a proxy configured. `hyper-util` gains
the `client-proxy` feature, which brings `ipnet`.

# Additional Information

Stacks on `wk/feat/rust-proxy-connector`; merge that first.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI. (locally yes; CI runs on this PR)
- [x] I have assessed the performance impact of my modifications.
