### PR TITLE
feat(rust): read the client identity from a PKCS#12 bundle

### DIFF
--- a/packages/rust/Cargo.lock
+++ b/packages/rust/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,7 +99,9 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "p12-keystore",
  "percent-encoding",
+ "rcgen",
  "rustls",
  "schemars 1.2.2",
  "secrecy",
@@ -73,10 +110,50 @@ dependencies = [
  "serde_with",
  "serial_test",
  "snafu",
+ "tempfile",
  "tokio",
  "tonic",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -183,10 +260,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
 
 [[package]]
 name = "bs58"
@@ -216,6 +326,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +351,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +372,41 @@ dependencies = [
  "serde",
  "windows-link",
 ]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "cms"
+version = "0.3.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758d5272932ff167e96ec9641a04d96ab1901cccc5ea9f47c15b4cbaa6f9ea53"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -260,12 +425,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "des"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "ctutils",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -336,6 +619,12 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "fnv"
@@ -457,8 +746,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
 ]
 
 [[package]]
@@ -514,6 +813,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +871,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -705,6 +1022,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +1130,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +1153,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,10 +1172,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -841,6 +1203,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -854,6 +1225,29 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "p12-keystore"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02686a966a6d270eb3e87178c70323a30a62741e59b37e542ff029fb774afa47"
+dependencies = [
+ "cbc",
+ "cms",
+ "der",
+ "des",
+ "hex",
+ "hmac",
+ "pkcs12",
+ "pkcs5",
+ "pkcs8",
+ "rand",
+ "rc2",
+ "sha1",
+ "sha2",
+ "thiserror",
+ "x509-parser",
+]
 
 [[package]]
 name = "parking_lot"
@@ -879,6 +1273,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "pear"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +1303,25 @@ dependencies = [
  "proc-macro2-diagnostics",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -943,6 +1366,58 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs12"
+version = "0.2.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8059bd79345d1d1c125656025814704bab5cdd204b1cefd5fab59b0fdd7476d2"
+dependencies = [
+ "cms",
+ "const-oid",
+ "der",
+ "digest",
+ "spki",
+ "x509-cert",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d440a804ec8d6fafbb6b84471e013286658d373248927692ab3366686220ca"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "scrypt",
+ "sha2",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
+dependencies = [
+ "cpubits",
+ "cpufeatures",
+ "universal-hash",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1071,6 +1546,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rc2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceda21af1ae61033b63175653a1af86cae399d79cd03ca80ba347eb3a6c4a7fe"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,6 +1658,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,6 +1733,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "salsa20"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
+dependencies = [
+ "cfg-if",
+ "cipher",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,6 +1793,18 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
+dependencies = [
+ "cfg-if",
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "secrecy"
@@ -1398,6 +1944,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +2024,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,6 +2068,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,6 +2089,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1795,6 +2404,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +2435,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common",
+ "ctutils",
+]
 
 [[package]]
 name = "untrusted"
@@ -2187,10 +2812,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-cert"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
+]
 
 [[package]]
 name = "zeroize"

--- a/packages/rust/Cargo.toml
+++ b/packages/rust/Cargo.toml
@@ -31,9 +31,11 @@ humantime = "2.3.0"
 hyper = "1.10"
 hyper-rustls = { version = "0.27", default-features = false }
 hyper-util = "0.1"
+p12-keystore = "0.3"
 percent-encoding = "2.3"
 prost = "0.14"
 prost-types = "0.14"
+rcgen = "0.14"
 rustls = { version = "0.23", default-features = false }
 schemars = "1"
 secrecy = "0.10"
@@ -44,6 +46,7 @@ serde_json = "1"
 serde_with = { version = "3", default-features = false }
 serial_test = "3.5"
 snafu = "0.9"
+tempfile = "3"
 tokio = { version = "1.52", default-features = false }
 tokio-util = "0.7"
 tonic = { version = "0.14", default-features = false }

--- a/packages/rust/armonik-transport/Cargo.toml
+++ b/packages/rust/armonik-transport/Cargo.toml
@@ -86,7 +86,8 @@ serial_test.workspace = true
 serde_json.workspace = true
 # A real file for the PKCS#12 tests to read: a generated bundle, or garbage that is not one.
 tempfile.workspace = true
-# A self-signed certificate and key, generated fresh in the PKCS#12 tests rather than committed.
+# Certificates and keys, self-signed or CA-signed, generated fresh in the PKCS#12 and PEM chain
+# tests rather than committed.
 rcgen.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 # The integration tests serve a gRPC service to call, which the regular build never does; these features

--- a/packages/rust/armonik-transport/Cargo.toml
+++ b/packages/rust/armonik-transport/Cargo.toml
@@ -52,6 +52,9 @@ hyper-rustls = { workspace = true, features = [
   "logging",
 ] }
 rustls = { workspace = true, features = ["ring", "logging", "std", "tls12"] }
+# Reads a client certificate bundled with its key as a PKCS#12 file, the form Windows and most
+# certificate authorities hand out; pure Rust, so it pulls in no OpenSSL of its own.
+p12-keystore.workspace = true
 serde = { workspace = true, optional = true }
 # `with_prefix!`, for a group of options whose flat names already share a literal prefix (`Tcp*`,
 # `Http2*`): it composes with `#[serde(flatten)]` to read the same names as before the grouping,
@@ -81,6 +84,10 @@ serial_test.workspace = true
 # The unit tests build configurations the way a caller does under the `serde` feature: from a JSON
 # document naming the flat options.
 serde_json.workspace = true
+# A real file for the PKCS#12 tests to read: a generated bundle, or garbage that is not one.
+tempfile.workspace = true
+# A self-signed certificate and key, generated fresh in the PKCS#12 tests rather than committed.
+rcgen.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 # The integration tests serve a gRPC service to call, which the regular build never does; these features
 # union with the `channel`/`codegen` above for test builds only.

--- a/packages/rust/armonik-transport/README.md
+++ b/packages/rust/armonik-transport/README.md
@@ -20,6 +20,24 @@ pinned by a test: [`http_config.flat.schema.json`](schema/http_config.flat.schem
 option vocabulary for generating an options class, and
 [`http_config.schema.json`](schema/http_config.schema.json) is the config's real, structured shape.
 
+## TLS and mutual TLS
+
+`CaCert` authenticates the server; `CertPem` and `KeyPem` together are the client's own identity
+for mutual TLS, and must be either both set or both empty. All three name files this crate reads
+when the connection is made, so a configuration can be built on one machine and used on another.
+
+`CertP12` is an alternative to `CertPem`/`KeyPem`: the client's certificate and key bundled
+together in one PKCS#12 file, the form Windows and most certificate authorities hand out,
+optionally protected by `CertP12Password`. Mutually exclusive with `CertPem`/`KeyPem` - set one
+identity or the other, never both. ArmoniK's C# client reads the same `CertP12` option, but has no
+`CertP12Password` counterpart yet, so a password-protected bundle is not portable to it.
+
+`CertP12Password` is a secret, redacted by `Debug`; the other options are not secrets themselves,
+only what they lead to is. `AllowUnsafeConnection` accepts any server certificate instead of
+verifying it, for a self-signed endpoint; it has no effect on a plain `http://` endpoint, which
+never negotiates TLS at all. `OverrideTargetName` overrides the name checked during verification,
+for an endpoint reached by an address that does not match its certificate.
+
 ## Reaching the endpoint through a proxy
 
 `HttpConfig::proxy` decides how the connection goes out. The default is `ProxySource::System`, the

--- a/packages/rust/armonik-transport/schema/http_config.flat.schema.json
+++ b/packages/rust/armonik-transport/schema/http_config.flat.schema.json
@@ -17,7 +17,7 @@
       ]
     },
     "CertP12": {
-      "description": "Path to the client certificate and key bundled together, in PKCS#12 format; mutually\nexclusive with `CertPem`/`KeyPem`.",
+      "description": "Path to the client certificate and key bundled together, in PKCS#12 format, any\nintermediates kept leaf first; mutually exclusive with `CertPem`/`KeyPem`.",
       "type": [
         "string",
         "null"
@@ -31,7 +31,7 @@
       ]
     },
     "CertPem": {
-      "description": "Path to the client certificate file, in PEM format; set together with `KeyPem`.",
+      "description": "Path to the client certificate file, in PEM format, the leaf first and any chain\nafter it; set together with `KeyPem`.",
       "type": [
         "string",
         "null"

--- a/packages/rust/armonik-transport/schema/http_config.flat.schema.json
+++ b/packages/rust/armonik-transport/schema/http_config.flat.schema.json
@@ -16,6 +16,20 @@
         "null"
       ]
     },
+    "CertP12": {
+      "description": "Path to the client certificate and key bundled together, in PKCS#12 format; mutually\nexclusive with `CertPem`/`KeyPem`.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "CertP12Password": {
+      "description": "Password protecting `CertP12`, empty for none; meaningless, and rejected, without\n`CertP12`.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "CertPem": {
       "description": "Path to the client certificate file, in PEM format; set together with `KeyPem`.",
       "type": [

--- a/packages/rust/armonik-transport/schema/http_config.schema.json
+++ b/packages/rust/armonik-transport/schema/http_config.schema.json
@@ -63,6 +63,35 @@
             "PemFiles"
           ],
           "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "A certificate and its key bundled together in one PKCS#12 file.",
+          "properties": {
+            "Pkcs12": {
+              "properties": {
+                "CertP12": {
+                  "description": "Path to the PKCS#12 bundle.",
+                  "type": "string"
+                },
+                "CertP12Password": {
+                  "description": "The password protecting the bundle, absent for none.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "CertP12"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Pkcs12"
+          ],
+          "type": "object"
         }
       ]
     },

--- a/packages/rust/armonik-transport/schema/http_config.schema.json
+++ b/packages/rust/armonik-transport/schema/http_config.schema.json
@@ -44,7 +44,7 @@
             "PemFiles": {
               "properties": {
                 "CertPem": {
-                  "description": "Path to the certificate file, in PEM format.",
+                  "description": "Path to the certificate file, in PEM format, the leaf first and any chain after\nit.",
                   "type": "string"
                 },
                 "KeyPem": {
@@ -71,7 +71,7 @@
             "Pkcs12": {
               "properties": {
                 "CertP12": {
-                  "description": "Path to the PKCS#12 bundle.",
+                  "description": "Path to the PKCS#12 bundle. Any intermediates it carries are kept, leaf first.",
                   "type": "string"
                 },
                 "CertP12Password": {

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -156,7 +156,7 @@ pub(crate) fn text<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<
     deserializer.deserialize_any(AnyScalar)
 }
 
-/// [`text`], for the one secret-valued option this crate reads.
+/// [`text`], for the secret-valued options this crate reads.
 ///
 /// A numeric-looking password may arrive as a real number the same way any other option can, and
 /// rejecting it would make some passwords unusable.
@@ -360,6 +360,24 @@ pub enum ConfigError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+    #[snafu(display("`CertP12`'s file `{path}` is not a valid PKCS#12 bundle [{location}]"))]
+    #[non_exhaustive]
+    Pkcs12 {
+        #[snafu(source(from(p12_keystore::error::Error, Box::new)))]
+        source: Box<p12_keystore::error::Error>,
+        path: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display(
+        "`CertP12`'s file `{path}` carries no private key and certificate chain [{location}]"
+    ))]
+    #[non_exhaustive]
+    EmptyPkcs12 {
+        path: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
     #[snafu(display("{msg} [{location}]"))]
     #[non_exhaustive]
     IncompatibleOptions {
@@ -395,6 +413,12 @@ mod schema {
         cert_pem: Option<String>,
         /// Path to the client key file, in PEM format; set together with `CertPem`.
         key_pem: Option<String>,
+        /// Path to the client certificate and key bundled together, in PKCS#12 format; mutually
+        /// exclusive with `CertPem`/`KeyPem`.
+        cert_p12: Option<String>,
+        /// Password protecting `CertP12`, empty for none; meaningless, and rejected, without
+        /// `CertP12`.
+        cert_p12_password: Option<String>,
         /// Path to the Certificate Authority file, in PEM format; empty for the system CAs.
         ca_cert: Option<String>,
         /// Accept any server certificate instead of verifying it: `1`, `true`, `yes`, `enable`,
@@ -514,6 +538,14 @@ mod schema {
             cert_pem: String,
             /// Path to the key file, in PEM format.
             key_pem: String,
+        },
+        /// A certificate and its key bundled together in one PKCS#12 file.
+        #[schemars(rename_all = "PascalCase")]
+        Pkcs12 {
+            /// Path to the PKCS#12 bundle.
+            cert_p12: String,
+            /// The password protecting the bundle, absent for none.
+            cert_p12_password: Option<String>,
         },
     }
 
@@ -917,6 +949,67 @@ mod tests {
                 key_pem: "no/such/key.pem".into(),
             })
         );
+    }
+
+    #[test]
+    fn cert_p12_and_the_pem_pair_are_mutually_exclusive() {
+        // Two spellings of the identity at once is a contradiction whichever half of the PEM pair
+        // is set, and the message has to name both spellings so either one can be removed.
+        for (cert, key) in [("cert.pem", "key.pem"), ("cert.pem", ""), ("", "key.pem")] {
+            let rendered = error(json!({
+                "Endpoint": "http://localhost:5001",
+                "CertPem": cert,
+                "KeyPem": key,
+                "CertP12": "identity.p12",
+            }));
+
+            assert!(rendered.contains("CertP12"), "{rendered}");
+            assert!(rendered.contains("CertPem"), "{rendered}");
+        }
+    }
+
+    #[test]
+    fn a_p12_password_without_a_p12_is_rejected_without_echoing_it() {
+        let rendered = error(json!({
+            "Endpoint": "http://localhost:5001",
+            "CertP12Password": "s3cr3t",
+        }));
+
+        assert!(rendered.contains("CertP12Password"), "{rendered}");
+        assert!(rendered.contains("CertP12"), "{rendered}");
+        assert!(!rendered.contains("s3cr3t"), "{rendered}");
+    }
+
+    #[test]
+    fn empty_p12_options_read_as_unset() {
+        // Including the password: an empty password next to no bundle is not "a password without
+        // a bundle", it is the shape a deployment with empty defaults declares.
+        let config = config(json!({
+            "Endpoint": "http://localhost:5001",
+            "CertP12": "",
+            "CertP12Password": "",
+        }));
+
+        assert!(config.tls.identity.is_none());
+    }
+
+    #[test]
+    fn a_p12_option_names_a_path_without_reading_it() {
+        let config = config(json!({
+            "Endpoint": "http://localhost:5001",
+            "CertP12": "no/such/identity.p12",
+            "CertP12Password": "s3cr3t",
+        }));
+
+        assert_eq!(
+            config.tls.identity,
+            Some(IdentitySource::Pkcs12 {
+                cert_p12: "no/such/identity.p12".into(),
+                cert_p12_password: Some(secrecy::SecretString::from("s3cr3t")),
+            })
+        );
+        let rendered = format!("{:?}", config.tls);
+        assert!(!rendered.contains("s3cr3t"), "{rendered}");
     }
 
     // --- the proxy ---

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -409,12 +409,13 @@ mod schema {
     struct HttpConfigSchema {
         /// Endpoint for sending requests.
         endpoint: Option<String>,
-        /// Path to the client certificate file, in PEM format; set together with `KeyPem`.
+        /// Path to the client certificate file, in PEM format, the leaf first and any chain
+        /// after it; set together with `KeyPem`.
         cert_pem: Option<String>,
         /// Path to the client key file, in PEM format; set together with `CertPem`.
         key_pem: Option<String>,
-        /// Path to the client certificate and key bundled together, in PKCS#12 format; mutually
-        /// exclusive with `CertPem`/`KeyPem`.
+        /// Path to the client certificate and key bundled together, in PKCS#12 format, any
+        /// intermediates kept leaf first; mutually exclusive with `CertPem`/`KeyPem`.
         cert_p12: Option<String>,
         /// Password protecting `CertP12`, empty for none; meaningless, and rejected, without
         /// `CertP12`.
@@ -534,7 +535,8 @@ mod schema {
         /// A certificate and its key, each in its own PEM file.
         #[schemars(rename_all = "PascalCase")]
         PemFiles {
-            /// Path to the certificate file, in PEM format.
+            /// Path to the certificate file, in PEM format, the leaf first and any chain after
+            /// it.
             cert_pem: String,
             /// Path to the key file, in PEM format.
             key_pem: String,
@@ -542,7 +544,7 @@ mod schema {
         /// A certificate and its key bundled together in one PKCS#12 file.
         #[schemars(rename_all = "PascalCase")]
         Pkcs12 {
-            /// Path to the PKCS#12 bundle.
+            /// Path to the PKCS#12 bundle. Any intermediates it carries are kept, leaf first.
             cert_p12: String,
             /// The password protecting the bundle, absent for none.
             cert_p12_password: Option<String>,

--- a/packages/rust/armonik-transport/src/connect.rs
+++ b/packages/rust/armonik-transport/src/connect.rs
@@ -133,10 +133,11 @@ fn build_connector(
     };
 
     // Configure client identity for mTLS
-    let tls_config = if let Some((cert, key)) = tls.identity {
-        // Use the the specified client certificate and key for the client authentication
+    let tls_config = if let Some((certs, key)) = tls.identity {
+        // The client's whole chain, leaf first, so a server that trusts only the root can build
+        // its path through the intermediates.
         tls_config
-            .with_client_auth_cert(vec![cert], key)
+            .with_client_auth_cert(certs, key)
             .with_context(|_| TlsSnafu {
                 endpoint: endpoint.clone(),
             })?

--- a/packages/rust/armonik-transport/src/tls_config.rs
+++ b/packages/rust/armonik-transport/src/tls_config.rs
@@ -29,7 +29,8 @@ use crate::config::{
 pub enum IdentitySource {
     /// A certificate and its key, each in its own PEM file.
     PemFiles {
-        /// Path to the certificate file, in PEM format. `CertPem`.
+        /// Path to the certificate file, in PEM format: the leaf first, then any intermediates,
+        /// as PEM chains are conventionally laid out. `CertPem`.
         cert_pem: PathBuf,
         /// Path to the key file, in PEM format. `KeyPem`.
         key_pem: PathBuf,
@@ -37,7 +38,8 @@ pub enum IdentitySource {
     /// A certificate and its key bundled together in one PKCS#12 file, the form Windows and most
     /// certificate authorities hand out.
     Pkcs12 {
-        /// Path to the PKCS#12 bundle. `CertP12`.
+        /// Path to the PKCS#12 bundle. Any intermediates it carries are kept, leaf first.
+        /// `CertP12`.
         cert_p12: PathBuf,
         /// The password protecting the bundle, `None` for none. `CertP12Password`. Redacted by
         /// `Debug` and zeroized on drop.
@@ -216,7 +218,9 @@ impl TryFrom<RawTls> for TlsConfig {
 #[derive(Debug)]
 pub(crate) struct ResolvedTls {
     pub(crate) allow_unsafe_connection: bool,
-    pub(crate) identity: Option<(CertificateDer<'static>, PrivateKeyDer<'static>)>,
+    /// The client's certificate chain, leaf first, and its key. The whole chain is kept: a server
+    /// that trusts only the root needs the intermediates to build its path.
+    pub(crate) identity: Option<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)>,
     pub(crate) cacert: Option<CertificateDer<'static>>,
     pub(crate) override_target: Option<Uri>,
 }
@@ -246,8 +250,21 @@ impl TlsConfig {
                 let key = std::fs::read(key_pem).context(IoSnafu {
                     path: key_pem.display().to_string(),
                 })?;
+                // Every certificate in the file, not just the first: a PEM file conventionally
+                // carries the leaf followed by its intermediates, and dropping those breaks
+                // against a server that trusts only the root. A file with none is still an error.
+                let certs = CertificateDer::pem_slice_iter(cert.as_bytes())
+                    .collect::<Result<Vec<_>, _>>()
+                    .and_then(|certs| {
+                        if certs.is_empty() {
+                            Err(rustls::pki_types::pem::Error::NoItemsFound)
+                        } else {
+                            Ok(certs)
+                        }
+                    })
+                    .context(TlsSnafu {})?;
                 Some((
-                    CertificateDer::from_pem_slice(cert.as_bytes()).context(TlsSnafu {})?,
+                    certs,
                     PrivateKeyDer::from_pem_slice(key.as_slice()).context(TlsSnafu {})?,
                 ))
             }
@@ -270,19 +287,18 @@ impl TlsConfig {
                 let (_, chain) = keystore
                     .private_key_chain()
                     .context(EmptyPkcs12Snafu { path: path.clone() })?;
-                let cert = chain
+                // The whole chain, in the leaf-first order `p12-keystore` rebuilds it in (the
+                // certificate the key names, then each issuer upward), which is the order rustls
+                // sends it in; under the `Strict` import policy the chain carries at least that
+                // leaf. Re-encoded into the same DER shapes the PEM pair produces, so everything
+                // past this point sees one identity format.
+                let certs: Vec<CertificateDer<'static>> = chain
                     .certs()
-                    .first()
-                    .context(EmptyPkcs12Snafu { path })?
-                    .as_der()
-                    .to_vec();
+                    .iter()
+                    .map(|cert| CertificateDer::from(cert.as_der().to_vec()))
+                    .collect();
                 let key = chain.key().as_der().to_vec();
-                // Re-encoded into the same DER shapes the PEM pair produces, so everything past
-                // this point sees one identity format.
-                Some((
-                    CertificateDer::from(cert),
-                    PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key)),
-                ))
+                Some((certs, PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key))))
             }
         };
 
@@ -431,6 +447,29 @@ mod tests {
         (pfx, cert_der, key_der)
     }
 
+    /// A CA-signed identity, generated fresh like the self-signed one: the CA signs itself, and
+    /// the leaf is signed by it. The chain tests use it to assert that both certificates survive
+    /// the resolve, in order.
+    fn ca_signed_identity() -> (rcgen::Certificate, rcgen::KeyPair, rcgen::Certificate) {
+        let ca_key = rcgen::KeyPair::generate().expect("a CA key");
+        let mut ca_params = rcgen::CertificateParams::new(Vec::new()).expect("CA params");
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        ca_params
+            .distinguished_name
+            .push(rcgen::DnType::CommonName, "test ca");
+        let ca_cert = ca_params.self_signed(&ca_key).expect("a CA certificate");
+
+        let leaf_key = rcgen::KeyPair::generate().expect("a leaf key");
+        let leaf_params =
+            rcgen::CertificateParams::new(vec!["test".to_owned()]).expect("leaf params");
+        let issuer = rcgen::Issuer::new(ca_params, ca_key);
+        let leaf_cert = leaf_params
+            .signed_by(&leaf_key, &issuer)
+            .expect("a leaf certificate");
+
+        (leaf_cert, leaf_key, ca_cert)
+    }
+
     /// `bytes`, written to a file the test owns, so the option under test names a real path.
     fn temp_file(bytes: &[u8]) -> tempfile::NamedTempFile {
         let mut file = tempfile::NamedTempFile::new().expect("temp file");
@@ -458,8 +497,13 @@ mod tests {
             .resolve(&endpoint())
             .expect("a valid PKCS#12 bundle");
 
-        let (cert, key) = resolved.identity.expect("an identity was bundled");
-        assert_eq!(cert.as_ref(), cert_der, "the leaf certificate round-trips");
+        let (certs, key) = resolved.identity.expect("an identity was bundled");
+        assert_eq!(certs.len(), 1, "one certificate went in, one comes out");
+        assert_eq!(
+            certs[0].as_ref(),
+            cert_der,
+            "the leaf certificate round-trips"
+        );
         let PrivateKeyDer::Pkcs8(key) = key else {
             panic!("expected the PKCS#8 variant, since that is what the bundle carried");
         };
@@ -467,6 +511,41 @@ mod tests {
             key.secret_pkcs8_der(),
             key_der.as_slice(),
             "the key round-trips"
+        );
+    }
+
+    #[test]
+    fn a_p12_bundle_keeps_its_intermediates_leaf_first() {
+        // A server that trusts only the root rebuilds its path through the intermediates the
+        // client sends; a resolve that kept only the leaf would fail that handshake.
+        let (leaf, leaf_key, ca) = ca_signed_identity();
+        let chain = p12_keystore::PrivateKeyChain::new(
+            [1u8].as_slice(),
+            p12_keystore::PrivateKey::from_der(&leaf_key.serialize_der())
+                .expect("a valid PKCS#8 key"),
+            [
+                p12_keystore::Certificate::from_der(leaf.der().as_ref()).expect("a valid leaf"),
+                p12_keystore::Certificate::from_der(ca.der().as_ref()).expect("a valid CA"),
+            ],
+        );
+        let mut keystore = p12_keystore::KeyStore::new();
+        keystore.add_entry(
+            "identity",
+            p12_keystore::KeyStoreEntry::PrivateKeyChain(chain),
+        );
+        let pfx = keystore.writer("s3cr3t").write().expect("write the bundle");
+        let file = temp_file(&pfx);
+
+        let resolved = p12_config(file.path(), Some("s3cr3t"))
+            .resolve(&endpoint())
+            .expect("a valid PKCS#12 bundle");
+
+        let (certs, _) = resolved.identity.expect("an identity was bundled");
+        let ders: Vec<&[u8]> = certs.iter().map(AsRef::as_ref).collect();
+        assert_eq!(
+            ders,
+            vec![leaf.der().as_ref(), ca.der().as_ref()],
+            "the whole chain survives, leaf first"
         );
     }
 
@@ -552,6 +631,70 @@ mod tests {
             "{}",
             chain(&error)
         );
+    }
+
+    // --- PEM chains ---
+
+    /// A configuration whose identity is the PEM pair at `cert_pem`/`key_pem`.
+    fn pem_config(cert_pem: &std::path::Path, key_pem: &std::path::Path) -> TlsConfig {
+        TlsConfig {
+            identity: Some(IdentitySource::PemFiles {
+                cert_pem: cert_pem.to_path_buf(),
+                key_pem: key_pem.to_path_buf(),
+            }),
+            ..TlsConfig::default()
+        }
+    }
+
+    #[test]
+    fn a_single_certificate_pem_pair_resolves_to_a_one_certificate_chain() {
+        let rcgen::CertifiedKey { cert, signing_key } =
+            rcgen::generate_simple_self_signed(["test".to_owned()]).expect("a self-signed cert");
+        let cert_file = temp_file(cert.pem().as_bytes());
+        let key_file = temp_file(signing_key.serialize_pem().as_bytes());
+
+        let resolved = pem_config(cert_file.path(), key_file.path())
+            .resolve(&endpoint())
+            .expect("a valid PEM pair");
+
+        let (certs, _) = resolved.identity.expect("an identity was configured");
+        assert_eq!(certs.len(), 1, "one certificate went in, one comes out");
+        assert_eq!(certs[0].as_ref(), cert.der().as_ref());
+    }
+
+    #[test]
+    fn a_pem_file_carrying_a_chain_keeps_every_certificate_in_order() {
+        // The same defect the PKCS#12 chain test guards against, in the PEM spelling: the file
+        // conventionally holds the leaf followed by its intermediates.
+        let (leaf, leaf_key, ca) = ca_signed_identity();
+        let cert_file = temp_file(format!("{}{}", leaf.pem(), ca.pem()).as_bytes());
+        let key_file = temp_file(leaf_key.serialize_pem().as_bytes());
+
+        let resolved = pem_config(cert_file.path(), key_file.path())
+            .resolve(&endpoint())
+            .expect("a valid PEM chain");
+
+        let (certs, _) = resolved.identity.expect("an identity was configured");
+        let ders: Vec<&[u8]> = certs.iter().map(AsRef::as_ref).collect();
+        assert_eq!(
+            ders,
+            vec![leaf.der().as_ref(), ca.der().as_ref()],
+            "the whole chain survives, leaf first"
+        );
+    }
+
+    #[test]
+    fn a_certificate_file_with_no_certificate_is_rejected() {
+        // Reading the whole file instead of its first item must not turn emptiness into an empty
+        // chain that only fails at the handshake.
+        let cert_file = temp_file(b"");
+        let key_file = temp_file(b"");
+
+        let error = pem_config(cert_file.path(), key_file.path())
+            .resolve(&endpoint())
+            .expect_err("an empty certificate file must be rejected");
+
+        assert!(matches!(error, ConfigError::Tls { .. }), "{error:?}");
     }
 
     // --- override target ---

--- a/packages/rust/armonik-transport/src/tls_config.rs
+++ b/packages/rust/armonik-transport/src/tls_config.rs
@@ -13,15 +13,18 @@ use std::path::PathBuf;
 
 use hyper::Uri;
 use rustls::pki_types::pem::PemObject;
-use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use snafu::ResultExt;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use secrecy::ExposeSecret;
+use snafu::{OptionExt, ResultExt};
 
 #[cfg(feature = "serde")]
 use crate::config::IncompatibleOptionsSnafu;
-use crate::config::{ConfigError, HttpSnafu, IoSnafu, TlsSnafu, UriSnafu};
+use crate::config::{
+    ConfigError, EmptyPkcs12Snafu, HttpSnafu, IoSnafu, Pkcs12Snafu, TlsSnafu, UriSnafu,
+};
 
 /// Where the client's TLS identity comes from.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum IdentitySource {
     /// A certificate and its key, each in its own PEM file.
@@ -31,7 +34,50 @@ pub enum IdentitySource {
         /// Path to the key file, in PEM format. `KeyPem`.
         key_pem: PathBuf,
     },
+    /// A certificate and its key bundled together in one PKCS#12 file, the form Windows and most
+    /// certificate authorities hand out.
+    Pkcs12 {
+        /// Path to the PKCS#12 bundle. `CertP12`.
+        cert_p12: PathBuf,
+        /// The password protecting the bundle, `None` for none. `CertP12Password`. Redacted by
+        /// `Debug` and zeroized on drop.
+        cert_p12_password: Option<secrecy::SecretString>,
+    },
 }
+
+/// Not derived: [`secrecy::SecretString`] deliberately implements no `PartialEq`. What is compared
+/// here is two configurations, not a credential against a guess, so exposing the passwords for the
+/// comparison is fine.
+impl PartialEq for IdentitySource {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                Self::PemFiles { cert_pem, key_pem },
+                Self::PemFiles {
+                    cert_pem: other_cert_pem,
+                    key_pem: other_key_pem,
+                },
+            ) => cert_pem == other_cert_pem && key_pem == other_key_pem,
+            (
+                Self::Pkcs12 {
+                    cert_p12,
+                    cert_p12_password,
+                },
+                Self::Pkcs12 {
+                    cert_p12: other_cert_p12,
+                    cert_p12_password: other_password,
+                },
+            ) => {
+                cert_p12 == other_cert_p12
+                    && cert_p12_password.as_ref().map(ExposeSecret::expose_secret)
+                        == other_password.as_ref().map(ExposeSecret::expose_secret)
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for IdentitySource {}
 
 /// TLS and mTLS: the client's own identity, the server's CA, and SSL verification behaviour.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -70,6 +116,10 @@ struct RawTls {
     #[serde(deserialize_with = "crate::config::text")]
     key_pem: String,
     #[serde(deserialize_with = "crate::config::text")]
+    cert_p12: String,
+    #[serde(deserialize_with = "crate::config::secret_text")]
+    cert_p12_password: secrecy::SecretString,
+    #[serde(deserialize_with = "crate::config::text")]
     ca_cert: String,
     #[serde(deserialize_with = "crate::config::text")]
     allow_unsafe_connection: String,
@@ -85,26 +135,58 @@ impl TryFrom<RawTls> for TlsConfig {
         let RawTls {
             cert_pem,
             key_pem,
+            cert_p12,
+            cert_p12_password,
             ca_cert,
             allow_unsafe_connection,
             override_target_name,
         } = raw;
 
-        // Half an identity is silent on a plain-TLS endpoint and only surfaces as a rejected
-        // handshake on an mTLS one, so it is caught here, before either path is opened.
-        let identity = match (cert_pem.is_empty(), key_pem.is_empty()) {
-            (true, true) => None,
-            (false, false) => Some(IdentitySource::PemFiles {
-                cert_pem: PathBuf::from(cert_pem),
-                key_pem: PathBuf::from(key_pem),
-            }),
-            _ => {
-                return IncompatibleOptionsSnafu {
-                    msg: String::from(
-                        "`CertPem` and `KeyPem` must be either both empty or both set",
-                    ),
+        // Both spellings of the identity at once is a contradiction to reject, not a preference
+        // to resolve silently.
+        if !cert_p12.is_empty() && (!cert_pem.is_empty() || !key_pem.is_empty()) {
+            return IncompatibleOptionsSnafu {
+                msg: String::from(
+                    "`CertP12` and `CertPem`/`KeyPem` name the client identity two different \
+                     ways; set only one",
+                ),
+            }
+            .fail();
+        }
+        // A password naming no bundle is a typo somewhere; honouring half of it would hide it.
+        if cert_p12.is_empty() && !cert_p12_password.expose_secret().is_empty() {
+            return IncompatibleOptionsSnafu {
+                msg: String::from("`CertP12Password` is set without `CertP12`"),
+            }
+            .fail();
+        }
+
+        let identity = if !cert_p12.is_empty() {
+            Some(IdentitySource::Pkcs12 {
+                cert_p12: PathBuf::from(cert_p12),
+                cert_p12_password: if cert_p12_password.expose_secret().is_empty() {
+                    None
+                } else {
+                    Some(cert_p12_password)
+                },
+            })
+        } else {
+            // Half an identity is silent on a plain-TLS endpoint and only surfaces as a rejected
+            // handshake on an mTLS one, so it is caught here, before either path is opened.
+            match (cert_pem.is_empty(), key_pem.is_empty()) {
+                (true, true) => None,
+                (false, false) => Some(IdentitySource::PemFiles {
+                    cert_pem: PathBuf::from(cert_pem),
+                    key_pem: PathBuf::from(key_pem),
+                }),
+                _ => {
+                    return IncompatibleOptionsSnafu {
+                        msg: String::from(
+                            "`CertPem` and `KeyPem` must be either both empty or both set",
+                        ),
+                    }
+                    .fail()
                 }
-                .fail()
             }
         };
 
@@ -167,6 +249,39 @@ impl TlsConfig {
                 Some((
                     CertificateDer::from_pem_slice(cert.as_bytes()).context(TlsSnafu {})?,
                     PrivateKeyDer::from_pem_slice(key.as_slice()).context(TlsSnafu {})?,
+                ))
+            }
+            Some(IdentitySource::Pkcs12 {
+                cert_p12,
+                cert_p12_password,
+            }) => {
+                let path = cert_p12.display().to_string();
+                let data = std::fs::read(cert_p12).context(IoSnafu { path: path.clone() })?;
+                // An absent password opens an unprotected bundle the same way an empty one does.
+                let password = cert_p12_password
+                    .as_ref()
+                    .map_or("", ExposeSecret::expose_secret);
+                let keystore = p12_keystore::KeyStore::from_pkcs12(
+                    &data,
+                    password,
+                    p12_keystore::Pkcs12ImportPolicy::Strict,
+                )
+                .context(Pkcs12Snafu { path: path.clone() })?;
+                let (_, chain) = keystore
+                    .private_key_chain()
+                    .context(EmptyPkcs12Snafu { path: path.clone() })?;
+                let cert = chain
+                    .certs()
+                    .first()
+                    .context(EmptyPkcs12Snafu { path })?
+                    .as_der()
+                    .to_vec();
+                let key = chain.key().as_der().to_vec();
+                // Re-encoded into the same DER shapes the PEM pair produces, so everything past
+                // this point sees one identity format.
+                Some((
+                    CertificateDer::from(cert),
+                    PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key)),
                 ))
             }
         };
@@ -286,6 +401,154 @@ mod tests {
         assert!(matches!(error, ConfigError::Io { .. }), "{error:?}");
         assert!(
             chain(&error).contains("no/such/ca.pem"),
+            "{}",
+            chain(&error)
+        );
+    }
+
+    // --- PKCS#12 ---
+
+    /// A fresh self-signed identity written into PKCS#12 bytes with `p12-keystore`'s own writer,
+    /// generated rather than committed so no fixture can expire. Returns the bundle and the DER
+    /// forms the resolve is expected to hand back.
+    fn p12_bundle(password: &str) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        let rcgen::CertifiedKey { cert, signing_key } =
+            rcgen::generate_simple_self_signed(["test".to_owned()]).expect("a self-signed cert");
+        let cert_der = cert.der().to_vec();
+        let key_der = signing_key.serialize_der();
+
+        let chain = p12_keystore::PrivateKeyChain::new(
+            [1u8].as_slice(),
+            p12_keystore::PrivateKey::from_der(&key_der).expect("a valid PKCS#8 key"),
+            [p12_keystore::Certificate::from_der(&cert_der).expect("a valid X.509 certificate")],
+        );
+        let mut keystore = p12_keystore::KeyStore::new();
+        keystore.add_entry(
+            "identity",
+            p12_keystore::KeyStoreEntry::PrivateKeyChain(chain),
+        );
+        let pfx = keystore.writer(password).write().expect("write the bundle");
+        (pfx, cert_der, key_der)
+    }
+
+    /// `bytes`, written to a file the test owns, so the option under test names a real path.
+    fn temp_file(bytes: &[u8]) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().expect("temp file");
+        std::io::Write::write_all(&mut file, bytes).expect("write");
+        file
+    }
+
+    /// A configuration whose identity is the PKCS#12 bundle at `path`.
+    fn p12_config(path: &std::path::Path, password: Option<&str>) -> TlsConfig {
+        TlsConfig {
+            identity: Some(IdentitySource::Pkcs12 {
+                cert_p12: path.to_path_buf(),
+                cert_p12_password: password.map(secrecy::SecretString::from),
+            }),
+            ..TlsConfig::default()
+        }
+    }
+
+    #[test]
+    fn a_p12_bundle_is_read_into_the_same_identity_a_pem_pair_would_be() {
+        let (pfx, cert_der, key_der) = p12_bundle("s3cr3t");
+        let file = temp_file(&pfx);
+
+        let resolved = p12_config(file.path(), Some("s3cr3t"))
+            .resolve(&endpoint())
+            .expect("a valid PKCS#12 bundle");
+
+        let (cert, key) = resolved.identity.expect("an identity was bundled");
+        assert_eq!(cert.as_ref(), cert_der, "the leaf certificate round-trips");
+        let PrivateKeyDer::Pkcs8(key) = key else {
+            panic!("expected the PKCS#8 variant, since that is what the bundle carried");
+        };
+        assert_eq!(
+            key.secret_pkcs8_der(),
+            key_der.as_slice(),
+            "the key round-trips"
+        );
+    }
+
+    #[test]
+    fn no_password_opens_a_bundle_protected_by_the_empty_one() {
+        // The empty password is what an "unprotected" PKCS#12 bundle is actually written with, so
+        // an absent option has to open it.
+        let (pfx, _, _) = p12_bundle("");
+        let file = temp_file(&pfx);
+
+        let resolved = p12_config(file.path(), None)
+            .resolve(&endpoint())
+            .expect("an unprotected bundle needs no password");
+
+        assert!(resolved.identity.is_some());
+    }
+
+    #[test]
+    fn a_wrong_p12_password_is_reported_with_the_path() {
+        // The path, not the password: whoever reads the error must learn which file refused to
+        // open, and nothing about what was tried.
+        let (pfx, _, _) = p12_bundle("right");
+        let file = temp_file(&pfx);
+
+        let error = p12_config(file.path(), Some("wrong"))
+            .resolve(&endpoint())
+            .expect_err("the wrong password must be rejected");
+
+        assert!(matches!(error, ConfigError::Pkcs12 { .. }), "{error:?}");
+        let rendered = chain(&error);
+        assert!(
+            rendered.contains(&file.path().display().to_string()),
+            "{rendered}"
+        );
+        assert!(!rendered.contains("wrong"), "{rendered}");
+    }
+
+    #[test]
+    fn a_p12_bundle_with_no_identity_is_rejected_as_empty() {
+        // A bundle can be perfectly valid PKCS#12 and still carry no private key chain, which is
+        // its own story: nothing is malformed, there is just no identity inside.
+        let pfx = p12_keystore::KeyStore::new()
+            .writer("s3cr3t")
+            .write()
+            .expect("write the bundle");
+        let file = temp_file(&pfx);
+
+        let error = p12_config(file.path(), Some("s3cr3t"))
+            .resolve(&endpoint())
+            .expect_err("an identity-less bundle must be rejected");
+
+        assert!(
+            matches!(error, ConfigError::EmptyPkcs12 { .. }),
+            "{error:?}"
+        );
+        assert!(
+            chain(&error).contains(&file.path().display().to_string()),
+            "{}",
+            chain(&error)
+        );
+    }
+
+    #[test]
+    fn a_file_that_is_not_pkcs12_is_rejected_as_such() {
+        let file = temp_file(b"clearly not a pkcs12 bundle");
+
+        let error = p12_config(file.path(), None)
+            .resolve(&endpoint())
+            .expect_err("garbage is not a pkcs12 bundle");
+
+        assert!(matches!(error, ConfigError::Pkcs12 { .. }), "{error:?}");
+    }
+
+    #[test]
+    fn a_p12_path_that_does_not_exist_is_reported_with_the_path() {
+        let error = p12_config(std::path::Path::new("no/such/identity.p12"), None)
+            .resolve(&endpoint())
+            .expect_err("a missing file must be reported");
+
+        assert!(matches!(error, ConfigError::Io { .. }), "{error:?}");
+        assert!(
+            chain(&error).contains("no/such/identity.p12"),
             "{}",
             chain(&error)
         );

--- a/packages/rust/armonik-transport/tests/schema.rs
+++ b/packages/rust/armonik-transport/tests/schema.rs
@@ -47,6 +47,21 @@ fn the_committed_flat_schema_matches_the_generated_one() {
 }
 
 #[test]
+fn both_schemas_name_the_pkcs12_identity() {
+    // Coarser than the golden comparison on purpose: this one states the contract in words, so a
+    // regeneration that quietly dropped the PKCS#12 options would fail with a readable message
+    // rather than a full-schema diff.
+    let flat = serde_json::to_string(&schemars::schema_for!(armonik_transport::HttpConfig))
+        .expect("a schema serialises to JSON");
+    assert!(flat.contains("\"CertP12\""), "{flat}");
+    assert!(flat.contains("\"CertP12Password\""), "{flat}");
+
+    let structured = serde_json::to_string(&armonik_transport::HttpConfig::structured_schema())
+        .expect("a schema serialises to JSON");
+    assert!(structured.contains("\"Pkcs12\""), "{structured}");
+}
+
+#[test]
 fn the_committed_structured_schema_matches_the_generated_one() {
     // The config's own shape: nested thematic units, and the TLS identity as a `oneOf` of its
     // variants.


### PR DESCRIPTION
# Motivation

A client certificate often arrives as a PKCS12 bundle, the form Windows and most certificate
authorities hand out, and the C# client already accepts one through `CertP12`. The Rust client
only reads a PEM pair.

# Description

`IdentitySource` gains a `Pkcs12` variant: `CertP12` names the bundle, `CertP12Password` its
password, held in a `SecretString`. The bundle is read when the connection is made, like the PEM
files: `p12-keystore` under a strict import policy, the leaf of the private-key chain as the
identity, the key re-encoded to the same DER shapes the PEM pair yields. `CertP12` is mutually
exclusive with `CertPem`/`KeyPem`, and a password without a bundle is rejected; both rules fail
while the configuration is being read and name their options. Error messages name the path, never
the password.

Both committed JSON schemas grow accordingly: the flat one gains the two options, the structured
one's identity `oneOf` gains the variant.

# Testing

Adds 11 tests (the commit message says 12; it counts one case twice): the mutual-exclusion
combinations, the orphan password (not echoed), resolve-time round-trip against a bundle generated
in the test (rcgen + p12-keystore's writer, no committed fixture), wrong password naming the path,
empty and garbage bundles, and the schema-presence guard. `cargo test -p armonik-transport
--all-features` passes at this branch's head; the run is in the commit message with clean clippy,
fmt, and `cargo check -p armonik`.

# Impact

One new dependency, `p12-keystore` (pure Rust, no OpenSSL), plus `tempfile`/`rcgen` as
dev-dependencies for the generated fixture. Parity note: the C# client has `CertP12` but no
`CertP12Password` yet; bringing that option to C# is worth its own issue.

# Additional Information

Stacks on `wk/refactor/rust-http-config`; merge that first.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI. (locally yes; CI runs on this PR)
- [x] I have assessed the performance impact of my modifications.
