### PR TITLE
feat(rust): describe the option vocabulary as a JSON schema

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,7 +211,9 @@ jobs:
           export Grpc__CaCert=certs/server1-ca.pem
           export GrpcClient__Endpoint=https://localhost:5001
           export GrpcClient__AllowUnsafeConnection=false
+          # The same authority under both spellings: C# reads CaCert, Rust reads CaCertPath.
           export GrpcClient__CaCert=$CertFolder/server1-ca.pem
+          export GrpcClient__CaCertPath=$CertFolder/server1-ca.pem
           ../../scripts/mock_test.sh ${{ matrix.language.dir }} '${{ matrix.language.cmd }}'
 
       - name: TLS store
@@ -265,7 +267,9 @@ jobs:
           export Grpc__ClientKey=certs/client.key
           export GrpcClient__Endpoint=https://localhost:5003
           export GrpcClient__AllowUnsafeConnection=false
+          # The same authority under both spellings: C# reads CaCert, Rust reads CaCertPath.
           export GrpcClient__CaCert=$CertFolder/server1-ca.pem
+          export GrpcClient__CaCertPath=$CertFolder/server1-ca.pem
           export GrpcClient__CertPem=$CertFolder/client.pem
           export GrpcClient__KeyPem=$CertFolder/client.key
           ../../scripts/mock_test.sh ${{ matrix.language.dir }} '${{ matrix.language.cmd }}'

--- a/packages/rust/Cargo.lock
+++ b/packages/rust/Cargo.lock
@@ -65,6 +65,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "rustls",
+ "schemars 1.2.2",
  "secrecy",
  "serde",
  "serde_json",
@@ -1166,8 +1167,21 @@ checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1243,6 +1257,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/packages/rust/Cargo.toml
+++ b/packages/rust/Cargo.toml
@@ -34,6 +34,7 @@ percent-encoding = "2.3"
 prost = "0.14"
 prost-types = "0.14"
 rustls = { version = "0.23", default-features = false }
+schemars = "1"
 secrecy = "0.10"
 # `std` as well as `derive`: without it `String` implements neither `Serialize` nor `Deserialize`, so
 # the `serde` feature would not compile.

--- a/packages/rust/armonik-transport/Cargo.toml
+++ b/packages/rust/armonik-transport/Cargo.toml
@@ -19,6 +19,10 @@ serde = [
   "dep:serde_with",
   "dep:serde_path_to_error",
 ]
+# A JSON schema of the option vocabulary, for generating an options class in another language.
+# `serde_json` because the prefix helper rewrites the generated schema's property names, and a
+# schemars 1.x schema is edited as the JSON value it wraps.
+schema = ["serde", "dep:schemars", "dep:serde_json"]
 
 [dependencies]
 # `channel` for `tonic::transport::Endpoint`, which is what `connect` builds; `codegen` for the
@@ -57,6 +61,9 @@ serde_with = { workspace = true, optional = true, features = ["std"] }
 # deserializer a flattened unit reads through, it recovers the option name that `#[serde(flatten)]`
 # otherwise buffers away, so no reader has to be told its own name.
 serde_path_to_error = { workspace = true, optional = true }
+# The JSON schema of the option vocabulary, behind the `schema` feature.
+schemars = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 humantime.workspace = true
 # `Proxy-Authorization: Basic` needs it. Already in the tree through `tonic`, so declaring it adds
 # nothing to the build.
@@ -86,3 +93,7 @@ tonic = { workspace = true, features = ["server", "router"] }
 # The test service's codec moves raw `Bytes`; production code here hands whole channels to its caller
 # rather than framing messages itself.
 bytes.workspace = true
+
+[[example]]
+name = "generate_schema"
+required-features = ["schema"]

--- a/packages/rust/armonik-transport/README.md
+++ b/packages/rust/armonik-transport/README.md
@@ -7,6 +7,16 @@ Depend on it when you need the connection layer without generated protobuf types
 `protoc`/`tonic-prost-build` build step. [`armonik`](../armonik) re-exports all of it, so a client that
 wants the services as well needs only that one.
 
+## Describing the options to another language
+
+The `schema` feature derives a JSON schema of the flat PascalCase option vocabulary (`Endpoint`,
+`TcpKeepalive`, `Http2KeepAliveInterval`, ...) from the types that define it, for a consumer that
+generates an options class of its own. Nothing is committed; print it with:
+
+```sh
+cargo run -p armonik-transport --features schema --example generate_schema
+```
+
 ## Reaching the endpoint through a proxy
 
 `HttpConfig::proxy` decides how the connection goes out. The default is `ProxySource::System`, the

--- a/packages/rust/armonik-transport/README.md
+++ b/packages/rust/armonik-transport/README.md
@@ -17,6 +17,10 @@ generates an options class of its own. Nothing is committed; print it with:
 cargo run -p armonik-transport --features schema --example generate_schema
 ```
 
+The Certificate Authority is named `CaCertPath`, where ArmoniK's C# client spells it `CaCert`. The
+option is a path to a PEM file, not the certificate, and the name says so. Until the C# client is
+renamed to match, a deployment serving both names the file twice.
+
 ## Reaching the endpoint through a proxy
 
 `HttpConfig::proxy` decides how the connection goes out. The default is `ProxySource::System`, the

--- a/packages/rust/armonik-transport/examples/generate_schema.rs
+++ b/packages/rust/armonik-transport/examples/generate_schema.rs
@@ -1,0 +1,17 @@
+//! Prints the JSON schema of the flat option vocabulary to stdout.
+//!
+//! For a consumer that generates an options class in another language:
+//!
+//! ```sh
+//! cargo run -p armonik-transport --features schema --example generate_schema
+//! ```
+
+use armonik_transport::reexports::schemars;
+
+fn main() {
+    let schema = schemars::schema_for!(armonik_transport::HttpConfig);
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&schema).expect("a schema serialises to JSON")
+    );
+}

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -73,7 +73,7 @@ pub struct HttpConfig {
     #[cfg_attr(feature = "schema", schemars(with = "String"))]
     pub endpoint: Uri,
     /// TLS and mTLS: the client's own identity, the server's CA, and SSL verification behaviour,
-    /// read under no prefix (`CertPem`, `CaCert`, `AllowUnsafeConnection`, ...).
+    /// read under no prefix (`CertPem`, `CaCertPath`, `AllowUnsafeConnection`, ...).
     #[cfg_attr(
         feature = "serde",
         serde(flatten, deserialize_with = "tls::deserialize")

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -4,7 +4,9 @@
 //! `serde` feature it also deserialises directly from a flat document of `PascalCase` options
 //! (`Endpoint`, `TcpKeepalive`, `Http2KeepAliveInterval`, ...), the same vocabulary every ArmoniK
 //! client reads; the thematic groups ([`TlsConfig`], [`TcpConfig`], [`Http2Config`]) flatten back
-//! into those names, so grouping the fields changes no option a deployment already sets.
+//! into those names, so grouping the fields changes no option a deployment already sets. The
+//! `schema` feature describes that same vocabulary as a JSON schema, derived from the types that
+//! define it rather than written out a second time.
 
 use std::time::Duration;
 
@@ -26,11 +28,26 @@ use crate::config_utils::{embed_prefixed, optional_duration, text};
 // own. An empty prefix strips nothing: it reads the flat vocabulary unchanged, and still gets the
 // naming and a prefix to give the day the unit is embedded a second time.
 #[cfg(feature = "serde")]
-embed_prefixed!(tls, crate::tls_config::TlsConfig, "");
+embed_prefixed!(
+    tls,
+    crate::tls_config::TlsConfig,
+    crate::tls_config::RawTls,
+    ""
+);
 #[cfg(feature = "serde")]
-embed_prefixed!(tcp, crate::tcp_config::TcpConfig, "Tcp");
+embed_prefixed!(
+    tcp,
+    crate::tcp_config::TcpConfig,
+    crate::tcp_config::TcpConfig,
+    "Tcp"
+);
 #[cfg(feature = "serde")]
-embed_prefixed!(http2, crate::http2_config::Http2Config, "Http2");
+embed_prefixed!(
+    http2,
+    crate::http2_config::Http2Config,
+    crate::http2_config::Http2Config,
+    "Http2"
+);
 
 /// Options for creating a gRPC client.
 ///
@@ -44,10 +61,16 @@ embed_prefixed!(http2, crate::http2_config::Http2Config, "Http2");
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "PascalCase", default))]
+#[cfg_attr(
+    feature = "schema",
+    derive(schemars::JsonSchema),
+    schemars(transform = crate::config_utils::strip_defaults)
+)]
 #[non_exhaustive]
 pub struct HttpConfig {
     /// Endpoint for sending requests. `Endpoint`.
     #[cfg_attr(feature = "serde", serde(deserialize_with = "endpoint"))]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
     pub endpoint: Uri,
     /// TLS and mTLS: the client's own identity, the server's CA, and SSL verification behaviour,
     /// read under no prefix (`CertPem`, `CaCert`, `AllowUnsafeConnection`, ...).
@@ -55,22 +78,27 @@ pub struct HttpConfig {
         feature = "serde",
         serde(flatten, deserialize_with = "tls::deserialize")
     )]
+    #[cfg_attr(feature = "schema", schemars(schema_with = "tls::schema"))]
     pub tls: TlsConfig,
     /// Timeout for establishing a connection to the server, defaults to 60s. `ConnectTimeout`.
     #[cfg_attr(feature = "serde", serde(deserialize_with = "connect_timeout"))]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
     pub connect_timeout: Option<Duration>,
     /// Timeout for each request, defaults to no timeout. `Timeout`.
     #[cfg_attr(feature = "serde", serde(deserialize_with = "optional_duration"))]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
     pub timeout: Option<Duration>,
     /// Rate limit for requests, written `count/duration` (e.g. `100/1s`), defaults to no rate
     /// limit. `RateLimit`.
     #[cfg_attr(feature = "serde", serde(deserialize_with = "rate_limit"))]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
     pub rate_limit: Option<(u64, Duration)>,
     /// TCP-level socket options, read under the `Tcp` prefix (`TcpKeepalive`, ...).
     #[cfg_attr(
         feature = "serde",
         serde(flatten, deserialize_with = "tcp::deserialize")
     )]
+    #[cfg_attr(feature = "schema", schemars(schema_with = "tcp::schema"))]
     pub tcp: TcpConfig,
     /// HTTP/2-level transport options, read under the `Http2` prefix (`Http2KeepAliveInterval`,
     /// ...).
@@ -78,9 +106,11 @@ pub struct HttpConfig {
         feature = "serde",
         serde(flatten, deserialize_with = "http2::deserialize")
     )]
+    #[cfg_attr(feature = "schema", schemars(schema_with = "http2::schema"))]
     pub http2: Http2Config,
     /// User-Agent header value sent with each request. `UserAgent`.
     #[cfg_attr(feature = "serde", serde(deserialize_with = "user_agent"))]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
     pub user_agent: Option<HeaderValue>,
     /// HTTP proxy used to reach the endpoint, defaults to following the environment.
     ///

--- a/packages/rust/armonik-transport/src/config_utils/mod.rs
+++ b/packages/rust/armonik-transport/src/config_utils/mod.rs
@@ -13,20 +13,30 @@
 #[cfg(feature = "serde")]
 use std::time::Duration;
 
-/// Everything one embedding of a grouped unit needs: the prefix its options are read under, and a
-/// reader that names the option a source got wrong.
+/// Everything one embedding of a grouped unit needs: the prefix its options are read under, a
+/// reader that names the option a source got wrong, and the unit's schema under the same prefix.
 ///
 /// The prefix is this embedding's to choose, not the unit's to declare: a unit is a plain
 /// collection of fields, and another embedding may compose the same one under a prefix of its own.
+/// Declaring the three together is what keeps them from drifting apart.
+///
+/// `$schema` is separate from `$ty` because a unit built through `TryFrom` describes itself to a
+/// schema in the shape a document writes, not the shape the program keeps.
 ///
 /// Emits a module rather than free functions because `macro_rules!` cannot build an identifier out
-/// of pieces on stable, and takes `$ty` as a full path because names in the body resolve inside
+/// of pieces on stable, and takes its types as full paths because names in the body resolve inside
 /// that module rather than at the call site.
 #[cfg(feature = "serde")]
 macro_rules! embed_prefixed {
-    ($name:ident, $ty:ty, $prefix:literal) => {
+    ($name:ident, $ty:ty, $schema:ty, $prefix:literal) => {
         mod $name {
             serde_with::with_prefix!(prefix $prefix);
+
+            /// The unit's schema, with this embedding's prefix on every property it declares.
+            #[cfg(feature = "schema")]
+            pub fn schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+                crate::config_utils::schema_with_prefix::<$schema>(generator, $prefix)
+            }
 
             /// The unit, read under this embedding's prefix, naming the option a source got wrong.
             ///
@@ -60,6 +70,79 @@ macro_rules! embed_prefixed {
 
 #[cfg(feature = "serde")]
 pub(crate) use embed_prefixed;
+
+/// Remove every `default` from the generated schema, recursively.
+///
+/// A `default` here is a Rust field's `Default`, serialised in the field's own type rather than in
+/// the option's text form: `false` on an option whose schema type is string. Every option's real
+/// contract is already stated once, as text: an empty or absent option reads as its default.
+#[cfg(feature = "schema")]
+pub(crate) fn strip_defaults(schema: &mut schemars::Schema) {
+    fn strip(value: &mut serde_json::Value) {
+        match value {
+            serde_json::Value::Object(object) => {
+                object.remove("default");
+                for child in object.values_mut() {
+                    strip(child);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for item in items {
+                    strip(item);
+                }
+            }
+            _ => {}
+        }
+    }
+    let object = schema.ensure_object();
+    object.remove("default");
+    for child in object.values_mut() {
+        strip(child);
+    }
+}
+
+/// `T`'s own schema with `prefix` glued onto every property, mirroring what
+/// [`serde_with::with_prefix!`] does to the names a flattened group is read from: `serde_with` has
+/// no `schemars` integration, so without this the schema would describe a field as `Field` where
+/// the source spells `PrefixField`.
+#[cfg(feature = "schema")]
+pub(crate) fn schema_with_prefix<T: schemars::JsonSchema>(
+    generator: &mut schemars::SchemaGenerator,
+    prefix: &str,
+) -> schemars::Schema {
+    /// The names live one level down in each branch of a union: a unit whose shapes are selected
+    /// untagged describes itself as an `anyOf`, and prefixing only the top level would rename
+    /// nothing at all there.
+    fn rename(object: &mut serde_json::Map<String, serde_json::Value>, prefix: &str) {
+        if let Some(serde_json::Value::Object(properties)) = object.remove("properties") {
+            let properties: serde_json::Map<String, serde_json::Value> = properties
+                .into_iter()
+                .map(|(name, subschema)| (format!("{prefix}{name}"), subschema))
+                .collect();
+            object.insert(String::from("properties"), properties.into());
+        }
+        if let Some(serde_json::Value::Array(required)) = object.get_mut("required") {
+            for name in required {
+                if let serde_json::Value::String(name) = name {
+                    *name = format!("{prefix}{name}");
+                }
+            }
+        }
+        for keyword in ["anyOf", "oneOf", "allOf"] {
+            if let Some(serde_json::Value::Array(branches)) = object.get_mut(keyword) {
+                for branch in branches {
+                    if let Some(branch) = branch.as_object_mut() {
+                        rename(branch, prefix);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut schema = T::json_schema(generator);
+    rename(schema.ensure_object(), prefix);
+    schema
+}
 
 /// Reads any option as text, whatever scalar shape a `serde` source gave it.
 ///
@@ -197,5 +280,52 @@ pub(crate) fn optional_u32<'de, D: serde::Deserializer<'de>>(
         Err(error) => Err(serde::de::Error::custom(format!(
             "`{value}` is not a valid integer: {error}"
         ))),
+    }
+}
+
+#[cfg(all(test, feature = "schema"))]
+mod tests {
+    use super::schema_with_prefix;
+
+    /// A unit whose shapes are selected untagged, so its schema is a union of branches and the
+    /// names live one level down rather than at the top.
+    ///
+    /// Never constructed: the derive is what is under test, not the values.
+    #[derive(schemars::JsonSchema)]
+    #[schemars(untagged)]
+    #[allow(dead_code)]
+    enum Untagged {
+        #[schemars(rename_all = "PascalCase")]
+        Both { first: String, second: String },
+        #[schemars(rename_all = "PascalCase")]
+        One { first: String },
+    }
+
+    #[test]
+    fn a_prefix_reaches_the_names_inside_a_union_branch() {
+        // Renaming the top level alone would rename nothing at all here: both the properties and
+        // the keys `required` names sit inside the branches, and a schema that kept the bare names
+        // would describe options no source spells.
+        let mut generator = schemars::SchemaGenerator::default();
+        let schema = schema_with_prefix::<Untagged>(&mut generator, "Prefix");
+        let value = serde_json::to_value(&schema).expect("a schema serialises to JSON");
+
+        let branches = value["anyOf"]
+            .as_array()
+            .unwrap_or_else(|| panic!("an untagged union is an anyOf: {value:#}"));
+        assert_eq!(branches.len(), 2, "{value:#}");
+        for branch in branches {
+            for name in branch["properties"]
+                .as_object()
+                .unwrap_or_else(|| panic!("each branch is an object shape: {value:#}"))
+                .keys()
+            {
+                assert!(name.starts_with("Prefix"), "`{name}` kept its bare name");
+            }
+            for name in branch["required"].as_array().into_iter().flatten() {
+                let name = name.as_str().expect("a required key is a string");
+                assert!(name.starts_with("Prefix"), "`{name}` kept its bare name");
+            }
+        }
     }
 }

--- a/packages/rust/armonik-transport/src/http2_config.rs
+++ b/packages/rust/armonik-transport/src/http2_config.rs
@@ -9,35 +9,45 @@ use std::time::Duration;
 /// HTTP/2-level transport options.
 ///
 /// Each field names one option; the full name a source spells is the embedding's prefix followed
-/// by that name.
+/// by that name, so no field doc spells it: the same field is a different option under a different
+/// prefix. A schema generated for this type on its own describes the unprefixed names it declares.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "PascalCase", default))]
+#[cfg_attr(
+    feature = "schema",
+    derive(schemars::JsonSchema),
+    schemars(transform = crate::config_utils::strip_defaults)
+)]
 #[non_exhaustive]
 pub struct Http2Config {
-    /// HTTP/2 PING frame interval (e.g. `20s`), defaults to no keepalive. `KeepAliveInterval`.
+    /// HTTP/2 PING frame interval (e.g. `20s`), defaults to no keepalive.
     #[cfg_attr(
         feature = "serde",
         serde(deserialize_with = "crate::config_utils::optional_duration")
     )]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
     pub keep_alive_interval: Option<Duration>,
-    /// HTTP/2 PING timeout (e.g. `10s`), defaults to no timeout. `KeepAliveTimeout`.
+    /// HTTP/2 PING timeout (e.g. `10s`), defaults to no timeout.
     #[cfg_attr(
         feature = "serde",
         serde(deserialize_with = "crate::config_utils::optional_duration")
     )]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
     pub keep_alive_timeout: Option<Duration>,
-    /// Send HTTP/2 keepalive PINGs even when idle, defaults to false. `KeepAliveWhileIdle`.
+    /// Send HTTP/2 keepalive PINGs even when idle, defaults to false.
     /// See [`crate::TlsConfig::allow_unsafe_connection`] for the accepted spellings.
     #[cfg_attr(
         feature = "serde",
         serde(deserialize_with = "crate::config_utils::bool_option")
     )]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
     pub keep_alive_while_idle: bool,
-    /// HTTP/2 max header list size in bytes, defaults to no limit. `MaxHeaderListSize`.
+    /// HTTP/2 max header list size in bytes, defaults to no limit.
     #[cfg_attr(
         feature = "serde",
         serde(deserialize_with = "crate::config_utils::optional_u32")
     )]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
     pub max_header_list_size: Option<u32>,
 }

--- a/packages/rust/armonik-transport/src/lib.rs
+++ b/packages/rust/armonik-transport/src/lib.rs
@@ -36,6 +36,8 @@ pub mod reexports {
     pub use hyper_rustls;
     pub use hyper_util;
     pub use rustls;
+    #[cfg(feature = "schema")]
+    pub use schemars;
     pub use secrecy;
     #[cfg(feature = "serde")]
     pub use serde;

--- a/packages/rust/armonik-transport/src/tcp_config.rs
+++ b/packages/rust/armonik-transport/src/tcp_config.rs
@@ -9,36 +9,45 @@ use std::time::Duration;
 /// TCP-level socket options.
 ///
 /// Each field names one option; the full name a source spells is the embedding's prefix followed
-/// by that name.
+/// by that name, so no field doc spells it: the same field is a different option under a different
+/// prefix. A schema generated for this type on its own describes the unprefixed names it declares.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "PascalCase", default))]
+#[cfg_attr(
+    feature = "schema",
+    derive(schemars::JsonSchema),
+    schemars(transform = crate::config_utils::strip_defaults)
+)]
 #[non_exhaustive]
 pub struct TcpConfig {
-    /// TCP keepalive duration (e.g. `30s`), defaults to no keepalive. `Keepalive`.
+    /// TCP keepalive duration (e.g. `30s`), defaults to no keepalive.
     #[cfg_attr(
         feature = "serde",
         serde(deserialize_with = "crate::config_utils::optional_duration")
     )]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
     pub keepalive: Option<Duration>,
     /// Interval between TCP keepalive probes (e.g. `5s`), defaults to OS default.
-    /// `KeepaliveInterval`.
     #[cfg_attr(
         feature = "serde",
         serde(deserialize_with = "crate::config_utils::optional_duration")
     )]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
     pub keepalive_interval: Option<Duration>,
-    /// Number of TCP keepalive retries, defaults to OS default. `KeepaliveRetries`.
+    /// Number of TCP keepalive retries, defaults to OS default.
     #[cfg_attr(
         feature = "serde",
         serde(deserialize_with = "crate::config_utils::optional_u32")
     )]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
     pub keepalive_retries: Option<u32>,
-    /// Enable Nagle's algorithm (disable TCP_NODELAY), defaults to false. `NagleAlgorithm`. See
+    /// Enable Nagle's algorithm (disable TCP_NODELAY), defaults to false. See
     /// [`crate::TlsConfig::allow_unsafe_connection`] for the accepted spellings.
     #[cfg_attr(
         feature = "serde",
         serde(deserialize_with = "crate::config_utils::bool_option")
     )]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
     pub nagle_algorithm: bool,
 }

--- a/packages/rust/armonik-transport/src/tls_config.rs
+++ b/packages/rust/armonik-transport/src/tls_config.rs
@@ -2,7 +2,7 @@
 //! verification behaves rather than what is verified.
 //!
 //! Unlike the TCP and HTTP/2 units, these fields share no common prefix in the environment
-//! (`CertPem`, `CaCert`, `AllowUnsafeConnection`, `OverrideTargetName`, ...), so the embedding
+//! (`CertPem`, `CaCertPath`, `AllowUnsafeConnection`, `OverrideTargetName`, ...), so the embedding
 //! composes them with a plain [`serde(flatten)`](serde::Deserialize) and no prefix at all.
 //!
 //! Every option naming a file loads it while the configuration is read: [`TlsConfig`] holds the
@@ -98,7 +98,7 @@ pub struct TlsConfig {
     /// `CertPem`/`KeyPem`, whose files are loaded as the configuration is read.
     pub identity: Option<Identity>,
     /// The Certificate Authority the server is verified against, `None` for the system CAs. Read
-    /// from `CaCert`, whose PEM file is loaded as the configuration is read.
+    /// from `CaCertPath`, whose PEM file is loaded as the configuration is read.
     pub ca_cert: Option<CertificateDer<'static>>,
     /// Override the endpoint name during SSL verification. `OverrideTargetName`.
     pub override_target_name: Option<String>,
@@ -122,7 +122,7 @@ pub(crate) struct RawTls {
     identity: RawIdentity,
     /// Path to the Certificate Authority file, in PEM format; empty for the system CAs.
     #[serde(default, deserialize_with = "crate::config_utils::text")]
-    ca_cert: String,
+    ca_cert_path: String,
     /// Accept any server certificate instead of verifying it: `1`, `true`, `yes`, `enable`,
     /// `allow` or `authorize`, and their negatives; empty for false.
     #[serde(default, deserialize_with = "crate::config_utils::text")]
@@ -211,7 +211,7 @@ impl TryFrom<RawTls> for TlsConfig {
     fn try_from(raw: RawTls) -> Result<Self, Self::Error> {
         let RawTls {
             identity,
-            ca_cert,
+            ca_cert_path,
             allow_unsafe_connection,
             override_target_name,
         } = raw;
@@ -223,11 +223,11 @@ impl TryFrom<RawTls> for TlsConfig {
             )
             .map_err(|msg| IncompatibleOptionsSnafu { msg }.build())?,
             identity: identity.load()?,
-            ca_cert: if ca_cert.is_empty() {
+            ca_cert: if ca_cert_path.is_empty() {
                 None
             } else {
-                let pem = std::fs::read_to_string(&ca_cert).context(IoSnafu {
-                    path: ca_cert.clone(),
+                let pem = std::fs::read_to_string(&ca_cert_path).context(IoSnafu {
+                    path: ca_cert_path.clone(),
                 })?;
                 Some(CertificateDer::from_pem_slice(pem.as_bytes()).context(TlsSnafu {})?)
             },
@@ -438,7 +438,7 @@ MC4CAQAwBQYDK2VwBCIEIAKZ5vS5lxuHsHFDHPJmgDlI5D43nIUJ6Woni24zaHSM
         // The CA is loaded with the rest of the configuration, so a typo in the option names the
         // file instead of surfacing as a failed handshake.
         let error = serde_json::from_value::<TlsConfig>(serde_json::json!({
-            "CaCert": "no/such/ca.pem",
+            "CaCertPath": "no/such/ca.pem",
         }))
         .expect_err("a missing file must be reported");
 
@@ -452,7 +452,7 @@ MC4CAQAwBQYDK2VwBCIEIAKZ5vS5lxuHsHFDHPJmgDlI5D43nIUJ6Woni24zaHSM
         let ca = dir.write("ca.pem", LEAF_CERT);
 
         let config = serde_json::from_value::<TlsConfig>(serde_json::json!({
-            "CaCert": ca.display().to_string(),
+            "CaCertPath": ca.display().to_string(),
         }))
         .expect("a readable CA file");
 

--- a/packages/rust/armonik-transport/src/tls_config.rs
+++ b/packages/rust/armonik-transport/src/tls_config.rs
@@ -138,6 +138,14 @@ pub(crate) struct RawTls {
 ///
 /// Selection is on key presence alone, so a present-but-empty option still selects a shape;
 /// [`RawIdentity::load`] is what reads empty as unset, whichever shape matched.
+///
+/// The shapes say which options exist and which arrive together, not which combinations are legal:
+/// half a PEM pair matches `Bare`, so the schema accepts it and [`RawIdentity::load`] refuses it.
+/// A relationship between options is enforced once, where the message can name both, rather than
+/// encoded a second time in the schema. `dependentRequired` could express this one, but a rule
+/// written twice drifts, and the reader is the copy that decides. This paragraph does not reach
+/// the schema - schemars keeps only variant docs for a flattened enum - so the part a consumer
+/// needs is on `Bare` itself.
 #[cfg(feature = "serde")]
 #[derive(Debug, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -153,8 +161,9 @@ enum RawIdentity {
         #[serde(deserialize_with = "crate::config_utils::text")]
         key_pem: String,
     },
-    /// At most one identity option present: no identity, or half of one, which [`Self::load`]
-    /// rejects by name.
+    /// Neither identity option set, or only one of them. Setting only one is refused when the
+    /// configuration is read, naming both options: this alternative admits it so the vocabulary
+    /// stays one list, and the reader is what decides a pair is a pair.
     #[serde(rename_all = "PascalCase")]
     Bare {
         /// Path to the certificate chain file, in PEM format; set together with `KeyPem`.

--- a/packages/rust/armonik-transport/src/tls_config.rs
+++ b/packages/rust/armonik-transport/src/tls_config.rs
@@ -111,14 +111,23 @@ pub struct TlsConfig {
 /// declares a variable with an empty default must not differ from one that leaves it out.
 #[cfg(feature = "serde")]
 #[derive(Debug, serde::Deserialize)]
+#[cfg_attr(
+    feature = "schema",
+    derive(schemars::JsonSchema),
+    schemars(transform = crate::config_utils::strip_defaults)
+)]
 #[serde(rename_all = "PascalCase")]
-struct RawTls {
+pub(crate) struct RawTls {
     #[serde(flatten)]
     identity: RawIdentity,
+    /// Path to the Certificate Authority file, in PEM format; empty for the system CAs.
     #[serde(default, deserialize_with = "crate::config_utils::text")]
     ca_cert: String,
+    /// Accept any server certificate instead of verifying it: `1`, `true`, `yes`, `enable`,
+    /// `allow` or `authorize`, and their negatives; empty for false.
     #[serde(default, deserialize_with = "crate::config_utils::text")]
     allow_unsafe_connection: String,
+    /// Override the endpoint name during SSL verification; empty for no override.
     #[serde(default, deserialize_with = "crate::config_utils::text")]
     override_target_name: String,
 }
@@ -131,13 +140,16 @@ struct RawTls {
 /// [`RawIdentity::load`] is what reads empty as unset, whichever shape matched.
 #[cfg(feature = "serde")]
 #[derive(Debug, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 enum RawIdentity {
     /// A certificate chain and its key, each in its own PEM file.
     #[serde(rename_all = "PascalCase")]
     PemFiles {
+        /// Path to the certificate chain file, in PEM format; set together with `KeyPem`.
         #[serde(deserialize_with = "crate::config_utils::text")]
         cert_pem: String,
+        /// Path to the key file, in PEM format; set together with `CertPem`.
         #[serde(deserialize_with = "crate::config_utils::text")]
         key_pem: String,
     },
@@ -145,8 +157,10 @@ enum RawIdentity {
     /// rejects by name.
     #[serde(rename_all = "PascalCase")]
     Bare {
+        /// Path to the certificate chain file, in PEM format; set together with `KeyPem`.
         #[serde(default, deserialize_with = "crate::config_utils::text")]
         cert_pem: String,
+        /// Path to the key file, in PEM format; set together with `CertPem`.
         #[serde(default, deserialize_with = "crate::config_utils::text")]
         key_pem: String,
     },

--- a/packages/rust/armonik-transport/tests/schema.rs
+++ b/packages/rust/armonik-transport/tests/schema.rs
@@ -1,0 +1,207 @@
+//! Smoke tests for the JSON schema of the flat option vocabulary.
+//!
+//! The schema is generated, never committed: `examples/generate_schema.rs` prints it for the
+//! consumer that wants a file. What is pinned here are the invariants a consumer builds against,
+//! not the byte-for-byte rendering, so a `schemars` upgrade that moves a keyword around does not
+//! break anything that was not actually promised.
+
+#![cfg(feature = "schema")]
+
+use armonik_transport::reexports::schemars;
+
+/// The generated schema, as plain JSON.
+fn schema() -> serde_json::Value {
+    serde_json::to_value(schemars::schema_for!(armonik_transport::HttpConfig))
+        .expect("a schema serialises to JSON")
+}
+
+/// Every property name declared anywhere in the schema: top level, `anyOf`/`allOf` branches, and
+/// `$defs` alike, so the assertions hold whatever nesting `schemars` chooses.
+fn property_names(value: &serde_json::Value, names: &mut Vec<String>) {
+    match value {
+        serde_json::Value::Object(object) => {
+            for (key, child) in object {
+                if key == "properties" {
+                    if let serde_json::Value::Object(properties) = child {
+                        names.extend(properties.keys().cloned());
+                    }
+                }
+                property_names(child, names);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                property_names(item, names);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Every `anyOf` array anywhere in the schema.
+fn any_ofs(value: &serde_json::Value, found: &mut Vec<Vec<serde_json::Value>>) {
+    match value {
+        serde_json::Value::Object(object) => {
+            for (key, child) in object {
+                if key == "anyOf" {
+                    if let serde_json::Value::Array(alternatives) = child {
+                        found.push(alternatives.clone());
+                    }
+                }
+                any_ofs(child, found);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                any_ofs(item, found);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn every_option_appears_under_its_flat_name() {
+    // The whole vocabulary, spelled exactly as deserialisation reads it: this list is what a
+    // consumer generating an options class builds against.
+    let schema = schema();
+    let mut names = Vec::new();
+    property_names(&schema, &mut names);
+
+    for option in [
+        "Endpoint",
+        "CertPem",
+        "KeyPem",
+        "CaCert",
+        "AllowUnsafeConnection",
+        "OverrideTargetName",
+        "ConnectTimeout",
+        "Timeout",
+        "RateLimit",
+        "TcpKeepalive",
+        "TcpKeepaliveInterval",
+        "TcpKeepaliveRetries",
+        "TcpNagleAlgorithm",
+        "Http2KeepAliveInterval",
+        "Http2KeepAliveTimeout",
+        "Http2KeepAliveWhileIdle",
+        "Http2MaxHeaderListSize",
+        "UserAgent",
+    ] {
+        assert!(names.iter().any(|name| name == option), "missing {option}");
+    }
+}
+
+#[test]
+fn the_schema_promises_nothing_that_is_not_read() {
+    // A consumer generates its options class from this, so an option the schema declares and
+    // deserialisation ignores is a field that silently does nothing. The proxy is set
+    // programmatically and no option reads it; the PKCS#12 identity is not an option at all.
+    let schema = schema();
+    let mut names = Vec::new();
+    property_names(&schema, &mut names);
+
+    for absent in ["ProxyAddress", "ProxyUsername", "ProxyPassword", "CertP12"] {
+        assert!(
+            !names.iter().any(|name| name == absent),
+            "`{absent}` is not read"
+        );
+    }
+}
+
+#[test]
+fn the_prefixed_groups_keep_their_flat_spellings() {
+    // `serde_with::with_prefix!` has no `schemars` integration, so without the prefix helper the
+    // schema would list each group under its unprefixed field names.
+    let schema = schema();
+    let mut names = Vec::new();
+    property_names(&schema, &mut names);
+
+    for unprefixed in [
+        "Keepalive",
+        "KeepaliveInterval",
+        "KeepaliveRetries",
+        "NagleAlgorithm",
+        "KeepAliveInterval",
+        "KeepAliveTimeout",
+        "KeepAliveWhileIdle",
+        "MaxHeaderListSize",
+    ] {
+        assert!(
+            !names.iter().any(|name| name == unprefixed),
+            "`{unprefixed}` appears unprefixed"
+        );
+    }
+}
+
+#[test]
+fn the_identity_alternatives_are_an_any_of() {
+    // The identity comes as both PEM halves or not at all: the schema has to spell the
+    // alternatives rather than flatten them into one bag of optional fields.
+    let schema = schema();
+    let mut found = Vec::new();
+    any_ofs(&schema, &mut found);
+
+    let identity = found.iter().find(|alternatives| {
+        alternatives.iter().any(|alternative| {
+            let mut names = Vec::new();
+            property_names(alternative, &mut names);
+            names.iter().any(|name| name == "CertPem") && names.iter().any(|name| name == "KeyPem")
+        })
+    });
+    assert!(
+        identity.is_some(),
+        "no anyOf alternative declares CertPem and KeyPem: {schema:#}"
+    );
+}
+
+#[test]
+fn no_default_survives_anywhere_in_the_schema() {
+    // A Rust field's `Default` serialises in the field's own type, not in the option's text form:
+    // `false`, or a `Duration` as `{"secs":..,"nanos":..}`, on an option whose schema type is
+    // string. Each option states its default in prose instead. The walk is recursive because
+    // `schemars` is free to nest, and a stripping transform that stops reaching a branch would
+    // otherwise resurface those values unnoticed.
+    fn defaults(value: &serde_json::Value, path: String, found: &mut Vec<String>) {
+        match value {
+            serde_json::Value::Object(object) => {
+                for (key, child) in object {
+                    if key == "default" {
+                        found.push(format!("{path}/{key} = {child}"));
+                    }
+                    defaults(child, format!("{path}/{key}"), found);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for (index, item) in items.iter().enumerate() {
+                    defaults(item, format!("{path}/{index}"), found);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // The unit types are public and generate their own schemas, so the guarantee has to hold for
+    // each on its own, not only for the configuration that embeds them.
+    for (name, schema) in [
+        ("HttpConfig", schema()),
+        (
+            "TcpConfig",
+            serde_json::to_value(schemars::schema_for!(armonik_transport::TcpConfig))
+                .expect("a schema serialises to JSON"),
+        ),
+        (
+            "Http2Config",
+            serde_json::to_value(schemars::schema_for!(armonik_transport::Http2Config))
+                .expect("a schema serialises to JSON"),
+        ),
+    ] {
+        let mut found = Vec::new();
+        defaults(&schema, String::new(), &mut found);
+
+        assert!(
+            found.is_empty(),
+            "{name}'s schema still carries defaults: {found:#?}"
+        );
+    }
+}

--- a/packages/rust/armonik-transport/tests/schema.rs
+++ b/packages/rust/armonik-transport/tests/schema.rs
@@ -72,7 +72,7 @@ fn every_option_appears_under_its_flat_name() {
         "Endpoint",
         "CertPem",
         "KeyPem",
-        "CaCert",
+        "CaCertPath",
         "AllowUnsafeConnection",
         "OverrideTargetName",
         "ConnectTimeout",


### PR DESCRIPTION
The flat option vocabulary is becoming an FFI contract: a .NET consumer will
generate its own options type from it. A hand-written mirror would drift from
the code the day someone forgot it, so this derives the description from the
types that already define the vocabulary.

A `schema` feature (schemars 1.x, off by default) makes `HttpConfig` and the
units it embeds describe themselves. One schema, flat, exactly the names
deserialisation reads.

## What is in it

- `schema` feature on `armonik-transport`, pulling in `schemars` and
  `serde_json`. It implies `serde`, and nothing else changes when it is off.
- `examples/generate_schema.rs` prints the schema, for whoever wants a file:
  `cargo run -p armonik-transport --features schema --example generate_schema`.
- The schema function folds into `embed_prefixed!`, so an embedding declares
  its prefix, its reader and its schema in one place. `serde_with::with_prefix!`
  has no schemars integration, hence a helper that reapplies the prefix to the
  generated properties, `required` keys included, inside union branches too.
- `strip_defaults`, because schemars serialises a field's `Default` in the
  field's own type: `false`, or a `Duration` as an object, on an option whose
  schema type is string. Each option states its default in prose instead.
- No committed JSON. Six tests pin the invariants a consumer builds against;
  a schemars upgrade that moves a keyword around breaks nothing that was
  actually promised.

## Two deliberate choices

No mirror structs. The real types derive `JsonSchema`; `TlsConfig` describes
itself through `RawTls`, the shape it already deserialises from, since a unit
built through `TryFrom` describes the shape a document writes rather than the
shape the program keeps.

The schema promises only what the reader reads. The proxy is
`#[serde(skip)]` and no option feeds it, so no proxy option appears; a test
pins that, because an option the schema declares and the reader ignores is a
generated field that silently does nothing.

A unit read under a non-empty prefix also stops spelling an option name in its
field docs. Those docs are now the schema's descriptions, and `Keepalive` is
not a name any source writes - `TcpKeepalive` is, and the prefix belongs to the
embedding. Units under no prefix keep their names, where the two coincide.

## Tests

6 new tests: 5 schema smoke tests, and one in `config_utils` covering the
prefix helper's union-branch case, which no embedding exercises with a
non-empty prefix yet.

## Gates

```
cargo test -p armonik-transport --all-features            80 passed, 0 failed
cargo clippy -p armonik-transport --all-features --all-targets   0 warnings
cargo clippy -p armonik --all-features --all-targets             0 warnings
cargo check -p armonik-transport --no-default-features           0 warnings
cargo fmt --check                                                clean
```
