### PR TITLE
refactor(rust): rename ClientConfig to HttpConfig

### DIFF
--- a/packages/rust/armonik-transport/Cargo.toml
+++ b/packages/rust/armonik-transport/Cargo.toml
@@ -62,7 +62,7 @@ tower-service.workspace = true
 # The boolean options are read straight from the environment, so testing which spellings they accept
 # means setting variables: process-global state, hence one test at a time.
 serial_test.workspace = true
-# Only to round-trip `ClientConfigArgs` in the test that pins the `serde` feature.
+# Only to round-trip `HttpConfigArgs` in the test that pins the `serde` feature.
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 # The integration tests serve a gRPC service to call, which the regular build never does; these features

--- a/packages/rust/armonik-transport/README.md
+++ b/packages/rust/armonik-transport/README.md
@@ -9,7 +9,7 @@ wants the services as well needs only that one.
 
 ## Reaching the endpoint through a proxy
 
-`ClientConfig::proxy` decides how the connection goes out. The default is `ProxySource::System`, the
+`HttpConfig::proxy` decides how the connection goes out. The default is `ProxySource::System`, the
 same as ArmoniK's C# client: `ALL_PROXY`/`HTTPS_PROXY`/`HTTP_PROXY` are honoured and `NO_PROXY` is
 matched the way curl matches it, so a client that configures nothing follows its environment and
 connects directly when the environment names no proxy. `ProxyConfig::disabled()` forces a direct
@@ -52,7 +52,7 @@ first two upstream. All but the second are pinned by a tripwire in `tests/upstre
 The connection is an HTTP `CONNECT` tunnel: TLS, mutual TLS included, is negotiated end to end with
 the real server, and the proxy only forwards opaque bytes. Because the `CONNECT` handshake itself goes
 out in the clear, the proxy's own URL has to be `http`. The handshake is bounded by
-`ClientConfig::connect_timeout`, 30 seconds when none is set.
+`HttpConfig::connect_timeout`, 30 seconds when none is set.
 
 ## Publishing
 

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -10,7 +10,7 @@ use crate::proxy::{ProxyConfig, ProxySource};
 /// Options for creating a gRPC Client
 #[derive(Debug, Default)]
 #[non_exhaustive]
-pub struct ClientConfig {
+pub struct HttpConfig {
     /// Endpoint for sending requests
     pub endpoint: Uri,
     /// Allow unsafe connections to the endpoint (without SSL), defaults to false
@@ -49,7 +49,7 @@ pub struct ClientConfig {
     pub proxy: ProxyConfig,
 }
 
-impl Clone for ClientConfig {
+impl Clone for HttpConfig {
     fn clone(&self) -> Self {
         Self {
             endpoint: self.endpoint.clone(),
@@ -85,7 +85,7 @@ impl Clone for ClientConfig {
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[non_exhaustive]
-pub struct ClientConfigArgs {
+pub struct HttpConfigArgs {
     /// Endpoint for sending requests
     pub endpoint: String,
     /// Path to the certificate file in pem format
@@ -164,7 +164,7 @@ pub struct ClientConfigArgs {
     pub proxy_password: secrecy::SecretString,
 }
 
-impl ClientConfigArgs {
+impl HttpConfigArgs {
     pub fn from_env() -> Result<Self, ConfigError> {
         use crate::utils::{read_env, read_env_bool};
         let ctx = EnvSnafu {};
@@ -198,13 +198,13 @@ impl ClientConfigArgs {
     }
 }
 
-impl ClientConfig {
+impl HttpConfig {
     pub fn from_env() -> Result<Self, ConfigError> {
-        Self::from_config_args(ClientConfigArgs::from_env()?)
+        Self::from_config_args(HttpConfigArgs::from_env()?)
     }
-    pub fn from_config_args(args: ClientConfigArgs) -> Result<Self, ConfigError> {
+    pub fn from_config_args(args: HttpConfigArgs) -> Result<Self, ConfigError> {
         let _span = tracing::debug_span!(
-            "ClientConfig",
+            "HttpConfig",
             args.endpoint,
             args.cert_pem,
             args.key_pem,
@@ -230,7 +230,7 @@ impl ClientConfig {
             args.proxy_username,
         );
 
-        let ClientConfigArgs {
+        let HttpConfigArgs {
             endpoint,
             cert_pem: cert_path,
             key_pem: key_path,
@@ -564,10 +564,10 @@ fn parse_proxy_source(proxy: &str) -> Result<ProxyConfig, ConfigError> {
     Ok(config)
 }
 
-impl TryFrom<&ClientConfig> for tonic::transport::Endpoint {
+impl TryFrom<&HttpConfig> for tonic::transport::Endpoint {
     type Error = ConfigError;
 
-    fn try_from(value: &ClientConfig) -> Result<Self, Self::Error> {
+    fn try_from(value: &HttpConfig) -> Result<Self, Self::Error> {
         Ok(Self::from(value.endpoint.clone()))
     }
 }
@@ -667,8 +667,8 @@ mod tests {
     use super::*;
 
     /// The minimum viable arguments: an endpoint, and nothing else set.
-    fn args() -> ClientConfigArgs {
-        ClientConfigArgs {
+    fn args() -> HttpConfigArgs {
+        HttpConfigArgs {
             endpoint: String::from("http://localhost:5001"),
             ..Default::default()
         }
@@ -689,7 +689,7 @@ mod tests {
 
     #[test]
     fn the_minimum_is_an_endpoint() {
-        let config = ClientConfig::from_config_args(args()).expect("an endpoint is enough");
+        let config = HttpConfig::from_config_args(args()).expect("an endpoint is enough");
 
         assert_eq!(config.endpoint.to_string(), "http://localhost:5001/");
         assert!(config.identity.is_none());
@@ -700,7 +700,7 @@ mod tests {
 
     #[test]
     fn an_endpoint_that_is_not_a_uri_is_reported() {
-        let error = ClientConfig::from_config_args(ClientConfigArgs {
+        let error = HttpConfig::from_config_args(HttpConfigArgs {
             endpoint: String::new(),
             ..args()
         })
@@ -713,7 +713,7 @@ mod tests {
 
     #[test]
     fn durations_are_read_in_the_units_they_are_written_in() {
-        let config = ClientConfig::from_config_args(ClientConfigArgs {
+        let config = HttpConfig::from_config_args(HttpConfigArgs {
             connect_timeout: String::from("500ms"),
             tcp_keepalive: String::from("30s"),
             tcp_keepalive_interval: String::from("2m"),
@@ -736,7 +736,7 @@ mod tests {
 
     #[test]
     fn a_duration_that_cannot_be_parsed_names_the_value() {
-        let error = ClientConfig::from_config_args(ClientConfigArgs {
+        let error = HttpConfig::from_config_args(HttpConfigArgs {
             tcp_keepalive: String::from("soon"),
             ..args()
         })
@@ -751,7 +751,7 @@ mod tests {
 
     #[test]
     fn integers_are_read_and_a_bad_one_names_the_value() {
-        let config = ClientConfig::from_config_args(ClientConfigArgs {
+        let config = HttpConfig::from_config_args(HttpConfigArgs {
             tcp_keepalive_retries: String::from("3"),
             http2_max_header_list_size: String::from("16384"),
             ..args()
@@ -760,7 +760,7 @@ mod tests {
         assert_eq!(config.tcp_keepalive_retries, Some(3));
         assert_eq!(config.http2_max_header_list_size, Some(16384));
 
-        let error = ClientConfig::from_config_args(ClientConfigArgs {
+        let error = HttpConfig::from_config_args(HttpConfigArgs {
             tcp_keepalive_retries: String::from("many"),
             ..args()
         })
@@ -775,7 +775,7 @@ mod tests {
     #[test]
     fn an_integer_that_does_not_fit_is_rejected_rather_than_wrapped() {
         // These are `u32`; a value past the top must fail rather than silently become something else.
-        let error = ClientConfig::from_config_args(ClientConfigArgs {
+        let error = HttpConfig::from_config_args(HttpConfigArgs {
             http2_max_header_list_size: String::from("4294967296"),
             ..args()
         })
@@ -791,7 +791,7 @@ mod tests {
 
     #[test]
     fn a_rate_limit_is_a_count_and_a_duration() {
-        let config = ClientConfig::from_config_args(ClientConfigArgs {
+        let config = HttpConfig::from_config_args(HttpConfigArgs {
             rate_limit: String::from("100/1s"),
             ..args()
         })
@@ -805,7 +805,7 @@ mod tests {
         // `tower`'s `Rate::new` asserts both halves are above zero, so a zero has to be refused here
         // rather than reaching it: a panic inside `connect` tells the caller nothing.
         for value in ["0/1s", "1/0s", "0/0s"] {
-            let error = ClientConfig::from_config_args(ClientConfigArgs {
+            let error = HttpConfig::from_config_args(HttpConfigArgs {
                 rate_limit: String::from(value),
                 ..args()
             })
@@ -824,7 +824,7 @@ mod tests {
     fn a_rate_limit_missing_its_duration_is_reported_with_the_expected_shape() {
         // The message has to show the format, since `100` on its own looks perfectly reasonable to whoever
         // wrote it.
-        let error = ClientConfig::from_config_args(ClientConfigArgs {
+        let error = HttpConfig::from_config_args(HttpConfigArgs {
             rate_limit: String::from("100"),
             ..args()
         })
@@ -841,7 +841,7 @@ mod tests {
 
     #[test]
     fn each_half_of_a_rate_limit_is_validated_separately() {
-        let count = ClientConfig::from_config_args(ClientConfigArgs {
+        let count = HttpConfig::from_config_args(HttpConfigArgs {
             rate_limit: String::from("plenty/1s"),
             ..args()
         })
@@ -851,7 +851,7 @@ mod tests {
             "{count:?}"
         );
 
-        let duration = ClientConfig::from_config_args(ClientConfigArgs {
+        let duration = HttpConfig::from_config_args(HttpConfigArgs {
             rate_limit: String::from("100/soon"),
             ..args()
         })
@@ -869,7 +869,7 @@ mod tests {
         // Half an identity is silent on a plain-TLS endpoint and only surfaces as a rejected handshake
         // on an mTLS one. Neither path is read from disk before the check, so this needs no fixture.
         for (cert, key) in [("cert.pem", ""), ("", "key.pem")] {
-            let error = ClientConfig::from_config_args(ClientConfigArgs {
+            let error = HttpConfig::from_config_args(HttpConfigArgs {
                 cert_pem: String::from(cert),
                 key_pem: String::from(key),
                 ..args()
@@ -888,7 +888,7 @@ mod tests {
 
     #[test]
     fn neither_half_is_no_identity_rather_than_an_error() {
-        let config = ClientConfig::from_config_args(args()).expect("valid");
+        let config = HttpConfig::from_config_args(args()).expect("valid");
         assert!(config.identity.is_none());
     }
 
@@ -896,7 +896,7 @@ mod tests {
     fn a_certificate_path_that_does_not_exist_is_reported_with_the_path() {
         // These options are paths, not contents. A typo in one has to name the file rather than surface
         // later as a TLS failure.
-        let error = ClientConfig::from_config_args(ClientConfigArgs {
+        let error = HttpConfig::from_config_args(HttpConfigArgs {
             cert_pem: String::from("no/such/cert.pem"),
             key_pem: String::from("no/such/key.pem"),
             ..args()
@@ -913,7 +913,7 @@ mod tests {
 
     #[test]
     fn a_missing_ca_certificate_is_reported_with_the_path() {
-        let error = ClientConfig::from_config_args(ClientConfigArgs {
+        let error = HttpConfig::from_config_args(HttpConfigArgs {
             ca_cert: String::from("no/such/ca.pem"),
             ..args()
         })
@@ -933,7 +933,7 @@ mod tests {
     fn an_override_target_given_as_a_host_keeps_the_endpoints_scheme_and_path() {
         // The common case: the certificate names one host, the endpoint is reached at another. Only the
         // authority is being overridden, so everything else has to come from the endpoint.
-        let config = ClientConfig::from_config_args(ClientConfigArgs {
+        let config = HttpConfig::from_config_args(HttpConfigArgs {
             endpoint: String::from("https://10.0.0.1:5003/base"),
             override_target_name: String::from("server.example.com"),
             ..args()
@@ -951,7 +951,7 @@ mod tests {
 
     #[test]
     fn an_override_target_given_as_a_uri_replaces_the_authority_and_the_path() {
-        let config = ClientConfig::from_config_args(ClientConfigArgs {
+        let config = HttpConfig::from_config_args(HttpConfigArgs {
             endpoint: String::from("https://10.0.0.1:5003/base"),
             override_target_name: String::from("https://server.example.com/other"),
             ..args()
@@ -971,7 +971,7 @@ mod tests {
 
     #[test]
     fn no_override_target_leaves_it_unset() {
-        let config = ClientConfig::from_config_args(args()).expect("valid");
+        let config = HttpConfig::from_config_args(args()).expect("valid");
         assert_eq!(config.override_target, None);
     }
 
@@ -984,7 +984,7 @@ mod tests {
         // what it changes. The feature is off by default, so nothing else here would notice it breaking.
         // Deserialise only: the type deliberately has no `Serialize`, so a proxy password cannot leak
         // through a configuration dump.
-        let deserialised: ClientConfigArgs = serde_json::from_str(
+        let deserialised: HttpConfigArgs = serde_json::from_str(
             r#"{"endpoint":"http://localhost:5001","timeout":"30s","proxy_password":"s3cr3t"}"#,
         )
         .expect("absent fields should default");
@@ -999,17 +999,17 @@ mod tests {
     // --- the proxy ---
 
     /// The configuration `set` produces, expected to be valid.
-    fn proxy_config(set: impl FnOnce(&mut ClientConfigArgs)) -> ClientConfig {
+    fn proxy_config(set: impl FnOnce(&mut HttpConfigArgs)) -> HttpConfig {
         let mut arguments = args();
         set(&mut arguments);
-        ClientConfig::from_config_args(arguments).expect("a valid configuration")
+        HttpConfig::from_config_args(arguments).expect("a valid configuration")
     }
 
     /// The error message `set` produces, expected to be a rejection.
-    fn proxy_error(set: impl FnOnce(&mut ClientConfigArgs)) -> String {
+    fn proxy_error(set: impl FnOnce(&mut HttpConfigArgs)) -> String {
         let mut arguments = args();
         set(&mut arguments);
-        ClientConfig::from_config_args(arguments)
+        HttpConfig::from_config_args(arguments)
             .expect_err("the configuration should be rejected")
             .to_string()
     }
@@ -1089,7 +1089,7 @@ mod tests {
     fn the_arguments_keep_the_password_out_of_their_debug_output() {
         // These are what a caller inspects before handing them over, and what a panic message or a
         // log line would render.
-        let arguments = ClientConfigArgs {
+        let arguments = HttpConfigArgs {
             proxy: "http://user:url-secret@proxy.corp:3128".into(),
             proxy_password: "option-secret".into(),
             ..args()

--- a/packages/rust/armonik-transport/src/connect.rs
+++ b/packages/rust/armonik-transport/src/connect.rs
@@ -1,4 +1,4 @@
-//! Turning a [`ClientConfig`] into a connected `tonic` channel.
+//! Turning a [`HttpConfig`] into a connected `tonic` channel.
 //!
 //! TLS, mTLS, and every timeout, keepalive and identity setting come together here.
 
@@ -12,11 +12,11 @@ use snafu::{ResultExt, Snafu};
 
 use crate::config::ConfigError;
 use crate::proxy::ProxyConnector;
-use crate::ClientConfig;
+use crate::HttpConfig;
 
 /// Connect to the endpoint described by `config`, eagerly: this resolves once the connection is
 /// established, not lazily on the first request.
-pub async fn connect(config: ClientConfig) -> Result<tonic::transport::Channel, ConnectionError> {
+pub async fn connect(config: HttpConfig) -> Result<tonic::transport::Channel, ConnectionError> {
     let endpoint = config.endpoint.clone();
     let override_target = config.override_target.clone();
     let http2_keep_alive_interval = config.http2_keep_alive_interval;
@@ -72,7 +72,7 @@ pub async fn connect(config: ClientConfig) -> Result<tonic::transport::Channel, 
 /// rather than its own; `pub` only so the signature is expressible.
 #[doc(hidden)]
 pub async fn https_connector(
-    config: ClientConfig,
+    config: HttpConfig,
 ) -> Result<HttpsConnector<ProxyConnector<HttpConnector>>, ConnectionError> {
     let endpoint = config.endpoint;
 
@@ -150,7 +150,7 @@ pub async fn https_connector(
     Ok(https.enable_http1().enable_http2().wrap_connector(http))
 }
 
-/// Everything that can go wrong between a [`ClientConfig`] and a usable channel.
+/// Everything that can go wrong between a [`HttpConfig`] and a usable channel.
 #[derive(Debug, Snafu)]
 #[non_exhaustive]
 // snafu keeps its generated context selectors module-private by default. Public so that a caller in

--- a/packages/rust/armonik-transport/src/lib.rs
+++ b/packages/rust/armonik-transport/src/lib.rs
@@ -9,7 +9,7 @@ mod connect;
 mod proxy;
 mod utils;
 
-pub use config::{ClientConfig, ClientConfigArgs, ConfigError};
+pub use config::{ConfigError, HttpConfig, HttpConfigArgs};
 pub use connect::{connect, https_connector, ConnectionError};
 pub use proxy::{ProxyConfig, ProxyError, ProxySource};
 // The password's own type, so a caller can build a `ProxyConfig` without declaring a dependency on

--- a/packages/rust/armonik-transport/tests/common/mod.rs
+++ b/packages/rust/armonik-transport/tests/common/mod.rs
@@ -286,17 +286,17 @@ pub fn error_chain(error: &dyn std::error::Error) -> String {
     rendered.join(" -> ")
 }
 
-/// Build a [`ClientConfig`] from the string form, applying `set` to the arguments first.
+/// Build a [`HttpConfig`] from the string form, applying `set` to the arguments first.
 ///
-/// Going through `ClientConfigArgs` keeps the parsing inside what is under test. It is a helper at all
+/// Going through `HttpConfigArgs` keeps the parsing inside what is under test. It is a helper at all
 /// because both structs are `#[non_exhaustive]`: a test outside the crate cannot write either as a
 /// struct expression, and `..Default::default()` is the form that is forbidden.
 #[allow(clippy::field_reassign_with_default)]
 pub fn config(
     endpoint: &str,
-    set: impl FnOnce(&mut armonik_transport::ClientConfigArgs),
-) -> armonik_transport::ClientConfig {
-    let mut args = armonik_transport::ClientConfigArgs::default();
+    set: impl FnOnce(&mut armonik_transport::HttpConfigArgs),
+) -> armonik_transport::HttpConfig {
+    let mut args = armonik_transport::HttpConfigArgs::default();
     args.endpoint = endpoint.to_owned();
     args.allow_unsafe_connection = true;
     set(&mut args);
@@ -307,7 +307,7 @@ pub fn config(
         use armonik_transport::reexports::secrecy::ExposeSecret as _;
         args.proxy.expose_secret().is_empty()
     };
-    let mut config = armonik_transport::ClientConfig::from_config_args(args)
+    let mut config = armonik_transport::HttpConfig::from_config_args(args)
         .expect("the configuration should be valid");
     if follow_environment {
         config.proxy = armonik_transport::ProxyConfig::disabled();

--- a/packages/rust/armonik-transport/tests/proxy.rs
+++ b/packages/rust/armonik-transport/tests/proxy.rs
@@ -7,7 +7,7 @@ use std::net::SocketAddr;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
-use armonik_transport::{ClientConfig, ProxyConfig};
+use armonik_transport::{HttpConfig, ProxyConfig};
 use tokio::net::TcpListener;
 
 mod common;
@@ -29,7 +29,7 @@ fn through_proxy(
     endpoint: &str,
     proxy: SocketAddr,
     credentials: Option<(&str, &str)>,
-) -> ClientConfig {
+) -> HttpConfig {
     let mut config = common::config(endpoint, |_| {});
     let mut proxy = ProxyConfig::explicit(
         hyper::Uri::try_from(format!("http://{proxy}")).expect("a valid proxy URI"),
@@ -42,19 +42,19 @@ fn through_proxy(
 }
 
 /// A client that connects directly, whatever proxy the tests happen to be running.
-fn direct(endpoint: &str) -> ClientConfig {
+fn direct(endpoint: &str) -> HttpConfig {
     common::config(endpoint, |_| {})
 }
 
 /// The same client, following the environment.
-fn following_the_environment(endpoint: &str) -> ClientConfig {
+fn following_the_environment(endpoint: &str) -> HttpConfig {
     let mut config = common::config(endpoint, |_| {});
     config.proxy = ProxyConfig::system();
     config
 }
 
 /// Connect and make one call, returning what the server answered.
-async fn call_through(config: ClientConfig) -> Result<bytes::Bytes, Box<dyn std::error::Error>> {
+async fn call_through(config: HttpConfig) -> Result<bytes::Bytes, Box<dyn std::error::Error>> {
     let channel = armonik_transport::connect(config).await?;
     Ok(common::call(channel).await?)
 }
@@ -374,7 +374,7 @@ async fn an_https_proxy_from_the_environment_is_refused_before_dialling() {
 
 #[tokio::test]
 async fn the_proxy_options_reach_the_tunnel() {
-    // Through `ClientConfigArgs` on purpose, so the parsing is under test along with the
+    // Through `HttpConfigArgs` on purpose, so the parsing is under test along with the
     // tunnelling: accepting the options and then not proxying is the defect the whole feature
     // exists to fix.
     let server = spawn_server().await;

--- a/packages/rust/armonik-transport/tests/upstream_tunnel.rs
+++ b/packages/rust/armonik-transport/tests/upstream_tunnel.rs
@@ -8,7 +8,7 @@
 
 use std::time::Duration;
 
-use armonik_transport::{ClientConfig, ProxyConfig};
+use armonik_transport::{HttpConfig, ProxyConfig};
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
 
@@ -17,7 +17,7 @@ mod common;
 use common::{error_chain, ProxyAuth, SlowService};
 
 /// A client reaching `endpoint` through `proxy`.
-fn through_proxy(endpoint: &str, proxy: std::net::SocketAddr) -> ClientConfig {
+fn through_proxy(endpoint: &str, proxy: std::net::SocketAddr) -> HttpConfig {
     let mut config = common::config(endpoint, |_| {});
     config.proxy = ProxyConfig::explicit(
         hyper::Uri::try_from(format!("http://{proxy}")).expect("a valid proxy URI"),
@@ -26,7 +26,7 @@ fn through_proxy(endpoint: &str, proxy: std::net::SocketAddr) -> ClientConfig {
 }
 
 /// Connect and make one call, returning what the server answered.
-async fn call_through(config: ClientConfig) -> Result<bytes::Bytes, Box<dyn std::error::Error>> {
+async fn call_through(config: HttpConfig) -> Result<bytes::Bytes, Box<dyn std::error::Error>> {
     let channel = armonik_transport::connect(config).await?;
     Ok(common::call(channel).await?)
 }

--- a/packages/rust/armonik/src/client/mod.rs
+++ b/packages/rust/armonik/src/client/mod.rs
@@ -8,8 +8,8 @@ use snafu::{ResultExt, Snafu};
 use armonik_transport::ConfigSnafu;
 #[cfg(feature = "_gen-client")]
 pub use armonik_transport::{
-    ClientConfig, ClientConfigArgs, ConfigError, ConnectionError, ProxyConfig, ProxyError,
-    ProxySource, ReadEnvError, SecretString,
+    ConfigError, ConnectionError, HttpConfig, HttpConfigArgs, ProxyConfig, ProxyError, ProxySource,
+    ReadEnvError, SecretString,
 };
 
 #[cfg(feature = "worker")]
@@ -72,11 +72,11 @@ pub struct Client<T = tonic::transport::Channel> {
 impl Client<tonic::transport::Channel> {
     /// Create a new client using the configuration from the environment variables
     pub async fn new() -> Result<Self, ConnectionError> {
-        Self::with_config(ClientConfig::from_env().context(ConfigSnafu {})?).await
+        Self::with_config(HttpConfig::from_env().context(ConfigSnafu {})?).await
     }
 
     /// Create a new client with the specified client configuration
-    pub async fn with_config(config: ClientConfig) -> Result<Self, ConnectionError> {
+    pub async fn with_config(config: HttpConfig) -> Result<Self, ConnectionError> {
         let endpoint = config.endpoint.to_string();
         tracing_futures::Instrument::instrument(
             async move {
@@ -96,7 +96,7 @@ impl Client<tonic::transport::Channel> {
         use http_body_util::BodyExt;
         use hyper_util::rt::TokioExecutor;
 
-        let mut config = ClientConfig::from_env().unwrap();
+        let mut config = HttpConfig::from_env().unwrap();
 
         match std::env::var("Http__Endpoint") {
             Ok(value) if !value.is_empty() => {

--- a/packages/rust/armonik/src/lib.rs
+++ b/packages/rust/armonik/src/lib.rs
@@ -11,7 +11,7 @@ pub mod server;
 #[cfg(feature = "_gen-client")]
 pub use armonik_transport as transport;
 #[cfg(feature = "_gen-client")]
-pub use client::{Client, ClientConfig};
+pub use client::{Client, HttpConfig};
 pub use objects::*;
 
 mod utils;


### PR DESCRIPTION
# Motivation

`ClientConfig` configures the HTTP transport of a connection, not a client: the `armonik` crate's
`Client` is built on top of it, and the name kept suggesting the two were the same layer. The
rename is also isolated here on purpose, so the configuration re-work that follows reviews without
rename noise.

# Description

Purely mechanical: `ClientConfig` becomes `HttpConfig` and `ClientConfigArgs` becomes
`HttpConfigArgs`, across both crates, doc comments and README included. `rustls::ClientConfig`, a
different type, stays as it is. The diff is symmetric, +68/-68; no identifier other than the two
type names changes.

# Testing

Adds no tests: nothing behaves differently. `cargo test -p armonik-transport --all-features`
passes at this branch's head; the run is in the commit message, with clean clippy, fmt on both
crates, and `cargo check -p armonik`.

# Impact

Breaking rename for both type names; every other identifier, message, and option is untouched.

# Additional Information

Stacks on `wk/test/rust-upstream-tripwires`; merge that first. First of four pieces re-cutting the
configuration re-work.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI. (locally yes; CI runs on this PR)
- [x] I have assessed the performance impact of my modifications.
