### PR TITLE
feat(rust): read the configuration from the environment under a prefix

### DIFF
--- a/packages/rust/armonik-transport/Cargo.toml
+++ b/packages/rust/armonik-transport/Cargo.toml
@@ -19,6 +19,9 @@ serde = [
   "dep:serde_with",
   "dep:serde_path_to_error",
 ]
+# Reading the options from environment variables, under a prefix the caller chooses. `serde`
+# because that is what does the reading; the feature adds no dependency of its own.
+env = ["serde"]
 # A JSON schema of the option vocabulary, for generating an options class in another language.
 # `serde_json` because the prefix helper rewrites the generated schema's property names, and a
 # schemars 1.x schema is edited as the JSON value it wraps.

--- a/packages/rust/armonik-transport/README.md
+++ b/packages/rust/armonik-transport/README.md
@@ -7,6 +7,18 @@ Depend on it when you need the connection layer without generated protobuf types
 `protoc`/`tonic-prost-build` build step. [`armonik`](../armonik) re-exports all of it, so a client that
 wants the services as well needs only that one.
 
+## Reading the options from the environment
+
+The `env` feature adds `HttpConfig::from_env(prefix)`: one variable per option, named `prefix` plus
+the option's own PascalCase spelling, with the prefix entirely the caller's to choose. An absent
+variable and one declared empty both read as the option's default. A value an option refuses is
+reported as the variable to go and fix, `prefix` included; an option belonging to one of the
+grouped units (`Tcp*`, `Http2*`, and the TLS options) is named by the unit instead, without the
+prefix. `armonik` sets the prefix ArmoniK deployments use, `GrpcClient__`.
+
+`HttpConfig::from_env_vars(prefix, variables)` reads the same options out of any set of variables,
+for a caller holding an environment other than its own process's.
+
 ## Describing the options to another language
 
 The `schema` feature derives a JSON schema of the flat PascalCase option vocabulary (`Endpoint`,

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -5,8 +5,11 @@
 //! (`Endpoint`, `TcpKeepalive`, `Http2KeepAliveInterval`, ...), the same vocabulary every ArmoniK
 //! client reads; the thematic groups ([`TlsConfig`], [`TcpConfig`], [`Http2Config`],
 //! [`RetryConfig`]) flatten back into those names, so grouping the fields changes no option a
-//! deployment already sets. The `schema` feature describes that same vocabulary as a JSON schema,
-//! derived from the types that define it rather than written out a second time.
+//! deployment already sets.
+//!
+//! The `schema` feature describes that same vocabulary as a JSON schema, derived from the types
+//! that define it rather than written out a second time, and the `env` feature reads it from
+//! environment variables under a prefix the caller chooses.
 
 use std::time::Duration;
 

--- a/packages/rust/armonik-transport/src/env.rs
+++ b/packages/rust/armonik-transport/src/env.rs
@@ -1,0 +1,273 @@
+//! Reading an [`HttpConfig`] from environment variables, under a prefix the caller chooses.
+//!
+//! The prefix is the only thing a caller decides: [`HttpConfig`]'s own `PascalCase` option names
+//! spell the rest of each variable. Which prefix a deployment sets is that deployment's
+//! vocabulary, not this crate's, so no prefix is named here and nothing calls this on its own.
+//!
+//! Every value reaches `serde` as the raw text the variable holds, and each option's own reader
+//! interprets it. So nothing guesses a type on the way in, and a value that happens to look like a
+//! number or a list arrives byte for byte.
+
+use serde::de::value::MapDeserializer;
+use serde::Deserialize as _;
+use snafu::{IntoError as _, Snafu};
+
+use crate::HttpConfig;
+
+impl HttpConfig {
+    /// Read every option from the process environment, under `prefix`.
+    pub fn from_env(prefix: &str) -> Result<Self, EnvError> {
+        Self::from_env_vars(prefix, std::env::vars_os())
+    }
+
+    /// [`HttpConfig::from_env`] over any set of variables, for a caller holding an environment it
+    /// did not get from its own process: a container specification it is about to submit, or a
+    /// test that must leave the one every other test shares alone.
+    pub fn from_env_vars(
+        prefix: &str,
+        variables: impl IntoIterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
+    ) -> Result<Self, EnvError> {
+        // A name is decoded lossily, because the plain `vars` iterator panics on any non-Unicode
+        // variable in the process, even one naming no option here, and a mangled name just fails
+        // to match the prefix. A value is not: it is the option's content, and a byte replaced by
+        // U+FFFD would name a different file or a different password, failing later and elsewhere.
+        //
+        // The prefix is matched exactly. Windows resolves variable names case-insensitively, so a
+        // differently cased spelling reaches the same variable there and no option here; one
+        // spelling reads the same on every platform.
+        let mut read = Vec::new();
+        for (name, value) in variables {
+            let name = name.to_string_lossy();
+            let Some(option) = name.strip_prefix(prefix) else {
+                continue;
+            };
+            let Some(value) = value.to_str() else {
+                return NotUnicodeSnafu {
+                    variable: format!("{prefix}{option}"),
+                }
+                .fail();
+            };
+            read.push((option.to_owned(), value.to_owned()));
+        }
+        let options = read.into_iter();
+
+        let mut track = serde_path_to_error::Track::new();
+        let tracked =
+            serde_path_to_error::Deserializer::new(MapDeserializer::new(options), &mut track);
+        Self::deserialize(tracked).map_err(|source| {
+            let path = track.path().to_string();
+            // An option behind `#[serde(flatten)]` is buffered before its reader sees it, so the
+            // tracker here is handed the whole unit and has no key to offer. The unit's own
+            // tracker has already written the option name into the message.
+            if path.is_empty() || path == "." {
+                ReadSnafu.into_error(source)
+            } else {
+                VariableSnafu {
+                    variable: format!("{prefix}{path}"),
+                }
+                .into_error(source)
+            }
+        })
+    }
+}
+
+/// Reading an [`HttpConfig`] from the environment failed.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum EnvError {
+    /// A refusal `serde` can attribute to one key, named with the caller's prefix so the message
+    /// is the variable to go and fix.
+    #[snafu(display("`{variable}`: {source} [{location}]"))]
+    #[non_exhaustive]
+    Variable {
+        variable: String,
+        #[snafu(source(from(serde::de::value::Error, Box::new)))]
+        source: Box<serde::de::value::Error>,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// A value the OS accepts and Unicode does not. Refused rather than decoded lossily: a byte
+    /// replaced by U+FFFD would name a different file, or authenticate as a different secret.
+    #[snafu(display("`{variable}` is not valid Unicode [{location}]"))]
+    #[non_exhaustive]
+    NotUnicode {
+        variable: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// A refusal no single key accounts for, whose message names what it is about itself.
+    #[snafu(display("{source} [{location}]"))]
+    #[non_exhaustive]
+    Read {
+        #[snafu(source(from(serde::de::value::Error, Box::new)))]
+        source: Box<serde::de::value::Error>,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+    use std::time::Duration;
+
+    use super::*;
+
+    /// The variables a process would hold, as [`HttpConfig::from_env_vars`] receives them.
+    fn variables<const N: usize>(pairs: [(&str, &str); N]) -> [(OsString, OsString); N] {
+        pairs.map(|(name, value)| (name.into(), value.into()))
+    }
+
+    #[test]
+    fn a_value_that_is_not_unicode_is_refused_rather_than_rewritten() {
+        // A lossy decode would put U+FFFD inside the path, so the option would name a file the
+        // deployment never wrote, and the failure would come from somewhere that cannot say why.
+        let error = HttpConfig::from_env_vars(
+            "GrpcClient__",
+            [
+                (
+                    OsString::from("GrpcClient__Endpoint"),
+                    OsString::from("http://localhost:5001"),
+                ),
+                (OsString::from("GrpcClient__CertPem"), not_unicode()),
+            ],
+        )
+        .expect_err("a non-Unicode value must be refused");
+
+        let rendered = error.to_string();
+        assert!(rendered.contains("GrpcClient__CertPem"), "{rendered}");
+        assert!(!rendered.contains('\u{FFFD}'), "{rendered}");
+    }
+
+    #[test]
+    fn the_prefix_is_the_callers_own_and_a_variable_outside_it_names_no_option() {
+        // Two deployments reading the same option under prefixes of their own is the whole point
+        // of taking one: neither may see the other's variable.
+        let config = HttpConfig::from_env_vars(
+            "First__",
+            variables([
+                ("First__Endpoint", "http://first:5001"),
+                ("Second__Endpoint", "http://second:5001"),
+                ("Endpoint", "http://bare:5001"),
+            ]),
+        )
+        .expect("a valid configuration");
+
+        assert_eq!(config.endpoint.host(), Some("first"));
+    }
+
+    #[test]
+    fn an_option_that_cannot_be_read_names_the_variable_to_go_and_fix() {
+        // The value alone leaves a reader hunting through a deployment for whichever of eight
+        // duration options is mistyped; the name has to carry the prefix to be that variable.
+        let rendered = HttpConfig::from_env_vars(
+            "Prefix__",
+            variables([
+                ("Prefix__Timeout", "soon"),
+                ("Prefix__Endpoint", "http://h"),
+            ]),
+        )
+        .expect_err("`soon` is not a duration")
+        .to_string();
+
+        assert!(rendered.contains("`Prefix__Timeout`"), "{rendered}");
+        assert!(rendered.contains("soon"), "{rendered}");
+    }
+
+    #[test]
+    fn a_flattened_option_is_named_by_its_own_unit_and_not_twice() {
+        // `#[serde(flatten)]` buffers the unit's keys where a path tracker cannot follow, so this
+        // reader has no key and contributes no name. The unit's own tracker supplies it, which
+        // costs the prefix: the message names the option rather than the variable.
+        let rendered =
+            HttpConfig::from_env_vars("Prefix__", variables([("Prefix__TcpKeepalive", "soon")]))
+                .expect_err("`soon` is not a duration")
+                .to_string();
+
+        assert!(rendered.contains("`TcpKeepalive`"), "{rendered}");
+        assert_eq!(
+            rendered.matches("TcpKeepalive").count(),
+            1,
+            "named once, by the unit alone: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Prefix__TcpKeepalive"),
+            "the variable's own name is out of reach here: {rendered}"
+        );
+    }
+
+    #[test]
+    fn a_value_reaches_its_option_as_the_text_the_variable_holds() {
+        // A source that ran values through a grammar of its own would read `[::1]` as a list and
+        // `1.0` as a float, whose default rendering is `1`. Both are values a deployment writes.
+        let config = HttpConfig::from_env_vars(
+            "Prefix__",
+            variables([
+                ("Prefix__OverrideTargetName", "[::1]"),
+                ("Prefix__UserAgent", "1.0"),
+            ]),
+        )
+        .expect("a valid configuration");
+
+        assert_eq!(config.tls.override_target_name.as_deref(), Some("[::1]"));
+        assert_eq!(
+            config.user_agent,
+            Some(hyper::http::HeaderValue::from_static("1.0"))
+        );
+    }
+
+    #[test]
+    fn a_variable_declared_empty_reads_as_the_option_default_like_an_absent_one() {
+        // A deployment that declares every variable with an empty default has to behave exactly
+        // like one that declares none.
+        let declared = HttpConfig::from_env_vars(
+            "Prefix__",
+            variables([
+                ("Prefix__Endpoint", ""),
+                ("Prefix__Timeout", ""),
+                ("Prefix__TcpKeepalive", ""),
+                ("Prefix__CertPem", ""),
+            ]),
+        )
+        .expect("an empty variable must not fail the read");
+        let absent = HttpConfig::from_env_vars("Prefix__", variables([]))
+            .expect("an absent variable must not fail the read");
+
+        for config in [&declared, &absent] {
+            assert_eq!(config.endpoint, hyper::Uri::default());
+            assert_eq!(config.timeout, None);
+            assert_eq!(config.tcp.keepalive, None);
+            assert_eq!(config.tls.identity, None);
+        }
+    }
+
+    #[test]
+    fn a_variable_that_is_not_unicode_does_not_bring_the_read_down() {
+        // `std::env::vars` panics on one of these, wherever in the process it came from, so the
+        // read goes through `OsString` and decodes lossily instead.
+        let config = HttpConfig::from_env_vars(
+            "Prefix__",
+            [
+                (OsString::from("Prefix__Timeout"), OsString::from("30s")),
+                (not_unicode(), OsString::from("whatever")),
+            ],
+        )
+        .expect("a non-Unicode variable names no option and must not fail the read");
+
+        assert_eq!(config.timeout, Some(Duration::from_secs(30)));
+    }
+
+    /// A byte sequence the OS accepts and Unicode does not, for a name or a value alike.
+    #[cfg(windows)]
+    fn not_unicode() -> OsString {
+        use std::os::windows::ffi::OsStringExt as _;
+        // An unpaired surrogate: representable in a Windows environment block, not in a `str`.
+        OsString::from_wide(&[0xD800, 0x0041])
+    }
+
+    #[cfg(not(windows))]
+    fn not_unicode() -> OsString {
+        use std::os::unix::ffi::OsStringExt as _;
+        OsString::from_vec(vec![0xFF, 0x41])
+    }
+}

--- a/packages/rust/armonik-transport/src/lib.rs
+++ b/packages/rust/armonik-transport/src/lib.rs
@@ -7,6 +7,8 @@
 mod config;
 mod config_utils;
 mod connect;
+#[cfg(feature = "env")]
+mod env;
 mod http2_config;
 mod proxy;
 mod retry_config;
@@ -16,6 +18,8 @@ mod utils;
 
 pub use config::{ConfigError, HttpConfig};
 pub use connect::{connect, https_connector, ConnectionError};
+#[cfg(feature = "env")]
+pub use env::EnvError;
 pub use http2_config::Http2Config;
 pub use proxy::{ProxyConfig, ProxyError, ProxySource};
 pub use retry_config::RetryConfig;

--- a/packages/rust/armonik/Cargo.toml
+++ b/packages/rust/armonik/Cargo.toml
@@ -19,8 +19,8 @@ client = ["_gen-client"]
 server = ["_gen-server"]
 agent = ["_gen-client", "_gen-server"]
 worker = ["_gen-client", "_gen-server"]
-# `armonik-transport/serde` so `Client::new()` can deserialise the `GrpcClient__*` variables.
-_gen-client = ["tonic/channel", "dep:armonik-transport", "armonik-transport/serde"]
+# `armonik-transport/env` so `Client::new()` can read the `GrpcClient__*` variables.
+_gen-client = ["tonic/channel", "dep:armonik-transport", "armonik-transport/env"]
 _gen-server = ["tonic/server", "tonic/router", "dep:tokio"]
 
 [dependencies]

--- a/packages/rust/armonik/src/client/env.rs
+++ b/packages/rust/armonik/src/client/env.rs
@@ -1,11 +1,9 @@
 //! ArmoniK's own environment vocabulary: `GrpcClient__*`.
 //!
-//! A deliberately small reader: every `GrpcClient__*` variable is handed to serde as the raw text
-//! it holds, and `armonik-transport`'s option readers do the interpreting. Reading the
-//! environment is integration work, ArmoniK's own vocabulary, so it lives in this crate rather
-//! than in the transport.
+//! The prefix is all this crate contributes. `armonik-transport` reads the options under whichever
+//! prefix it is given; naming that prefix is integration work, ArmoniK's own vocabulary, so it
+//! lives here rather than in the transport.
 
-use armonik_transport::reexports::serde;
 use snafu::ResultExt;
 
 use super::{ConnectionError, HttpConfig};
@@ -18,40 +16,12 @@ pub(super) fn config_from_env() -> Result<HttpConfig, NewClientError> {
     config_from(std::env::vars_os())
 }
 
-/// [`config_from_env`] over any set of variables, so the prefix rule and the decoding can be
-/// exercised without mutating the process environment, which every other test shares.
+/// [`config_from_env`] over any set of variables, so the prefix rule can be exercised without
+/// mutating the process environment, which every other test shares.
 fn config_from(
-    variables: impl Iterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
+    variables: impl IntoIterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
 ) -> Result<HttpConfig, NewClientError> {
-    use serde::Deserialize as _;
-
-    // Raw text, verbatim: each option's own reader parses what it needs, so nothing guesses a
-    // type here and a numeric-looking password survives byte for byte.
-    //
-    // A name is decoded lossily, because the plain `vars` iterator panics on any non-Unicode
-    // variable in the process, even one naming no option here, and a mangled name just fails to
-    // match the prefix. A value is not: it is the option's content, and a byte replaced by U+FFFD
-    // would name a different file or a different password, which fails later and somewhere else.
-    //
-    // The prefix is matched exactly. Windows resolves variable names case-insensitively, so
-    // `GRPCCLIENT__ENDPOINT` reaches the same variable there and no option here; the spelling
-    // every ArmoniK client documents is the one that is read, on every platform alike.
-    let mut options = Vec::new();
-    for (name, value) in variables {
-        let name = name.to_string_lossy();
-        let Some(option) = name.strip_prefix(ARMONIK_PREFIX) else {
-            continue;
-        };
-        let Some(value) = value.to_str() else {
-            return NotUnicodeSnafu {
-                option: format!("{ARMONIK_PREFIX}{option}"),
-            }
-            .fail();
-        };
-        options.push((option.to_owned(), value.to_owned()));
-    }
-    HttpConfig::deserialize(serde::de::value::MapDeserializer::new(options.into_iter()))
-        .context(EnvSnafu)
+    HttpConfig::from_env_vars(ARMONIK_PREFIX, variables).context(EnvSnafu)
 }
 
 /// Creating a client from the environment.
@@ -62,15 +32,8 @@ pub enum NewClientError {
     #[snafu(display("Could not read the client configuration from the environment [{location}]"))]
     #[non_exhaustive]
     Env {
-        #[snafu(source(from(serde::de::value::Error, Box::new)))]
-        source: Box<serde::de::value::Error>,
-        #[snafu(implicit)]
-        location: snafu::Location,
-    },
-    #[snafu(display("`{option}` is not valid Unicode [{location}]"))]
-    #[non_exhaustive]
-    NotUnicode {
-        option: String,
+        #[snafu(source(from(armonik_transport::EnvError, Box::new)))]
+        source: Box<armonik_transport::EnvError>,
         #[snafu(implicit)]
         location: snafu::Location,
     },
@@ -150,90 +113,18 @@ mod tests {
     }
 
     #[test]
-    fn an_option_that_cannot_be_read_reports_the_value_it_was_given() {
+    fn an_option_that_cannot_be_read_names_the_variable_it_came_from() {
         let error = config_from(variables([
             ("GrpcClient__Endpoint", "http://localhost:5001"),
             ("GrpcClient__Timeout", "soon"),
         ]))
         .expect_err("`soon` is not a duration");
 
-        // The value and what was expected of it, but not the variable it came from: a plain
-        // `MapDeserializer` keeps no path, so the key is gone by the time a reader rejects the
-        // value. Wrapping the read in a path tracker is what puts the name back.
+        // The full variable, so the message is the line of the deployment to go and fix rather
+        // than a value to hunt for: eight options share the duration reader.
         let rendered = chain(&error);
+        assert!(rendered.contains("`GrpcClient__Timeout`"), "{rendered}");
         assert!(rendered.contains("soon"), "{rendered}");
         assert!(rendered.contains("duration"), "{rendered}");
-    }
-
-    #[test]
-    fn a_non_unicode_value_is_refused_rather_than_rewritten() {
-        // Lossy decoding would put U+FFFD inside a path or a password, so the option would name a
-        // different file, or authenticate as a different secret, and fail somewhere that cannot
-        // say why.
-        let error = config_from(
-            [
-                (
-                    std::ffi::OsString::from("GrpcClient__Endpoint"),
-                    std::ffi::OsString::from("http://localhost:5001"),
-                ),
-                (
-                    std::ffi::OsString::from("GrpcClient__CertPem"),
-                    lossy_value(),
-                ),
-            ]
-            .into_iter(),
-        )
-        .expect_err("a non-Unicode value must be refused");
-
-        let rendered = chain(&error);
-        assert!(rendered.contains("GrpcClient__CertPem"), "{rendered}");
-        assert!(!rendered.contains('\u{FFFD}'), "{rendered}");
-    }
-
-    #[test]
-    fn a_variable_that_is_not_unicode_does_not_bring_the_read_down() {
-        // `std::env::vars` panics on one of these, wherever in the process it came from, so the
-        // read goes through `OsString` and decodes lossily instead.
-        let odd = lossy_name();
-        let config = config_from(
-            [
-                (
-                    std::ffi::OsString::from("GrpcClient__Endpoint"),
-                    std::ffi::OsString::from("http://localhost:5001"),
-                ),
-                (odd, std::ffi::OsString::from("whatever")),
-            ]
-            .into_iter(),
-        )
-        .expect("a non-Unicode variable names no option and must not fail the read");
-
-        assert_eq!(config.endpoint.host(), Some("localhost"));
-    }
-
-    /// A variable value that is not valid Unicode, built the way each platform allows.
-    #[cfg(windows)]
-    fn lossy_value() -> std::ffi::OsString {
-        use std::os::windows::ffi::OsStringExt as _;
-        std::ffi::OsString::from_wide(&[0x0063, 0xD800, 0x002E, 0x0070, 0x0065, 0x006D])
-    }
-
-    #[cfg(not(windows))]
-    fn lossy_value() -> std::ffi::OsString {
-        use std::os::unix::ffi::OsStringExt as _;
-        std::ffi::OsString::from_vec(vec![0x63, 0xFF, 0x2E, 0x70, 0x65, 0x6D])
-    }
-
-    /// A variable name that is not valid Unicode, built the way each platform allows.
-    #[cfg(windows)]
-    fn lossy_name() -> std::ffi::OsString {
-        use std::os::windows::ffi::OsStringExt as _;
-        // An unpaired surrogate: representable in a Windows environment block, not in a `str`.
-        std::ffi::OsString::from_wide(&[0xD800, 0x0041])
-    }
-
-    #[cfg(not(windows))]
-    fn lossy_name() -> std::ffi::OsString {
-        use std::os::unix::ffi::OsStringExt as _;
-        std::ffi::OsString::from_vec(vec![0xFF, 0x41])
     }
 }


### PR DESCRIPTION
## What

`armonik-transport` gains an `env` feature: `HttpConfig::from_env(prefix)` reads every option from
one environment variable each, named `prefix` plus the option's own PascalCase spelling. The prefix
is entirely the caller's: `GrpcClient__` is ArmoniK's vocabulary, so it stays in `armonik`, which now
contributes the prefix and nothing else. `HttpConfig::from_env_vars(prefix, variables)` reads the
same options out of any set of variables, for a caller holding an environment other than its own
process's, and for tests, which must not mutate the one every other test in the process shares.

## Why

A value a reader refused named the value but not the variable it came from: a plain
`MapDeserializer` keeps no path, so the key is gone by the time the value is refused. Eight options
share the duration reader, so that message left a reader hunting through a deployment. Wrapping the
extraction in `serde_path_to_error` puts the name back. `GrpcClient__Timeout=soon`, under the same
outer "Could not read the client configuration from the environment":

```
before  -> `soon` is not a valid duration (e.g. `30s` or `1m`): expected number at 0
after   -> `GrpcClient__Timeout`: `soon` is not a valid duration (e.g. `30s` or `1m`): expected number at 0
```

An option behind `#[serde(flatten)]` is out of reach here, as it is anywhere: flatten buffers the
unit's keys where a path tracker cannot follow, so the path is empty. The unit's own tracker, already
in `config_utils`, has written the name into the message, and this reader adds nothing rather than a
bare `.` or a second copy of the name. What that costs is the prefix: `GrpcClient__TcpKeepalive=soon`
reads ``` `TcpKeepalive`: `soon` is not a valid duration ```. A test pins that division of labour.

`figment` is not here, though the earlier design work on this used it: its `Env` provider buys
`#[serde(flatten)]` support that `MapDeserializer` already has, and its scalar grammar then has to be
undone by a provider of one's own, because a bare `1.0` parses into a float whose default rendering
is `1` - a silently corrupted credential. A dependency, a `Provider` impl and a collect-then-read
step, to end up where a 10-line `filter_map` already is.

## Tests

6 new tests, all in `armonik-transport/src/env.rs`: the prefix is the caller's own and a variable
outside it names no option; an option that cannot be read names the variable to go and fix; a
flattened option is named by its own unit and not twice; a value reaches its option as the text the
variable holds (`[::1]`, `1.0`); a variable declared empty reads as the option default, like an
absent one; a variable that is not Unicode does not bring the read down (moved here with the
decoding it covers, which moved out of `armonik`).

`armonik`'s `an_option_that_cannot_be_read_reports_the_value_it_was_given` pinned the missing name.
It is now `an_option_that_cannot_be_read_names_the_variable_it_came_from` and asserts it is there.

## Gates, from `packages/rust`, all green

```
cargo test -p armonik-transport --all-features                          62 + 13 + 5 + 6 + 0 passed
cargo test -p armonik --all-features --lib client::env                  4 passed
cargo clippy -p armonik-transport --all-features --all-targets          0 warnings
cargo clippy -p armonik --all-features --all-targets                    0 warnings
cargo check -p armonik-transport --no-default-features                  0 warnings
cargo check -p armonik-transport --no-default-features --features env   0 warnings
cargo fmt --check                                                       clean
```

`armonik`'s other 110 lib tests need a running mock server and fail identically on the base branch.
