### PR TITLE
ci(publish): stop a duplicate run racing on the registry push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -133,6 +133,24 @@ on:
         type: boolean
         default: false
 
+# One head SHA can arrive twice. `synchronize` fires whenever the merge ref has
+# to be recomputed, which happens both when the head moves and when the base
+# moves, so re-cutting a stack of pull requests delivers two events a second
+# apart for the same head. Both resolve the same pre-release version and race on
+# the same registry push, and the loser fails. The group is keyed on the ref,
+# `refs/pull/<n>/merge` for both deliveries, so the second cancels the first.
+#
+# Cancelling is confined to pull requests. A push to `main` or to a tag carries
+# its own version and collides with nothing, while interrupting one part way
+# through would leave some ecosystems pushed and the rest not, on registries
+# where a version cannot be pushed again; those runs queue instead.
+#
+# Group names are repository-wide, hence the workflow prefix: reusing `ci.yml`'s
+# bare `ci-<ref>` would make the two workflows cancel each other.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Deny everything by default and let each job grant itself the minimum. This has
 # to stay `{}` rather than be removed: the repository's default workflow token
 # permission is `write`, so a workflow with no `permissions` key at all hands a

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -133,22 +133,32 @@ on:
         type: boolean
         default: false
 
-# One head SHA can arrive twice. `synchronize` fires whenever the merge ref has
-# to be recomputed, which happens both when the head moves and when the base
-# moves, so re-cutting a stack of pull requests delivers two events a second
-# apart for the same head. Both resolve the same pre-release version and race on
-# the same registry push, and the loser fails. The group is keyed on the ref,
-# `refs/pull/<n>/merge` for both deliveries, so the second cancels the first.
+# One head SHA can arrive twice. `synchronize` fires whenever a pull request's
+# merge ref has to be recomputed, which happens both when the head moves and
+# when the base moves, so re-cutting a stack of pull requests delivers two
+# events a second apart for the same head. Both resolve the same pre-release
+# version and race on the same registry push, and the loser fails.
 #
-# Cancelling is confined to pull requests. A push to `main` or to a tag carries
-# its own version and collides with nothing, while interrupting one part way
-# through would leave some ecosystems pushed and the rest not, on registries
-# where a version cannot be pushed again; those runs queue instead.
+# Only such duplicates may share a group, hence the head SHA in the key. A later
+# commit on the same pull request, or a later push to `main`, lands in a group
+# of its own and is left alone: it carries a version of its own and races with
+# nothing, while stopping it part way would leave some ecosystems pushed and the
+# rest not, at a version none of these registries accepts a second time. Sharing
+# one group would not merely cancel those runs, it would drop them, a group
+# holding one running and one pending run and no more.
 #
-# Group names are repository-wide, hence the workflow prefix: reusing `ci.yml`'s
-# bare `ci-<ref>` would make the two workflows cancel each other.
+# `github.sha` cannot stand in for the head SHA here: on a pull request it is
+# the merge commit, which the two deliveries do not share once it is the base
+# that moved.
+#
+# Cancelling stays off outside pull requests, where the same ref twice is a
+# release published twice rather than one delivered twice.
+#
+# Group names share one repository-wide namespace, hence the workflow prefix:
+# reusing `ci.yml`'s bare `ci-<ref>` would make the two workflows cancel each
+# other.
 concurrency:
-  group: publish-${{ github.ref }}
+  group: publish-${{ github.ref }}-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Deny everything by default and let each job grant itself the minimum. This has


### PR DESCRIPTION
# Motivation

The publish workflow can run twice for one head SHA. A pull request's merge ref
is recomputed both when the head moves and when the base moves, and each
recomputation delivers a `synchronize` event, so re-cutting a stack delivers two
events a second apart for the same `head.sha`. Both resolve the same pre-release
version and push it to the same registry: the first wins, the second fails.
Observed on three stacked pull requests on 2026-08-07.

# Description

Adds a top-level `concurrency` block keyed on the ref and the pull request head
SHA, which is what the two deliveries share, so the second cancels the first.

Only such duplicates share a group. A later commit on the same pull request, or
a later push to `main`, lands in a group of its own and is left alone: it
carries a version of its own and races with nothing, while stopping it part way
would leave some ecosystems pushed and the rest not, at a version none of these
registries accepts a second time.

`cancel-in-progress` stays off outside pull requests, where the same ref twice
is a release published twice rather than one delivered twice.

The group name carries the workflow because group names share one
repository-wide namespace: reusing `ci.yml`'s bare `ci-<ref>` would make the two
workflows cancel each other.

# Testing

Nothing here is reachable by a test: the behaviour is in GitHub's event
delivery. The three workflow files were parsed with the repository's `js-yaml`
to confirm the block sits at the top level and that the three group names are
distinct. Command and output are in the commit message.

# Impact

What each channel publishes, and where, is unchanged. A duplicate delivery is
cancelled instead of failing on the push. Nothing else changes: every other run
keeps a group to itself.

The duplicate delivery is not specific to this workflow. Every workflow ran
twice on the affected SHA; `ci.yml` and `test.yml` absorbed it because they
already carry a concurrency group.

# Additional Information

None.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation. No documented
      behaviour changes.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
      Workflow triggering is not testable from this repository; see Testing.
- [ ] Tests pass locally and in the CI. To be confirmed by this pull request's
      own run.
- [x] I have assessed the performance impact of my modifications.
