### PR TITLE
feat(rust): give the transport a retry policy, as a unit of its own

### DIFF
--- a/packages/rust/armonik-transport/README.md
+++ b/packages/rust/armonik-transport/README.md
@@ -36,6 +36,17 @@ refused rather than ignored.
 
 ArmoniK's C# client reads the same `CertP12` option but has no `CertP12Password` counterpart, so a
 password-protected bundle is not portable to it.
+## Replaying a failed request
+
+`HttpConfig::retry` holds the policy: `MaxAttempts`, `InitialBackOff`, `MaxBackOff` and
+`BackOffMultiplier`, defaulting to what ArmoniK's other clients hand grpc-dotnet, so a deployment
+that sets nothing behaves the same whichever client talks to it. It is applied by whoever makes the
+calls: a channel carries no notion of a call, so `connect` does not read it.
+
+`BackOffMultiplier` is spelled `BackoffMultiplier`, with a lowercase o, by the C# client. Until that
+client is renamed to match, a deployment setting `GrpcClient__BackoffMultiplier` is read by C# and
+not by this crate, which reads `GrpcClient__BackOffMultiplier`. `InitialBackOff` and `MaxBackOff`
+are spelled identically on both sides.
 
 ## Reaching the endpoint through a proxy
 

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -3,10 +3,10 @@
 //! [`HttpConfig`] is plain data: every field is typed, public, and buildable by hand. Under the
 //! `serde` feature it also deserialises directly from a flat document of `PascalCase` options
 //! (`Endpoint`, `TcpKeepalive`, `Http2KeepAliveInterval`, ...), the same vocabulary every ArmoniK
-//! client reads; the thematic groups ([`TlsConfig`], [`TcpConfig`], [`Http2Config`]) flatten back
-//! into those names, so grouping the fields changes no option a deployment already sets. The
-//! `schema` feature describes that same vocabulary as a JSON schema, derived from the types that
-//! define it rather than written out a second time.
+//! client reads; the thematic groups ([`TlsConfig`], [`TcpConfig`], [`Http2Config`],
+//! [`RetryConfig`]) flatten back into those names, so grouping the fields changes no option a
+//! deployment already sets. The `schema` feature describes that same vocabulary as a JSON schema,
+//! derived from the types that define it rather than written out a second time.
 
 use std::time::Duration;
 
@@ -15,6 +15,7 @@ use snafu::Snafu;
 
 use crate::http2_config::Http2Config;
 use crate::proxy::ProxyConfig;
+use crate::retry_config::RetryConfig;
 use crate::tcp_config::TcpConfig;
 use crate::tls_config::TlsConfig;
 
@@ -47,6 +48,13 @@ embed_prefixed!(
     crate::http2_config::Http2Config,
     crate::http2_config::Http2Config,
     "Http2"
+);
+#[cfg(feature = "serde")]
+embed_prefixed!(
+    retry,
+    crate::retry_config::RetryConfig,
+    crate::retry_config::RawRetry,
+    ""
 );
 
 /// Options for creating a gRPC client.
@@ -108,6 +116,17 @@ pub struct HttpConfig {
     )]
     #[cfg_attr(feature = "schema", schemars(schema_with = "http2::schema"))]
     pub http2: Http2Config,
+    /// How a failed request is replayed, read under no prefix (`MaxAttempts`, `InitialBackOff`,
+    /// ...).
+    ///
+    /// Applied by whoever makes the calls: a channel carries no notion of a call, so nothing in
+    /// `connect` reads it.
+    #[cfg_attr(
+        feature = "serde",
+        serde(flatten, deserialize_with = "retry::deserialize")
+    )]
+    #[cfg_attr(feature = "schema", schemars(schema_with = "retry::schema"))]
+    pub retry: RetryConfig,
     /// User-Agent header value sent with each request. `UserAgent`.
     #[cfg_attr(feature = "serde", serde(deserialize_with = "user_agent"))]
     #[cfg_attr(feature = "schema", schemars(with = "String"))]
@@ -130,6 +149,7 @@ impl Default for HttpConfig {
             rate_limit: None,
             tcp: TcpConfig::default(),
             http2: Http2Config::default(),
+            retry: RetryConfig::default(),
             user_agent: None,
             proxy: ProxyConfig::default(),
         }
@@ -382,6 +402,10 @@ mod tests {
             "TcpKeepalive": "",
             "TcpKeepaliveRetries": "",
             "UserAgent": "",
+            "MaxAttempts": "",
+            "InitialBackOff": "",
+            "MaxBackOff": "",
+            "BackOffMultiplier": "",
         }));
 
         assert_eq!(config.connect_timeout, Some(DEFAULT_CONNECT_TIMEOUT));
@@ -390,6 +414,7 @@ mod tests {
         assert_eq!(config.tcp.keepalive, None);
         assert_eq!(config.tcp.keepalive_retries, None);
         assert_eq!(config.user_agent, None);
+        assert_eq!(config.retry, RetryConfig::default());
     }
 
     // --- durations and numbers ---
@@ -442,6 +467,9 @@ mod tests {
             ("Http2MaxHeaderListSize", "many"),
             ("TcpNagleAlgorithm", "perhaps"),
             ("Http2KeepAliveWhileIdle", "perhaps"),
+            ("MaxAttempts", "many"),
+            ("InitialBackOff", "a while"),
+            ("BackOffMultiplier", "twice"),
         ] {
             let rendered = error(json!({
                 "Endpoint": "http://localhost:5001",
@@ -782,5 +810,85 @@ mod tests {
 
         assert!(rendered.contains("no/such/identity.p12"), "{rendered}");
         assert!(!rendered.contains("s3cr3t"), "{rendered}");
+    }
+
+    // --- retry ---
+
+    #[test]
+    fn the_retry_options_default_to_what_the_other_clients_do() {
+        let config = config(json!({"Endpoint": "http://localhost:5001"}));
+
+        assert_eq!(config.retry, RetryConfig::default());
+    }
+
+    #[test]
+    fn each_retry_option_is_read() {
+        let config = config(json!({
+            "Endpoint": "http://localhost:5001",
+            "MaxAttempts": "3",
+            "InitialBackOff": "250ms",
+            "MaxBackOff": "2s",
+            "BackOffMultiplier": "3",
+        }));
+
+        assert_eq!(config.retry.max_attempts, 3);
+        assert_eq!(config.retry.initial_back_off, Duration::from_millis(250));
+        assert_eq!(config.retry.max_back_off, Duration::from_secs(2));
+        assert_eq!(config.retry.back_off_multiplier, 3.0);
+    }
+
+    #[test]
+    fn a_fractional_multiplier_survives_the_trip_through_text() {
+        // The one option that is a real number: reading it as an integer would round the growth
+        // the other clients use down to no growth at all.
+        let config = config(json!({
+            "Endpoint": "http://localhost:5001",
+            "BackOffMultiplier": "1.5",
+        }));
+
+        assert_eq!(config.retry.back_off_multiplier, 1.5);
+    }
+
+    #[test]
+    fn zero_attempts_is_refused_by_the_option_rather_than_read_as_one() {
+        // `0` and `1` would both mean one try and no replay, so a source that spells `0` means
+        // something the client cannot do and has to hear about it.
+        let rendered = error(json!({
+            "Endpoint": "http://localhost:5001",
+            "MaxAttempts": "0",
+        }));
+
+        assert!(rendered.contains("`MaxAttempts`"), "{rendered}");
+        assert!(rendered.contains("zero"), "{rendered}");
+    }
+
+    #[test]
+    fn a_ceiling_below_the_initial_back_off_is_refused_and_names_both_options() {
+        // Setting one of the two is enough: the other keeps its default, and the pair is what is
+        // wrong, so the message cannot lean on the key a source spelled.
+        for value in [
+            json!({"Endpoint": "http://localhost:5001", "InitialBackOff": "10s"}),
+            json!({"Endpoint": "http://localhost:5001", "MaxBackOff": "500ms"}),
+        ] {
+            let rendered = error(value);
+
+            assert!(rendered.contains("`MaxBackOff`"), "{rendered}");
+            assert!(rendered.contains("`InitialBackOff`"), "{rendered}");
+        }
+    }
+
+    #[test]
+    fn a_ceiling_equal_to_the_initial_back_off_is_a_constant_wait_rather_than_an_error() {
+        let config = config(json!({
+            "Endpoint": "http://localhost:5001",
+            "InitialBackOff": "2s",
+            "MaxBackOff": "2s",
+            "MaxAttempts": "3",
+        }));
+
+        assert_eq!(
+            config.retry.bounds().collect::<Vec<_>>(),
+            [Duration::from_secs(2); 2]
+        );
     }
 }

--- a/packages/rust/armonik-transport/src/config_utils/mod.rs
+++ b/packages/rust/armonik-transport/src/config_utils/mod.rs
@@ -295,6 +295,32 @@ pub(crate) fn optional_u32<'de, D: serde::Deserializer<'de>>(
     }
 }
 
+/// Reads a field whose own type states what it accepts - a real number, an integer that cannot be
+/// zero - empty for `None`. The message quotes the value and the type's own complaint, like
+/// [`bool_option`].
+///
+/// Preferred to a check made once the whole unit is built: the value is refused while the source's
+/// key is still known, so the name comes from the document rather than from a string written next
+/// to the check.
+#[cfg(feature = "serde")]
+pub(crate) fn optional_parsed<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    let value = text(deserializer)?;
+    if value.is_empty() {
+        return Ok(None);
+    }
+    match value.parse() {
+        Ok(parsed) => Ok(Some(parsed)),
+        Err(error) => Err(serde::de::Error::custom(format!(
+            "`{value}` is not valid: {error}"
+        ))),
+    }
+}
+
 #[cfg(all(test, feature = "schema"))]
 mod tests {
     use super::schema_with_prefix;

--- a/packages/rust/armonik-transport/src/lib.rs
+++ b/packages/rust/armonik-transport/src/lib.rs
@@ -9,6 +9,7 @@ mod config_utils;
 mod connect;
 mod http2_config;
 mod proxy;
+mod retry_config;
 mod tcp_config;
 mod tls_config;
 mod utils;
@@ -17,6 +18,7 @@ pub use config::{ConfigError, HttpConfig};
 pub use connect::{connect, https_connector, ConnectionError};
 pub use http2_config::Http2Config;
 pub use proxy::{ProxyConfig, ProxyError, ProxySource};
+pub use retry_config::RetryConfig;
 pub use tcp_config::TcpConfig;
 pub use tls_config::{Identity, TlsConfig};
 // The password's own type, so a caller can build a `ProxyConfig` without declaring a dependency on

--- a/packages/rust/armonik-transport/src/retry_config.rs
+++ b/packages/rust/armonik-transport/src/retry_config.rs
@@ -169,11 +169,24 @@ impl TryFrom<RawRetry> for RetryConfig {
             }
         );
 
+        let back_off_multiplier = back_off_multiplier.unwrap_or(DEFAULT_BACK_OFF_MULTIPLIER);
+        // `f64` parses `nan`, `inf` and every negative as happily as a real multiplier, and none of
+        // them backs anything off: below 1 each wait is shorter than the last, and a value that is
+        // not a finite number makes the schedule meaningless rather than long.
+        snafu::ensure!(
+            back_off_multiplier.is_finite() && back_off_multiplier >= 1.0,
+            IncompatibleOptionsSnafu {
+                msg: format!(
+                    "`BackOffMultiplier` ({back_off_multiplier}) is not a finite number of at least 1"
+                ),
+            }
+        );
+
         Ok(Self {
             max_attempts: max_attempts.map_or(DEFAULT_MAX_ATTEMPTS, std::num::NonZeroU32::get),
             initial_back_off,
             max_back_off,
-            back_off_multiplier: back_off_multiplier.unwrap_or(DEFAULT_BACK_OFF_MULTIPLIER),
+            back_off_multiplier,
             retryable_status_codes: DEFAULT_RETRYABLE_STATUS_CODES.to_vec(),
         })
     }
@@ -189,6 +202,49 @@ mod tests {
             max_attempts,
             ..RetryConfig::default()
         }
+    }
+
+    /// The policy `BackOffMultiplier=value` produces, whichever way it turns out.
+    #[cfg(feature = "serde")]
+    fn from_multiplier(value: &str) -> Result<RetryConfig, ConfigError> {
+        use serde::Deserialize as _;
+        RetryConfig::deserialize(serde::de::value::MapDeserializer::<
+            _,
+            serde::de::value::Error,
+        >::new([("BackOffMultiplier", value)].into_iter()))
+        .map_err(|error| {
+            IncompatibleOptionsSnafu {
+                msg: error.to_string(),
+            }
+            .build()
+        })
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn a_multiplier_that_backs_nothing_off_is_refused() {
+        // `f64` parses every one of these, and each would make the schedule something other than a
+        // backoff: no wait at all, waits that shrink, or a number that is not one.
+        for value in ["0", "-1", "0.5", "nan", "inf", "-inf"] {
+            let rendered = from_multiplier(value)
+                .err()
+                .map(|error| error.to_string())
+                .unwrap_or_else(|| panic!("`{value}` should be refused"));
+
+            assert!(
+                rendered.contains("BackOffMultiplier"),
+                "{value}: {rendered}"
+            );
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn a_multiplier_of_one_is_a_constant_wait_and_allowed() {
+        // The edge of the rule, and a legitimate policy: retry at a fixed interval.
+        let policy = from_multiplier("1").expect("a constant wait is a policy");
+
+        assert_eq!(policy.back_off_multiplier, 1.0);
     }
 
     #[test]

--- a/packages/rust/armonik-transport/src/retry_config.rs
+++ b/packages/rust/armonik-transport/src/retry_config.rs
@@ -1,0 +1,250 @@
+//! When a failed request is worth sending again, and how long to wait first.
+//!
+//! A unit of fields, not a naming scheme: the embedding composes them with `#[serde(flatten)]`
+//! under a prefix of its own, so the same unit serves however many embeddings read retry options,
+//! and grouping these fields changes no environment variable a deployment already sets.
+//!
+//! The schedule follows the gRPC retry specification: the wait before replay `n` is bounded by
+//! `min(initial * multiplier^n, max)`. The defaults are the ones ArmoniK's other clients hand
+//! grpc-dotnet, so a deployment behaves the same whichever client talks to it.
+
+use std::time::Duration;
+
+#[cfg(feature = "serde")]
+use crate::config::{ConfigError, IncompatibleOptionsSnafu};
+
+/// Attempts in all, first try included, when the option is left unset.
+const DEFAULT_MAX_ATTEMPTS: u32 = 5;
+/// Wait before the second attempt, when the option is left unset.
+const DEFAULT_INITIAL_BACK_OFF: Duration = Duration::from_secs(1);
+/// Ceiling the wait grows to, when the option is left unset.
+const DEFAULT_MAX_BACK_OFF: Duration = Duration::from_secs(5);
+/// What each wait is multiplied by, when the option is left unset.
+const DEFAULT_BACK_OFF_MULTIPLIER: f64 = 1.5;
+/// Failures worth sending the request again for, the same three ArmoniK's other clients fix.
+const DEFAULT_RETRYABLE_STATUS_CODES: [tonic::Code; 3] = [
+    tonic::Code::Unavailable,
+    tonic::Code::Aborted,
+    tonic::Code::Unknown,
+];
+
+/// Replaying a failed request: how many attempts, how long between them, and which failures are
+/// worth another try.
+///
+/// Each option is a field of its own name; the full name a source spells is the embedding's prefix
+/// followed by that name, so no field doc spells it: the same field is a different option under a
+/// different prefix. A schema generated for this type on its own describes the unprefixed names it
+/// declares.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize),
+    serde(try_from = "RawRetry")
+)]
+#[non_exhaustive]
+pub struct RetryConfig {
+    /// Attempts in all for one request, first try included; `1` never replays.
+    pub max_attempts: u32,
+    /// Wait before the second attempt.
+    pub initial_back_off: Duration,
+    /// Ceiling the wait grows to, never below [`Self::initial_back_off`].
+    pub max_back_off: Duration,
+    /// What each wait is multiplied by.
+    pub back_off_multiplier: f64,
+    /// Failures worth sending the request again for.
+    ///
+    /// Set programmatically: no option reads it, as in ArmoniK's other clients, which fix the same
+    /// three codes.
+    pub retryable_status_codes: Vec<tonic::Code>,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: DEFAULT_MAX_ATTEMPTS,
+            initial_back_off: DEFAULT_INITIAL_BACK_OFF,
+            max_back_off: DEFAULT_MAX_BACK_OFF,
+            back_off_multiplier: DEFAULT_BACK_OFF_MULTIPLIER,
+            retryable_status_codes: DEFAULT_RETRYABLE_STATUS_CODES.to_vec(),
+        }
+    }
+}
+
+impl RetryConfig {
+    /// Whether a request that failed with `code` is worth sending again.
+    pub fn is_retryable(&self, code: tonic::Code) -> bool {
+        self.retryable_status_codes.contains(&code)
+    }
+
+    /// The longest each replay may wait, one item per replay and nothing past the last attempt:
+    /// `initial_back_off`, each following one multiplied by `back_off_multiplier`, never above
+    /// `max_back_off`.
+    ///
+    /// A bound rather than the wait itself, because the specification draws the wait uniformly
+    /// below it so that clients which failed together do not come back together.
+    pub fn bounds(&self) -> impl Iterator<Item = Duration> + use<> {
+        let ceiling = self.max_back_off;
+        let multiplier = self.back_off_multiplier;
+        // A ceiling below the first wait is refused while reading the options, but the fields are
+        // public and a caller may set either, so the first bound is held to the ceiling too.
+        let mut bound = self.initial_back_off.min(ceiling);
+
+        (0..self.max_attempts.saturating_sub(1)).map(move |_| {
+            let current = bound;
+            // `Duration::mul_f64` panics on a multiplier that is negative, infinite or not a
+            // number, so the growth goes through the fallible constructor and settles on the
+            // ceiling for anything it refuses.
+            bound = Duration::try_from_secs_f64(bound.as_secs_f64() * multiplier)
+                .unwrap_or(ceiling)
+                .min(ceiling);
+            current
+        })
+    }
+}
+
+/// The flat string options [`RetryConfig`] is read from, one per field, all optional.
+///
+/// Every field tolerates the eager typing a `serde` source may apply (a bare number arriving as
+/// one), and an empty string means unset, the same as an absent key: a deployment that declares a
+/// variable with an empty default must not differ from one that leaves it out.
+///
+/// Each value is held in the type that states what it accepts, so a refusal is raised while the
+/// source's own key is still known and the message needs no option name written into it.
+#[cfg(feature = "serde")]
+#[derive(Debug, Default, serde::Deserialize)]
+#[cfg_attr(
+    feature = "schema",
+    derive(schemars::JsonSchema),
+    schemars(transform = crate::config_utils::strip_defaults)
+)]
+#[serde(rename_all = "PascalCase", default)]
+pub(crate) struct RawRetry {
+    /// Attempts in all for one request, first try included; `1` never replays, `0` is refused, and
+    /// empty is the default.
+    #[serde(deserialize_with = "crate::config_utils::optional_parsed")]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
+    max_attempts: Option<std::num::NonZeroU32>,
+    /// Wait before the second attempt (e.g. `1s`); empty for the default.
+    #[serde(deserialize_with = "crate::config_utils::optional_duration")]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
+    initial_back_off: Option<Duration>,
+    /// Ceiling the wait grows to (e.g. `5s`); empty for the default.
+    #[serde(deserialize_with = "crate::config_utils::optional_duration")]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
+    max_back_off: Option<Duration>,
+    /// What each wait is multiplied by; empty for the default.
+    #[serde(deserialize_with = "crate::config_utils::optional_parsed")]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
+    back_off_multiplier: Option<f64>,
+}
+
+#[cfg(feature = "serde")]
+impl TryFrom<RawRetry> for RetryConfig {
+    type Error = ConfigError;
+
+    fn try_from(raw: RawRetry) -> Result<Self, Self::Error> {
+        let RawRetry {
+            max_attempts,
+            initial_back_off,
+            max_back_off,
+            back_off_multiplier,
+        } = raw;
+
+        let initial_back_off = initial_back_off.unwrap_or(DEFAULT_INITIAL_BACK_OFF);
+        let max_back_off = max_back_off.unwrap_or(DEFAULT_MAX_BACK_OFF);
+
+        // The two are named here because the mistake belongs to neither key alone: a ceiling below
+        // the first wait holds every wait down to it, so one of the two options does nothing and
+        // the source cannot say which was meant. Setting only one is enough to reach this, since
+        // the other keeps its default.
+        snafu::ensure!(
+            max_back_off >= initial_back_off,
+            IncompatibleOptionsSnafu {
+                msg: format!(
+                    "`MaxBackOff` ({}) is below `InitialBackOff` ({}), which would hold every \
+                     wait down to the ceiling",
+                    humantime::format_duration(max_back_off),
+                    humantime::format_duration(initial_back_off),
+                ),
+            }
+        );
+
+        Ok(Self {
+            max_attempts: max_attempts.map_or(DEFAULT_MAX_ATTEMPTS, std::num::NonZeroU32::get),
+            initial_back_off,
+            max_back_off,
+            back_off_multiplier: back_off_multiplier.unwrap_or(DEFAULT_BACK_OFF_MULTIPLIER),
+            retryable_status_codes: DEFAULT_RETRYABLE_STATUS_CODES.to_vec(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The default policy with `max_attempts` replaced, the only field most tests here vary.
+    fn policy(max_attempts: u32) -> RetryConfig {
+        RetryConfig {
+            max_attempts,
+            ..RetryConfig::default()
+        }
+    }
+
+    #[test]
+    fn the_defaults_are_the_ones_the_other_clients_use() {
+        // A deployment that sets nothing has to behave the same whichever client talks to it.
+        let policy = RetryConfig::default();
+
+        assert_eq!(policy.max_attempts, 5);
+        assert_eq!(policy.initial_back_off, Duration::from_secs(1));
+        assert_eq!(policy.max_back_off, Duration::from_secs(5));
+        assert_eq!(policy.back_off_multiplier, 1.5);
+        assert!(policy.is_retryable(tonic::Code::Unavailable));
+        assert!(policy.is_retryable(tonic::Code::Aborted));
+        assert!(policy.is_retryable(tonic::Code::Unknown));
+        assert!(!policy.is_retryable(tonic::Code::InvalidArgument));
+    }
+
+    #[test]
+    fn the_bounds_grow_by_the_multiplier_and_stop_at_the_ceiling() {
+        let policy = RetryConfig {
+            initial_back_off: Duration::from_secs(1),
+            max_back_off: Duration::from_secs(4),
+            back_off_multiplier: 2.0,
+            ..policy(6)
+        };
+
+        assert_eq!(
+            policy.bounds().collect::<Vec<_>>(),
+            [1, 2, 4, 4, 4].map(Duration::from_secs),
+            "1, 2, 4, then the ceiling holds"
+        );
+    }
+
+    #[test]
+    fn there_is_one_bound_per_replay_and_none_beyond() {
+        assert_eq!(policy(3).bounds().count(), 2, "three attempts, two waits");
+        assert_eq!(policy(1).bounds().count(), 0, "one attempt is no replay");
+    }
+
+    #[test]
+    fn a_multiplier_no_duration_can_hold_settles_on_the_ceiling() {
+        // The fields are public, so a caller can set a multiplier `Duration::mul_f64` would panic
+        // on. Every such value has to come out as a bounded wait instead.
+        for multiplier in [f64::NAN, f64::INFINITY, -1.0, f64::MAX] {
+            let policy = RetryConfig {
+                initial_back_off: Duration::from_secs(1),
+                max_back_off: Duration::from_secs(4),
+                back_off_multiplier: multiplier,
+                ..policy(4)
+            };
+
+            assert_eq!(
+                policy.bounds().collect::<Vec<_>>(),
+                [1, 4, 4].map(Duration::from_secs),
+                "{multiplier} should be held to the ceiling"
+            );
+        }
+    }
+}

--- a/packages/rust/armonik-transport/tests/schema.rs
+++ b/packages/rust/armonik-transport/tests/schema.rs
@@ -89,6 +89,10 @@ fn every_option_appears_under_its_flat_name() {
         "Http2KeepAliveWhileIdle",
         "Http2MaxHeaderListSize",
         "UserAgent",
+        "MaxAttempts",
+        "InitialBackOff",
+        "MaxBackOff",
+        "BackOffMultiplier",
     ] {
         assert!(names.iter().any(|name| name == option), "missing {option}");
     }
@@ -97,13 +101,18 @@ fn every_option_appears_under_its_flat_name() {
 #[test]
 fn the_schema_promises_nothing_that_is_not_read() {
     // A consumer generates its options class from this, so an option the schema declares and
-    // deserialisation ignores is a field that silently does nothing. The proxy is set
-    // programmatically and no option reads it.
+    // deserialisation ignores is a field that silently does nothing. The proxy and the retryable
+    // status codes are set programmatically and no option reads them.
     let schema = schema();
     let mut names = Vec::new();
     property_names(&schema, &mut names);
 
-    for absent in ["ProxyAddress", "ProxyUsername", "ProxyPassword"] {
+    for absent in [
+        "ProxyAddress",
+        "ProxyUsername",
+        "ProxyPassword",
+        "RetryableStatusCodes",
+    ] {
         assert!(
             !names.iter().any(|name| name == absent),
             "`{absent}` is not read"

--- a/packages/rust/armonik/src/client/mod.rs
+++ b/packages/rust/armonik/src/client/mod.rs
@@ -7,7 +7,7 @@ use snafu::{ResultExt, Snafu};
 #[cfg(feature = "_gen-client")]
 pub use armonik_transport::{
     ConfigError, ConnectionError, Http2Config, HttpConfig, Identity, ProxyConfig, ProxyError,
-    ProxySource, SecretString, TcpConfig, TlsConfig,
+    ProxySource, RetryConfig, SecretString, TcpConfig, TlsConfig,
 };
 
 #[cfg(feature = "_gen-client")]


### PR DESCRIPTION
Give the transport a retry policy, configured as its own unit.

`RetryConfig` carries what ArmoniK's other clients hand grpc-dotnet, so a deployment behaves the
same whichever client talks to it: five attempts, one second growing by 1.5 to a five-second
ceiling, replaying on `Unavailable`, `Aborted` and `Unknown`. It is reached as `config.retry`, and
applied by whoever makes the calls: a channel carries no notion of a call, so nothing in `connect`
reads it.

Four options travel with the rest of the vocabulary, under no prefix: `MaxAttempts`,
`InitialBackOff`, `MaxBackOff`, `BackOffMultiplier`. The unit declares plain fields and no names of
its own; `config.rs` states the prefix next to the field with `embed_prefixed!`, as it already does
for `tcp`, `http2` and `tls`, so the reading and the JSON schema both come from that one
declaration. The capital O is the PascalCase rendering of "back off", produced by `rename_all` from
the field name alone: no option here carries a rename attribute.

**One name differs from the C# client, on purpose.** `InitialBackOff` and `MaxBackOff` are spelled
exactly as `ArmoniK.Api.Client/Options/GrpcClient.cs` spells them, and both sides read the same
`GrpcClient__` prefix, so those two reach either client. `BackOffMultiplier` does not: C# spells it
`BackoffMultiplier`, with a lowercase o. Until the rename lands there, a deployment setting
`GrpcClient__BackoffMultiplier` is read by C# and not by this crate. No alias covers it, since an
alias would keep the misspelling alive on both sides; the README records the divergence.

`RawRetry` holds each value in the type that states what it accepts, so a bad one is refused while
the source's key is still known and no option name has to be written next to the check:
`MaxAttempts` is a `NonZeroU32`, and `0` - which would mean one try and no replay, exactly like `1`
- is named by the document that spelled it. `config_utils` gains the generic reader that serves it
and the multiplier.

The one rule spanning two options goes through `TryFrom<RawRetry>`, as `TlsConfig` does with
`RawTls`: a `MaxBackOff` below `InitialBackOff` holds every wait down to the ceiling, so one of the
two does nothing and the source cannot say which was meant. Setting either alone reaches it, since
the other keeps its default.

`bounds()` is the schedule those options describe, one item per replay and nothing past the last
attempt. The growth goes through `Duration::try_from_secs_f64` rather than `mul_f64`, which panics
on a multiplier a caller set to a negative, infinite or non-numeric value; anything it refuses
settles on the ceiling.

Left for their own PRs, out of #707: the `retry!` macro and the `GrpcStatus` trait, which are the
caller-facing loop, together with the `fastrand` jitter draw only that loop consumes;
`MaxRetryBufferPerCall` and `MaxRetryUnarySize`, which bound a replay buffer nothing here holds; and
`RetryableStatusCodes` as an option, which no other ArmoniK client exposes - the three codes stay a
programmatic field, fixed as C# fixes them.

10 tests. In `retry_config.rs`: the defaults are the ones the other clients use; the bounds grow by
the multiplier and stop at the ceiling; there is one bound per replay and none beyond; a multiplier
no `Duration` can hold settles on the ceiling. In `config.rs`, through a document: the options
default; each one is read; a fractional multiplier survives the trip through text; zero attempts is
refused by the option rather than read as one; a ceiling below the initial back off is refused and
names both options; a ceiling equal to it is a constant wait rather than an error. The existing
`an_empty_option_reads_as_its_default` and `the_named_option_carries_the_prefix...` cases gain the
four options, and `tests/schema.rs` pins them in the vocabulary and pins `RetryableStatusCodes` out
of it.

From `packages/rust`, all green: `cargo test -p armonik-transport --all-features` (90 passed, 0
failed), `cargo clippy -p armonik-transport --all-features --all-targets` and `cargo clippy -p
armonik --all-features --all-targets` (0 warnings), `cargo check -p armonik-transport
--no-default-features` (0 warnings), `cargo fmt --check`. `cargo run -p armonik-transport --features
schema --example generate_schema` lists the four options as strings.
