### PR TITLE
feat(rust): read the client identity from a PKCS#12 bundle

### DIFF
--- a/packages/rust/Cargo.lock
+++ b/packages/rust/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,7 +98,9 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "p12-keystore",
  "percent-encoding",
+ "rcgen",
  "rustls",
  "schemars 1.2.2",
  "secrecy",
@@ -77,6 +114,45 @@ dependencies = [
  "tonic",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -174,10 +250,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
 
 [[package]]
 name = "bs58"
@@ -201,6 +310,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +335,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +356,41 @@ dependencies = [
  "serde",
  "windows-link",
 ]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "cms"
+version = "0.3.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758d5272932ff167e96ec9641a04d96ab1901cccc5ea9f47c15b4cbaa6f9ea53"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -245,12 +409,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "des"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "ctutils",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -308,6 +590,12 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "fnv"
@@ -429,8 +717,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
 ]
 
 [[package]]
@@ -486,6 +784,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +842,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -671,6 +987,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +1095,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +1118,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,10 +1137,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -807,6 +1168,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -820,6 +1190,29 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "p12-keystore"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02686a966a6d270eb3e87178c70323a30a62741e59b37e542ff029fb774afa47"
+dependencies = [
+ "cbc",
+ "cms",
+ "der",
+ "des",
+ "hex",
+ "hmac",
+ "pkcs12",
+ "pkcs5",
+ "pkcs8",
+ "rand",
+ "rc2",
+ "sha1",
+ "sha2",
+ "thiserror",
+ "x509-parser",
+]
 
 [[package]]
 name = "parking_lot"
@@ -842,6 +1235,35 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -886,6 +1308,58 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs12"
+version = "0.2.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8059bd79345d1d1c125656025814704bab5cdd204b1cefd5fab59b0fdd7476d2"
+dependencies = [
+ "cms",
+ "const-oid",
+ "der",
+ "digest",
+ "spki",
+ "x509-cert",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d440a804ec8d6fafbb6b84471e013286658d373248927692ab3366686220ca"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "scrypt",
+ "sha2",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
+dependencies = [
+ "cpubits",
+ "cpufeatures",
+ "universal-hash",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1001,6 +1475,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rc2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceda21af1ae61033b63175653a1af86cae399d79cd03ca80ba347eb3a6c4a7fe"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,6 +1587,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,6 +1662,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "salsa20"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
+dependencies = [
+ "cfg-if",
+ "cipher",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1722,18 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
+dependencies = [
+ "cfg-if",
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "secrecy"
@@ -1339,6 +1884,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1964,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,6 +2008,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,6 +2029,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1736,6 +2344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,6 +2366,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common",
+ "ctutils",
+]
 
 [[package]]
 name = "untrusted"
@@ -2110,6 +2734,45 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
 ]
 
 [[package]]

--- a/packages/rust/Cargo.toml
+++ b/packages/rust/Cargo.toml
@@ -30,9 +30,11 @@ humantime = "2.3.0"
 hyper = "1.10"
 hyper-rustls = { version = "0.27", default-features = false }
 hyper-util = "0.1"
+p12-keystore = "0.3"
 percent-encoding = "2.3"
 prost = "0.14"
 prost-types = "0.14"
+rcgen = "0.14"
 rustls = { version = "0.23", default-features = false }
 schemars = "1"
 secrecy = "0.10"

--- a/packages/rust/armonik-transport/Cargo.toml
+++ b/packages/rust/armonik-transport/Cargo.toml
@@ -51,6 +51,9 @@ hyper-rustls = { workspace = true, features = [
   "logging",
 ] }
 rustls = { workspace = true, features = ["ring", "logging", "std", "tls12"] }
+# Reads a certificate bundled with its key as a PKCS#12 file; pure Rust, so it pulls in no OpenSSL
+# of its own.
+p12-keystore.workspace = true
 serde = { workspace = true, optional = true }
 # `with_prefix!`, for a group of options whose flat names already share a literal prefix (`Tcp*`,
 # `Http2*`): it composes with `#[serde(flatten)]` to read the same names as before the grouping,
@@ -86,6 +89,10 @@ serial_test.workspace = true
 # The unit tests build configurations the way a caller does under the `serde` feature: from a JSON
 # document naming the flat options.
 serde_json.workspace = true
+# A CA-signed certificate and its key, generated fresh for the PKCS#12 tests: `p12-keystore`
+# rebuilds a bundle's chain by issuer, so proving the intermediates survive needs material that
+# really signed the leaf, which a committed fixture would also have to keep unexpired.
+rcgen.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 # The integration tests serve a gRPC service to call, which the regular build never does; these features
 # union with the `channel`/`codegen` above for test builds only.

--- a/packages/rust/armonik-transport/README.md
+++ b/packages/rust/armonik-transport/README.md
@@ -21,6 +21,22 @@ The Certificate Authority is named `CaCertPath`, where ArmoniK's C# client spell
 option is a path to a PEM file, not the certificate, and the name says so. Until the C# client is
 renamed to match, a deployment serving both names the file twice.
 
+## The client's identity for mutual TLS
+
+The identity is loaded while the configuration is read, so a mistyped path fails there, naming the
+option, rather than later as a refused handshake. It comes one of two ways.
+
+`CertPem` and `KeyPem` are the certificate chain and its key, each in its own PEM file; set both or
+neither. `CertP12` is the alternative: the two bundled together in one PKCS#12 file, the form
+Windows and most certificate authorities hand out, optionally protected by `CertP12Password`.
+Whichever way it is spelled, the whole chain the file carries is presented, leaf first, so a server
+that trusts only the root can still build its path. `CertP12` and `CertPem`/`KeyPem` are mutually
+exclusive - set one identity or the other, never both - and a `CertP12Password` naming no bundle is
+refused rather than ignored.
+
+ArmoniK's C# client reads the same `CertP12` option but has no `CertP12Password` counterpart, so a
+password-protected bundle is not portable to it.
+
 ## Reaching the endpoint through a proxy
 
 `HttpConfig::proxy` decides how the connection goes out. The default is `ProxySource::System`, the

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -267,6 +267,24 @@ pub enum ConfigError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+    #[snafu(display("`CertP12`'s file `{path}` is not a valid PKCS#12 bundle [{location}]"))]
+    #[non_exhaustive]
+    Pkcs12 {
+        #[snafu(source(from(p12_keystore::error::Error, Box::new)))]
+        source: Box<p12_keystore::error::Error>,
+        path: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display(
+        "`CertP12`'s file `{path}` carries no private key and certificate chain [{location}]"
+    ))]
+    #[non_exhaustive]
+    EmptyPkcs12 {
+        path: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
     #[snafu(display("{msg} [{location}]"))]
     #[non_exhaustive]
     IncompatibleOptions {
@@ -683,5 +701,86 @@ mod tests {
         }));
 
         assert!(rendered.contains("no/such/cert.pem"), "{rendered}");
+    }
+
+    #[test]
+    fn cert_p12_and_the_pem_pair_are_mutually_exclusive() {
+        // Two spellings of the identity at once is a contradiction whichever half of the PEM pair
+        // is set, and the message has to name both spellings so either one can be removed.
+        for (cert, key) in [("cert.pem", "key.pem"), ("cert.pem", ""), ("", "key.pem")] {
+            let rendered = error(json!({
+                "Endpoint": "http://localhost:5001",
+                "CertPem": cert,
+                "KeyPem": key,
+                "CertP12": "identity.p12",
+            }));
+
+            assert!(rendered.contains("CertP12"), "{rendered}");
+            assert!(rendered.contains("CertPem"), "{rendered}");
+        }
+    }
+
+    #[test]
+    fn a_p12_password_without_a_p12_is_rejected_without_echoing_it() {
+        // Both shapes the orphan takes: alone, and next to a PEM identity that is legal on its own.
+        for extra in [
+            json!({}),
+            json!({"CertPem": "cert.pem", "KeyPem": "key.pem"}),
+        ] {
+            let mut value = json!({
+                "Endpoint": "http://localhost:5001",
+                "CertP12Password": "s3cr3t",
+            });
+            value
+                .as_object_mut()
+                .expect("a JSON object")
+                .extend(extra.as_object().expect("a JSON object").clone());
+
+            let rendered = error(value);
+            assert!(rendered.contains("CertP12Password"), "{rendered}");
+            assert!(rendered.contains("CertP12"), "{rendered}");
+            assert!(!rendered.contains("s3cr3t"), "{rendered}");
+        }
+    }
+
+    #[test]
+    fn empty_p12_options_read_as_unset() {
+        // Including the password: an empty password next to no bundle is not "a password without a
+        // bundle", it is the shape a deployment with empty defaults declares.
+        let config = config(json!({
+            "Endpoint": "http://localhost:5001",
+            "CertP12": "",
+            "CertP12Password": "",
+        }));
+
+        assert!(config.tls.identity.is_none());
+    }
+
+    #[test]
+    fn an_empty_cert_p12_leaves_the_pem_pair_next_to_it_alone() {
+        // A present-but-empty `CertP12` names no bundle, so it is neither an identity of its own
+        // nor a contradiction with the PEM pair that is really set.
+        let rendered = error(json!({
+            "Endpoint": "http://localhost:5001",
+            "CertP12": "",
+            "CertPem": "no/such/cert.pem",
+            "KeyPem": "no/such/key.pem",
+        }));
+
+        assert!(rendered.contains("no/such/cert.pem"), "{rendered}");
+    }
+
+    #[test]
+    fn a_p12_path_that_leads_nowhere_fails_while_reading_and_names_it() {
+        // The bundle is loaded as the configuration is read, like the PEM pair, and the password
+        // it was opened with stays out of the message.
+        let rendered = error(json!({
+            "Endpoint": "http://localhost:5001",
+            "CertP12": "no/such/identity.p12",
+            "CertP12Password": "s3cr3t",
+        }));
+
+        assert!(rendered.contains("no/such/identity.p12"), "{rendered}");
+        assert!(!rendered.contains("s3cr3t"), "{rendered}");
     }
 }

--- a/packages/rust/armonik-transport/src/config_utils/mod.rs
+++ b/packages/rust/armonik-transport/src/config_utils/mod.rs
@@ -205,6 +205,18 @@ pub(crate) fn text<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<
     deserializer.deserialize_any(AnyScalar)
 }
 
+/// [`text`], for an option whose value is a secret: a [`secrecy::SecretString`] is redacted by
+/// `Debug` and zeroized on drop, which a plain `String` field is not.
+///
+/// A numeric-looking secret may arrive as a real number the same way any other option can, and
+/// rejecting it would make some values unusable.
+#[cfg(feature = "serde")]
+pub(crate) fn secret_text<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<secrecy::SecretString, D::Error> {
+    text(deserializer).map(secrecy::SecretString::from)
+}
+
 /// The spellings a boolean option accepts, as an error message shows them.
 #[cfg(feature = "serde")]
 const BOOLEAN_SPELLINGS: &str = "e.g. `true`, `1`, `yes`, or `false`, `0`, `no`";

--- a/packages/rust/armonik-transport/src/tls_config.rs
+++ b/packages/rust/armonik-transport/src/tls_config.rs
@@ -15,18 +15,20 @@ use std::path::Path;
 
 use hyper::Uri;
 use rustls::pki_types::pem::PemObject;
-use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use snafu::ResultExt;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use secrecy::ExposeSecret;
+use snafu::{OptionExt, ResultExt};
 
 use crate::config::{
-    ConfigError, HttpSnafu, IncompatibleOptionsSnafu, IoSnafu, TlsSnafu, UriSnafu,
+    ConfigError, EmptyPkcs12Snafu, HttpSnafu, IncompatibleOptionsSnafu, IoSnafu, Pkcs12Snafu,
+    TlsSnafu, UriSnafu,
 };
 
 /// The client's TLS identity for mTLS: the certificate chain it presents, and the chain's key.
 ///
-/// Loaded material rather than paths, so it can be built from content directly; reading the pair
-/// from PEM files is [`Identity::from_pem_files`], which is also how the `CertPem`/`KeyPem`
-/// options are read.
+/// Loaded material rather than paths, so it can be built from content directly; reading it from
+/// files is [`Identity::from_pem_files`] or [`Identity::from_pkcs12`], which is also how the
+/// `CertPem`/`KeyPem` and `CertP12` options are read.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Identity {
     /// The certificate chain presented to the server, leaf first.
@@ -77,6 +79,43 @@ impl Identity {
 
         Ok(Self { certs, key })
     }
+
+    /// Load an identity from a PKCS#12 bundle, the form Windows and most certificate authorities
+    /// hand out: the chain it carries and the key that chain belongs to. `password` is `None` for
+    /// a bundle that carries no password, which is also how an empty one reads.
+    pub fn from_pkcs12(
+        cert_p12: impl AsRef<Path>,
+        password: Option<&secrecy::SecretString>,
+    ) -> Result<Self, ConfigError> {
+        let path = cert_p12.as_ref().display().to_string();
+        let data = std::fs::read(cert_p12.as_ref()).context(IoSnafu { path: path.clone() })?;
+        // An unprotected bundle is written with the empty password, so an absent option opens it.
+        let password = password.map_or("", |secret| secret.expose_secret());
+        // `Strict` rather than the lenient policies: a bundle whose chain cannot be rebuilt is a
+        // mistake to report, not one to paper over with a partial identity.
+        let keystore = p12_keystore::KeyStore::from_pkcs12(
+            &data,
+            password,
+            p12_keystore::Pkcs12ImportPolicy::Strict,
+        )
+        .context(Pkcs12Snafu { path: path.clone() })?;
+        let (_, chain) = keystore
+            .private_key_chain()
+            .context(EmptyPkcs12Snafu { path })?;
+
+        // The whole chain, in the leaf-first order `p12-keystore` rebuilds it in (the certificate
+        // the key names, then each issuer upward), which is the order rustls sends it in.
+        // Re-encoded into the DER shapes the PEM pair produces, so everything past this point sees
+        // one identity format.
+        let certs = chain
+            .certs()
+            .iter()
+            .map(|cert| CertificateDer::from(cert.as_der().to_vec()))
+            .collect();
+        let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(chain.key().as_der().to_vec()));
+
+        Ok(Self { certs, key })
+    }
 }
 
 /// TLS and mTLS: the client's own identity, the server's CA, and SSL verification behaviour.
@@ -95,7 +134,8 @@ pub struct TlsConfig {
     /// `authorize`, and their negatives. A `serde` source may also give a real boolean.
     pub allow_unsafe_connection: bool,
     /// TLS identity of the client, `None` for no client authentication. Read from
-    /// `CertPem`/`KeyPem`, whose files are loaded as the configuration is read.
+    /// `CertPem`/`KeyPem`, or from `CertP12`/`CertP12Password`, whose files are loaded as the
+    /// configuration is read.
     pub identity: Option<Identity>,
     /// The Certificate Authority the server is verified against, `None` for the system CAs. Read
     /// from `CaCertPath`, whose PEM file is loaded as the configuration is read.
@@ -133,8 +173,13 @@ pub(crate) struct RawTls {
 }
 
 /// The shapes the client's identity arrives in, selected untagged by which options the document
-/// names: a variant matches only when its own options are all present, and `Bare`, which
+/// names: every shape carries every identity option, and what tells them apart is which ones it
+/// requires. `Pkcs12` requires `CertP12`, `PemFiles` requires both PEM halves, and `Bare`, which
 /// requires none, is last, so a more specific shape always wins over it.
+///
+/// Carrying the other spelling's options rather than ignoring them is what lets [`Self::load`]
+/// reject the two spellings set at once, and what keeps a PEM pair readable next to a `CertP12`
+/// that is present but empty.
 ///
 /// Selection is on key presence alone, so a present-but-empty option still selects a shape;
 /// [`RawIdentity::load`] is what reads empty as unset, whichever shape matched.
@@ -151,6 +196,23 @@ pub(crate) struct RawTls {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 enum RawIdentity {
+    /// A certificate chain and its key bundled together in one PKCS#12 file.
+    #[serde(rename_all = "PascalCase")]
+    Pkcs12 {
+        /// Path to the PKCS#12 bundle; mutually exclusive with `CertPem`/`KeyPem`.
+        #[serde(deserialize_with = "crate::config_utils::text")]
+        cert_p12: String,
+        /// Password protecting `CertP12`, empty for none; rejected without `CertP12`.
+        #[serde(default, deserialize_with = "crate::config_utils::secret_text")]
+        #[cfg_attr(feature = "schema", schemars(with = "String"))]
+        cert_p12_password: secrecy::SecretString,
+        /// Path to the certificate chain file, in PEM format; set together with `KeyPem`.
+        #[serde(default, deserialize_with = "crate::config_utils::text")]
+        cert_pem: String,
+        /// Path to the key file, in PEM format; set together with `CertPem`.
+        #[serde(default, deserialize_with = "crate::config_utils::text")]
+        key_pem: String,
+    },
     /// A certificate chain and its key, each in its own PEM file.
     #[serde(rename_all = "PascalCase")]
     PemFiles {
@@ -160,10 +222,18 @@ enum RawIdentity {
         /// Path to the key file, in PEM format; set together with `CertPem`.
         #[serde(deserialize_with = "crate::config_utils::text")]
         key_pem: String,
+        /// Path to the PKCS#12 bundle; mutually exclusive with `CertPem`/`KeyPem`.
+        #[serde(default, deserialize_with = "crate::config_utils::text")]
+        cert_p12: String,
+        /// Password protecting `CertP12`, empty for none; rejected without `CertP12`.
+        #[serde(default, deserialize_with = "crate::config_utils::secret_text")]
+        #[cfg_attr(feature = "schema", schemars(with = "String"))]
+        cert_p12_password: secrecy::SecretString,
     },
-    /// Neither identity option set, or only one of them. Setting only one is refused when the
-    /// configuration is read, naming both options: this alternative admits it so the vocabulary
-    /// stays one list, and the reader is what decides a pair is a pair.
+    /// Neither identity option set, or an incomplete one: half a PEM pair, or a password naming no
+    /// bundle. Each is refused when the configuration is read, naming the options involved; this
+    /// alternative admits them so the vocabulary stays one list, and the reader is what decides
+    /// which combinations make an identity.
     #[serde(rename_all = "PascalCase")]
     Bare {
         /// Path to the certificate chain file, in PEM format; set together with `KeyPem`.
@@ -172,34 +242,81 @@ enum RawIdentity {
         /// Path to the key file, in PEM format; set together with `CertPem`.
         #[serde(default, deserialize_with = "crate::config_utils::text")]
         key_pem: String,
+        /// Path to the PKCS#12 bundle; mutually exclusive with `CertPem`/`KeyPem`.
+        #[serde(default, deserialize_with = "crate::config_utils::text")]
+        cert_p12: String,
+        /// Password protecting `CertP12`, empty for none; rejected without `CertP12`.
+        #[serde(default, deserialize_with = "crate::config_utils::secret_text")]
+        #[cfg_attr(feature = "schema", schemars(with = "String"))]
+        cert_p12_password: secrecy::SecretString,
     },
 }
 
 #[cfg(feature = "serde")]
 impl RawIdentity {
-    /// The loaded identity this shape names, `None` when every identity option is unset.
-    fn load(self) -> Result<Option<Identity>, ConfigError> {
+    /// The four identity options, whatever shape matched, so the rules below are stated once.
+    fn options(self) -> (String, String, String, secrecy::SecretString) {
         match self {
-            Self::PemFiles { cert_pem, key_pem } if !cert_pem.is_empty() && !key_pem.is_empty() => {
-                Identity::from_pem_files(cert_pem, key_pem).map(Some)
+            Self::Pkcs12 {
+                cert_p12,
+                cert_p12_password,
+                cert_pem,
+                key_pem,
             }
-            // An empty value is the option left unset, whatever shape the presence of its key
-            // selected.
-            Self::PemFiles { cert_pem, key_pem } | Self::Bare { cert_pem, key_pem } => {
-                if cert_pem.is_empty() && key_pem.is_empty() {
-                    Ok(None)
-                } else {
-                    // Half an identity is silent on a plain-TLS endpoint and only surfaces as a
-                    // rejected handshake on an mTLS one, so it is caught here, before either path
-                    // is opened.
-                    IncompatibleOptionsSnafu {
-                        msg: String::from(
-                            "`CertPem` and `KeyPem` must be either both empty or both set",
-                        ),
-                    }
-                    .fail()
-                }
+            | Self::PemFiles {
+                cert_pem,
+                key_pem,
+                cert_p12,
+                cert_p12_password,
             }
+            | Self::Bare {
+                cert_pem,
+                key_pem,
+                cert_p12,
+                cert_p12_password,
+            } => (cert_pem, key_pem, cert_p12, cert_p12_password),
+        }
+    }
+
+    /// The loaded identity this shape names, `None` when every identity option is unset. An empty
+    /// value is the option left unset, whatever shape the presence of its key selected.
+    fn load(self) -> Result<Option<Identity>, ConfigError> {
+        let (cert_pem, key_pem, cert_p12, cert_p12_password) = self.options();
+
+        // Both spellings of the identity at once is a contradiction to reject, not a preference to
+        // resolve silently.
+        snafu::ensure!(
+            cert_p12.is_empty() || (cert_pem.is_empty() && key_pem.is_empty()),
+            IncompatibleOptionsSnafu {
+                msg: String::from(
+                    "`CertP12` and `CertPem`/`KeyPem` name the client identity two different \
+                     ways; set only one",
+                ),
+            }
+        );
+        // A password naming no bundle is a typo somewhere; honouring half of it would hide it.
+        snafu::ensure!(
+            !cert_p12.is_empty() || cert_p12_password.expose_secret().is_empty(),
+            IncompatibleOptionsSnafu {
+                msg: String::from("`CertP12Password` is set without `CertP12`"),
+            }
+        );
+
+        if !cert_p12.is_empty() {
+            // The empty password and no password open the same bundle, so the two need no telling
+            // apart here.
+            return Identity::from_pkcs12(cert_p12, Some(&cert_p12_password)).map(Some);
+        }
+
+        match (cert_pem.is_empty(), key_pem.is_empty()) {
+            (true, true) => Ok(None),
+            (false, false) => Identity::from_pem_files(cert_pem, key_pem).map(Some),
+            // Half an identity is silent on a plain-TLS endpoint and only surfaces as a rejected
+            // handshake on an mTLS one, so it is caught here, before either path is opened.
+            _ => IncompatibleOptionsSnafu {
+                msg: String::from("`CertPem` and `KeyPem` must be either both empty or both set"),
+            }
+            .fail(),
         }
     }
 }
@@ -305,8 +422,8 @@ mod tests {
         Uri::try_from("http://localhost:5001").expect("a valid endpoint")
     }
 
-    /// A throwaway self-signed certificate, in PEM. Static because generating one would drag a
-    /// certificate-issuing dependency into the tests for material whose content never matters.
+    /// A throwaway self-signed certificate, in PEM. A constant rather than generated material:
+    /// these tests assert on the file's own bytes, and a constant is those bytes written out.
     const LEAF_CERT: &str = "-----BEGIN CERTIFICATE-----
 MIIBTDCB/6ADAgECAhRyMWWAJ+yfjk7RGKDLxakVhcQ0yTAFBgMrZXAwHDEaMBgG
 A1UEAwwRYXJtb25pay10ZXN0LWxlYWYwHhcNMjYwODA3MDAxMjE0WhcNMzYwODA0
@@ -337,10 +454,10 @@ MC4CAQAwBQYDK2VwBCIEIAKZ5vS5lxuHsHFDHPJmgDlI5D43nIUJ6Woni24zaHSM
 -----END PRIVATE KEY-----
 ";
 
-    /// A directory of PEM files for one test, removed on drop.
-    struct PemDir(PathBuf);
+    /// A directory of certificate fixtures for one test, removed on drop.
+    struct FixtureDir(PathBuf);
 
-    impl PemDir {
+    impl FixtureDir {
         fn new(name: &str) -> Self {
             let path =
                 std::env::temp_dir().join(format!("armonik-tls-{name}-{}", std::process::id()));
@@ -348,14 +465,14 @@ MC4CAQAwBQYDK2VwBCIEIAKZ5vS5lxuHsHFDHPJmgDlI5D43nIUJ6Woni24zaHSM
             Self(path)
         }
 
-        fn write(&self, name: &str, content: &str) -> PathBuf {
+        fn write(&self, name: &str, content: impl AsRef<[u8]>) -> PathBuf {
             let path = self.0.join(name);
             std::fs::write(&path, content).expect("write the fixture file");
             path
         }
     }
 
-    impl Drop for PemDir {
+    impl Drop for FixtureDir {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.0);
         }
@@ -365,8 +482,8 @@ MC4CAQAwBQYDK2VwBCIEIAKZ5vS5lxuHsHFDHPJmgDlI5D43nIUJ6Woni24zaHSM
     fn an_identity_is_loaded_with_its_whole_chain_in_file_order() {
         // `rustls` sends the chain as given and expects the leaf first, so the file's own order
         // has to survive loading.
-        let dir = PemDir::new("chain");
-        let cert = dir.write("cert.pem", &format!("{LEAF_CERT}{CHAIN_CERT}"));
+        let dir = FixtureDir::new("chain");
+        let cert = dir.write("cert.pem", format!("{LEAF_CERT}{CHAIN_CERT}"));
         let key = dir.write("key.pem", LEAF_KEY);
 
         let identity = Identity::from_pem_files(&cert, &key).expect("valid PEM files");
@@ -392,7 +509,7 @@ MC4CAQAwBQYDK2VwBCIEIAKZ5vS5lxuHsHFDHPJmgDlI5D43nIUJ6Woni24zaHSM
 
     #[test]
     fn a_missing_key_file_is_reported_with_its_own_path() {
-        let dir = PemDir::new("missing-key");
+        let dir = FixtureDir::new("missing-key");
         let cert = dir.write("cert.pem", LEAF_CERT);
 
         let error = Identity::from_pem_files(&cert, dir.0.join("no-key.pem"))
@@ -406,7 +523,7 @@ MC4CAQAwBQYDK2VwBCIEIAKZ5vS5lxuHsHFDHPJmgDlI5D43nIUJ6Woni24zaHSM
     fn a_certificate_file_with_no_certificate_is_rejected_with_the_path() {
         // Iterating an empty file yields an empty chain rather than an error, and `rustls` would
         // only refuse it at handshake time.
-        let dir = PemDir::new("empty");
+        let dir = FixtureDir::new("empty");
         let cert = dir.write("cert.pem", "not a certificate\n");
         let key = dir.write("key.pem", LEAF_KEY);
 
@@ -423,13 +540,195 @@ MC4CAQAwBQYDK2VwBCIEIAKZ5vS5lxuHsHFDHPJmgDlI5D43nIUJ6Woni24zaHSM
 
     #[test]
     fn an_identity_clone_carries_the_same_material() {
-        let dir = PemDir::new("clone");
+        let dir = FixtureDir::new("clone");
         let cert = dir.write("cert.pem", LEAF_CERT);
         let key = dir.write("key.pem", LEAF_KEY);
 
         let identity = Identity::from_pem_files(&cert, &key).expect("valid PEM files");
 
         assert_eq!(identity.clone(), identity);
+    }
+
+    // --- PKCS#12 ---
+
+    /// A CA-signed identity, generated fresh rather than committed so no fixture can expire: the
+    /// CA signs itself, and the leaf is signed by it. `p12-keystore` rebuilds a bundle's chain by
+    /// issuer, so only material that really signed the leaf proves the chain survives.
+    fn ca_signed_identity() -> (rcgen::Certificate, rcgen::KeyPair, rcgen::Certificate) {
+        let ca_key = rcgen::KeyPair::generate().expect("a CA key");
+        let mut ca_params = rcgen::CertificateParams::new(Vec::new()).expect("CA params");
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        ca_params
+            .distinguished_name
+            .push(rcgen::DnType::CommonName, "test ca");
+        let ca_cert = ca_params.self_signed(&ca_key).expect("a CA certificate");
+
+        let leaf_key = rcgen::KeyPair::generate().expect("a leaf key");
+        let leaf_params =
+            rcgen::CertificateParams::new(vec!["test".to_owned()]).expect("leaf params");
+        let issuer = rcgen::Issuer::new(ca_params, ca_key);
+        let leaf_cert = leaf_params
+            .signed_by(&leaf_key, &issuer)
+            .expect("a leaf certificate");
+
+        (leaf_cert, leaf_key, ca_cert)
+    }
+
+    /// A PKCS#12 bundle carrying `key` and `certs`, written with `p12-keystore`'s own writer.
+    fn p12_bundle(key: &rcgen::KeyPair, certs: &[&rcgen::Certificate], password: &str) -> Vec<u8> {
+        let chain = p12_keystore::PrivateKeyChain::new(
+            [1u8].as_slice(),
+            p12_keystore::PrivateKey::from_der(&key.serialize_der()).expect("a valid PKCS#8 key"),
+            certs.iter().map(|cert| {
+                p12_keystore::Certificate::from_der(cert.der().as_ref())
+                    .expect("a valid X.509 certificate")
+            }),
+        );
+        let mut keystore = p12_keystore::KeyStore::new();
+        keystore.add_entry(
+            "identity",
+            p12_keystore::KeyStoreEntry::PrivateKeyChain(chain),
+        );
+        keystore.writer(password).write().expect("write the bundle")
+    }
+
+    #[test]
+    fn a_p12_bundle_is_read_into_the_same_identity_a_pem_pair_would_be() {
+        let rcgen::CertifiedKey { cert, signing_key } =
+            rcgen::generate_simple_self_signed(["test".to_owned()]).expect("a self-signed cert");
+        let dir = FixtureDir::new("p12");
+        let path = dir.write("identity.p12", p12_bundle(&signing_key, &[&cert], "s3cr3t"));
+
+        let identity = Identity::from_pkcs12(&path, Some(&secrecy::SecretString::from("s3cr3t")))
+            .expect("a valid PKCS#12 bundle");
+
+        assert_eq!(identity.certs.len(), 1, "one certificate in, one out");
+        assert_eq!(identity.certs[0].as_ref(), cert.der().as_ref());
+        let PrivateKeyDer::Pkcs8(key) = &identity.key else {
+            panic!("expected the PKCS#8 variant, since that is what the bundle carried");
+        };
+        assert_eq!(key.secret_pkcs8_der(), signing_key.serialize_der());
+    }
+
+    #[test]
+    fn a_p12_bundle_keeps_its_intermediates_leaf_first() {
+        // A server that trusts only the root rebuilds its path through the intermediates the
+        // client sends; a load that kept only the leaf would fail that handshake.
+        let (leaf, leaf_key, ca) = ca_signed_identity();
+        let dir = FixtureDir::new("p12-chain");
+        let path = dir.write(
+            "identity.p12",
+            p12_bundle(&leaf_key, &[&leaf, &ca], "s3cr3t"),
+        );
+
+        let identity = Identity::from_pkcs12(&path, Some(&secrecy::SecretString::from("s3cr3t")))
+            .expect("a valid PKCS#12 bundle");
+
+        let ders: Vec<&[u8]> = identity.certs.iter().map(AsRef::as_ref).collect();
+        assert_eq!(
+            ders,
+            vec![leaf.der().as_ref(), ca.der().as_ref()],
+            "the whole chain survives, leaf first"
+        );
+    }
+
+    #[test]
+    fn no_password_opens_a_bundle_protected_by_the_empty_one() {
+        // The empty password is what an "unprotected" PKCS#12 bundle is actually written with, so
+        // an absent option has to open it.
+        let rcgen::CertifiedKey { cert, signing_key } =
+            rcgen::generate_simple_self_signed(["test".to_owned()]).expect("a self-signed cert");
+        let dir = FixtureDir::new("p12-nopass");
+        let path = dir.write("identity.p12", p12_bundle(&signing_key, &[&cert], ""));
+
+        Identity::from_pkcs12(&path, None).expect("an unprotected bundle needs no password");
+    }
+
+    #[test]
+    fn a_wrong_p12_password_is_reported_with_the_path() {
+        // The path, not the password: whoever reads the error must learn which file refused to
+        // open, and nothing about what was tried.
+        let rcgen::CertifiedKey { cert, signing_key } =
+            rcgen::generate_simple_self_signed(["test".to_owned()]).expect("a self-signed cert");
+        let dir = FixtureDir::new("p12-refused");
+        let path = dir.write("identity.p12", p12_bundle(&signing_key, &[&cert], "s3cr3t"));
+
+        let error = Identity::from_pkcs12(&path, Some(&secrecy::SecretString::from("hunter2")))
+            .expect_err("the wrong password must be rejected");
+
+        assert!(matches!(error, ConfigError::Pkcs12 { .. }), "{error:?}");
+        let rendered = chain(&error);
+        assert!(rendered.contains("identity.p12"), "{rendered}");
+        assert!(!rendered.contains("hunter2"), "{rendered}");
+    }
+
+    #[test]
+    fn a_p12_bundle_with_no_identity_is_rejected_as_empty() {
+        // A bundle can be perfectly valid PKCS#12 and still carry no private key chain, which is
+        // its own story: nothing is malformed, there is just no identity inside.
+        let dir = FixtureDir::new("p12-empty");
+        let path = dir.write(
+            "identity.p12",
+            p12_keystore::KeyStore::new()
+                .writer("s3cr3t")
+                .write()
+                .expect("write the bundle"),
+        );
+
+        let error = Identity::from_pkcs12(&path, Some(&secrecy::SecretString::from("s3cr3t")))
+            .expect_err("an identity-less bundle must be rejected");
+
+        assert!(
+            matches!(error, ConfigError::EmptyPkcs12 { .. }),
+            "{error:?}"
+        );
+        assert!(chain(&error).contains("identity.p12"), "{}", chain(&error));
+    }
+
+    #[test]
+    fn a_file_that_is_not_pkcs12_is_rejected_as_such() {
+        let dir = FixtureDir::new("p12-garbage");
+        let path = dir.write("identity.p12", "clearly not a pkcs12 bundle");
+
+        let error = Identity::from_pkcs12(&path, None).expect_err("garbage is not a bundle");
+
+        assert!(matches!(error, ConfigError::Pkcs12 { .. }), "{error:?}");
+    }
+
+    #[test]
+    fn a_p12_path_that_does_not_exist_is_reported_with_the_path() {
+        let error = Identity::from_pkcs12("no/such/identity.p12", None)
+            .expect_err("a missing file must be reported");
+
+        assert!(matches!(error, ConfigError::Io { .. }), "{error:?}");
+        assert!(
+            chain(&error).contains("no/such/identity.p12"),
+            "{}",
+            chain(&error)
+        );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn the_cert_p12_option_loads_the_bundle_it_names() {
+        // The whole path a deployment takes, from the option to the loaded chain: `config.rs`
+        // covers which combinations are legal, this covers that the legal one reads the file.
+        let (leaf, leaf_key, ca) = ca_signed_identity();
+        let dir = FixtureDir::new("p12-option");
+        let path = dir.write(
+            "identity.p12",
+            p12_bundle(&leaf_key, &[&leaf, &ca], "s3cr3t"),
+        );
+
+        let config: TlsConfig = serde_json::from_value(serde_json::json!({
+            "CertP12": path.display().to_string(),
+            "CertP12Password": "s3cr3t",
+        }))
+        .expect("a valid configuration");
+
+        let identity = config.identity.expect("an identity was configured");
+        let ders: Vec<&[u8]> = identity.certs.iter().map(AsRef::as_ref).collect();
+        assert_eq!(ders, vec![leaf.der().as_ref(), ca.der().as_ref()]);
     }
 
     #[cfg(feature = "serde")]
@@ -448,7 +747,7 @@ MC4CAQAwBQYDK2VwBCIEIAKZ5vS5lxuHsHFDHPJmgDlI5D43nIUJ6Woni24zaHSM
     #[cfg(feature = "serde")]
     #[test]
     fn a_ca_certificate_is_loaded_while_the_configuration_is_read() {
-        let dir = PemDir::new("ca");
+        let dir = FixtureDir::new("ca");
         let ca = dir.write("ca.pem", LEAF_CERT);
 
         let config = serde_json::from_value::<TlsConfig>(serde_json::json!({

--- a/packages/rust/armonik-transport/tests/schema.rs
+++ b/packages/rust/armonik-transport/tests/schema.rs
@@ -73,6 +73,8 @@ fn every_option_appears_under_its_flat_name() {
         "CertPem",
         "KeyPem",
         "CaCertPath",
+        "CertP12",
+        "CertP12Password",
         "AllowUnsafeConnection",
         "OverrideTargetName",
         "ConnectTimeout",
@@ -96,12 +98,12 @@ fn every_option_appears_under_its_flat_name() {
 fn the_schema_promises_nothing_that_is_not_read() {
     // A consumer generates its options class from this, so an option the schema declares and
     // deserialisation ignores is a field that silently does nothing. The proxy is set
-    // programmatically and no option reads it; the PKCS#12 identity is not an option at all.
+    // programmatically and no option reads it.
     let schema = schema();
     let mut names = Vec::new();
     property_names(&schema, &mut names);
 
-    for absent in ["ProxyAddress", "ProxyUsername", "ProxyPassword", "CertP12"] {
+    for absent in ["ProxyAddress", "ProxyUsername", "ProxyPassword"] {
         assert!(
             !names.iter().any(|name| name == absent),
             "`{absent}` is not read"
@@ -134,24 +136,49 @@ fn the_prefixed_groups_keep_their_flat_spellings() {
     }
 }
 
+/// The property names one alternative of an `anyOf` requires.
+fn required_names(alternative: &serde_json::Value) -> Vec<String> {
+    alternative
+        .get("required")
+        .and_then(serde_json::Value::as_array)
+        .map(|names| {
+            names
+                .iter()
+                .filter_map(|name| name.as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 #[test]
 fn the_identity_alternatives_are_an_any_of() {
-    // The identity comes as both PEM halves or not at all: the schema has to spell the
-    // alternatives rather than flatten them into one bag of optional fields.
+    // The identity comes as both PEM halves, as a PKCS#12 bundle, or not at all: the schema has to
+    // spell the alternatives rather than flatten them into one bag of optional fields. Each shape
+    // declares every identity option, since that is how deserialisation catches the two spellings
+    // set at once, so what tells the shapes apart there and here alike is which ones they require.
     let schema = schema();
     let mut found = Vec::new();
     any_ofs(&schema, &mut found);
 
     let identity = found.iter().find(|alternatives| {
-        alternatives.iter().any(|alternative| {
+        let pem = alternatives.iter().any(|alternative| {
+            let required = required_names(alternative);
+            required.iter().any(|name| name == "CertPem")
+                && required.iter().any(|name| name == "KeyPem")
+        });
+        let bundle = alternatives.iter().any(|alternative| {
+            let required = required_names(alternative);
             let mut names = Vec::new();
             property_names(alternative, &mut names);
-            names.iter().any(|name| name == "CertPem") && names.iter().any(|name| name == "KeyPem")
-        })
+            required.iter().any(|name| name == "CertP12")
+                && !required.iter().any(|name| name == "CertPem")
+                && names.iter().any(|name| name == "CertP12Password")
+        });
+        pem && bundle
     });
     assert!(
         identity.is_some(),
-        "no anyOf alternative declares CertPem and KeyPem: {schema:#}"
+        "no anyOf spells the PEM pair and the PKCS#12 bundle as alternatives: {schema:#}"
     );
 }
 


### PR DESCRIPTION
Lets the client's mTLS identity come from a PKCS#12 bundle instead of a PEM certificate/key pair.
`CertP12` names a certificate and its key bundled together, the form Windows and most certificate
authorities hand out, optionally protected by `CertP12Password`. It is an alternative to
`CertPem`/`KeyPem`, not an addition: setting both spellings is refused while the configuration is
read, as is a password naming no bundle.

## How it works

The bundle is loaded through `p12-keystore` (pure Rust, so no OpenSSL joins the build) under
`Pkcs12ImportPolicy::Strict`, and its whole chain is kept leaf first, re-encoded into the DER
shapes the PEM pair already produces, so a server that trusts only the root can still build its
path and nothing past `Identity` sees two identity formats. Loading happens while the configuration
is read, like every other file-naming option, so a mistyped path fails where the error can name the
option rather than surfacing later as a refused handshake.

`CertP12Password` is a `SecretString`: redacted by `Debug`, zeroized on drop, and never echoed in
an error. It deserialises through a `secret_text` reader added to `config_utils`, naming no option
of its own. The proxy-options PR adds the same reader; whichever lands second drops its copy.

`RawIdentity` gains a `Pkcs12` shape, first so it wins over the PEM one and ahead of `Bare`, which
requires nothing and so stays last. Every shape carries every identity option and differs only in
which it requires: that is what lets `load` see both spellings at once, and what keeps a PEM pair
readable next to a `CertP12` that is present but empty. The generated schema spells the same
distinction, as an `anyOf` whose branches differ by `required`; `tests/schema.rs` pins both new
option names and the bundle branch, in place of the assertion that `CertP12` is absent.

## C# parity

Worth knowing before this merges: the C# client declares `CertP12`
(`packages/csharp/ArmoniK.Api.Client/Options/GrpcClient.cs:62`) but has **no** `CertP12Password` -
`GrpcChannelFactory.cs:536` opens the file with `new X509Certificate2(path)`, and no spelling of a
p12 password exists anywhere under `packages/csharp/`. So `CertP12Password` is a name only the Rust
client knows, and a password-protected bundle is not portable to C#. The alternative is to refuse
password-protected bundles instead, keeping the vocabularies identical; this PR takes the first
road and documents the divergence in `armonik-transport/README.md`.

## Tests

13 new tests. The PKCS#12 material: a bundle round-tripping into the same identity a PEM pair
produces, a CA-signed chain keeping its intermediates leaf first, an unprotected bundle opening
without a password, a wrong password naming the path and not itself, an identity-less bundle, a
file that is not PKCS#12, a path that leads nowhere, and the `CertP12` option reading the file it
names. The option rules: mutual exclusion in all three combinations, an orphan password not echoed,
empty options reading as unset, an empty `CertP12` leaving the PEM pair alone, and a bundle path
that leads nowhere failing while the configuration is read. Fixtures are generated with `rcgen`
rather than committed, so nothing can expire, and because `p12-keystore` rebuilds a bundle's chain
by issuer, proving the intermediates survive needs material that really signed the leaf.

## Gates

From `packages/rust`, all green:

```
cargo test -p armonik-transport --all-features                  69 + 13 + 5 + 6 passed
cargo clippy -p armonik-transport --all-features --all-targets  0 warnings
cargo clippy -p armonik --all-features --all-targets            0 warnings
cargo check -p armonik-transport --no-default-features          0 warnings
cargo fmt --check                                               clean
cargo run -p armonik-transport --features schema --example generate_schema
```
