### PR TITLE
feat(rust): read the proxy from the ProxyAddress options

### DIFF
--- a/packages/rust/armonik-transport/README.md
+++ b/packages/rust/armonik-transport/README.md
@@ -70,6 +70,23 @@ connection; `ProxyConfig::explicit(uri)` names a proxy, which is then used whate
 `with_credentials` authenticates to it, half by half: a half left empty keeps what the proxy URL
 itself carried.
 
+As options, `ProxyAddress` takes the same four values as ArmoniK's C# client: empty and `system`
+follow the environment, `none` forces a direct connection, anything else is the proxy's URL,
+defaulting to the `http` scheme. `ProxyUsername` and `ProxyPassword` authenticate to it. A URL that
+cannot be dialled as written, no host, a port that is not one, or a scheme other than `http`, is
+refused while the configuration is being read.
+
+Credentials go in one place or the other, never both: a URL carrying `user:password@` next to a
+non-empty `ProxyUsername` or `ProxyPassword` is refused rather than merged, since guessing which
+half of which source wins would turn a mixed configuration into a silent surprise.
+
+Three divergences from the C# client are deliberate. The option is `ProxyAddress`, where C# spells
+it `Proxy`; the matching C# rename is filed separately, and until it lands a deployment setting
+both clients names the proxy twice. Spell `none` and `system` exactly so, or capitalised: this
+crate accepts any casing, C# treats `NONE` as a proxy URL. And an `https` proxy URL, which C#
+passes to the runtime, is refused here: the `CONNECT` handshake would go out in the clear to a
+proxy expecting TLS.
+
 The connection is an HTTP `CONNECT` tunnel: TLS, mutual TLS included, is negotiated end to end with
 the real server, and the proxy only forwards opaque bytes. Because the `CONNECT` handshake itself goes
 out in the clear, the proxy's own URL has to be `http`. The handshake is bounded by

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -4,8 +4,8 @@
 //! `serde` feature it also deserialises directly from a flat document of `PascalCase` options
 //! (`Endpoint`, `TcpKeepalive`, `Http2KeepAliveInterval`, ...), the same vocabulary every ArmoniK
 //! client reads; the thematic groups ([`TlsConfig`], [`TcpConfig`], [`Http2Config`],
-//! [`RetryConfig`]) flatten back into those names, so grouping the fields changes no option a
-//! deployment already sets.
+//! [`RetryConfig`], [`ProxyConfig`]) flatten back into those names, so grouping the fields changes
+//! no option a deployment already sets.
 //!
 //! The `schema` feature describes that same vocabulary as a JSON schema, derived from the types
 //! that define it rather than written out a second time, and the `env` feature reads it from
@@ -58,6 +58,13 @@ embed_prefixed!(
     crate::retry_config::RetryConfig,
     crate::retry_config::RawRetry,
     ""
+);
+#[cfg(feature = "serde")]
+embed_prefixed!(
+    proxy,
+    crate::proxy::ProxyConfig,
+    crate::proxy::ProxyShape,
+    "Proxy"
 );
 
 /// Options for creating a gRPC client.
@@ -134,11 +141,13 @@ pub struct HttpConfig {
     #[cfg_attr(feature = "serde", serde(deserialize_with = "user_agent"))]
     #[cfg_attr(feature = "schema", schemars(with = "String"))]
     pub user_agent: Option<HeaderValue>,
-    /// HTTP proxy used to reach the endpoint, defaults to following the environment.
-    ///
-    /// Set programmatically: no option reads it, and a document that spells one is ignored rather
-    /// than refused, because a type with flattened fields cannot also deny unknown ones.
-    #[cfg_attr(feature = "serde", serde(skip))]
+    /// HTTP proxy used to reach the endpoint, read under the `Proxy` prefix (`ProxyAddress`,
+    /// `ProxyUsername`, `ProxyPassword`), defaults to following the environment.
+    #[cfg_attr(
+        feature = "serde",
+        serde(flatten, deserialize_with = "proxy::deserialize")
+    )]
+    #[cfg_attr(feature = "schema", schemars(schema_with = "proxy::schema"))]
     pub proxy: ProxyConfig,
 }
 
@@ -320,6 +329,7 @@ pub enum ConfigError {
 
 #[cfg(all(test, feature = "serde"))]
 mod tests {
+    use secrecy::ExposeSecret as _;
     use serde_json::json;
 
     use super::*;
@@ -379,18 +389,18 @@ mod tests {
     }
 
     #[test]
-    fn a_proxy_option_is_ignored_rather_than_refused() {
-        // The proxy is set programmatically, and flattening the units rules out denying unknown
-        // fields, so an option naming it passes through instead of failing the read. Whoever
-        // gives those options meaning has to add the reading, not assume a guard here.
+    fn a_proxy_option_is_read_rather_than_ignored() {
         let config = config(json!({
             "Endpoint": "http://localhost:5001",
             "ProxyAddress": "http://proxy.corp:3128",
             "ProxyUsername": "user",
         }));
 
-        assert_eq!(config.proxy.source, ProxySource::System);
-        assert!(config.proxy.username.is_empty());
+        let ProxySource::Explicit(uri) = &config.proxy.source else {
+            panic!("expected an explicit proxy");
+        };
+        assert_eq!(uri.host(), Some("proxy.corp"));
+        assert_eq!(config.proxy.username, "user");
     }
 
     #[test]
@@ -893,5 +903,226 @@ mod tests {
             config.retry.bounds().collect::<Vec<_>>(),
             [Duration::from_secs(2); 2]
         );
+    }
+
+    // --- the proxy ---
+
+    /// The configuration `ProxyAddress=value` produces, expected to be valid.
+    fn proxy_config(value: &str) -> HttpConfig {
+        config(json!({"Endpoint": "http://localhost:5001", "ProxyAddress": value}))
+    }
+
+    /// The error message `ProxyAddress=value` produces, expected to be a rejection.
+    fn proxy_error(value: &str) -> String {
+        error(json!({"Endpoint": "http://localhost:5001", "ProxyAddress": value}))
+    }
+
+    #[test]
+    fn an_empty_or_system_address_follows_the_environment() {
+        // The same reading as ArmoniK's C# client, where an unset option leaves the handler
+        // following the environment.
+        for value in ["", "system", "System", "SYSTEM"] {
+            let config = proxy_config(value);
+            assert_eq!(config.proxy.source, ProxySource::System, "{value:?}");
+        }
+    }
+
+    #[test]
+    fn none_forces_a_direct_connection() {
+        for value in ["none", "None", "NONE"] {
+            let config = proxy_config(value);
+            assert_eq!(config.proxy.source, ProxySource::Disabled, "{value:?}");
+        }
+    }
+
+    #[test]
+    fn a_proxy_url_defaults_to_the_http_scheme() {
+        let with_scheme = proxy_config("http://proxy.corp:3128");
+        let without_scheme = proxy_config("proxy.corp:3128");
+
+        let ProxySource::Explicit(with_scheme) = with_scheme.proxy.source else {
+            panic!("expected an explicit proxy");
+        };
+        let ProxySource::Explicit(without_scheme) = without_scheme.proxy.source else {
+            panic!("expected an explicit proxy");
+        };
+        assert_eq!(with_scheme, without_scheme);
+        assert_eq!(with_scheme.host(), Some("proxy.corp"));
+        assert_eq!(with_scheme.port_u16(), Some(3128));
+    }
+
+    #[test]
+    fn credentials_in_the_url_are_honoured_and_removed_from_it() {
+        let config = proxy_config("http://user:secret@proxy.corp:3128");
+
+        assert_eq!(config.proxy.username, "user");
+        assert_eq!(config.proxy.password.expose_secret(), "secret");
+        let ProxySource::Explicit(uri) = &config.proxy.source else {
+            panic!("expected an explicit proxy");
+        };
+        assert!(
+            !uri.to_string().contains("secret"),
+            "the URI is rendered in errors and logs: {uri}"
+        );
+    }
+
+    #[test]
+    fn the_dedicated_credential_options_are_read() {
+        let config = config(json!({
+            "Endpoint": "http://localhost:5001",
+            "ProxyAddress": "http://proxy.corp:3128",
+            "ProxyUsername": "user",
+            "ProxyPassword": "secret",
+        }));
+
+        assert_eq!(config.proxy.username, "user");
+        assert_eq!(config.proxy.password.expose_secret(), "secret");
+    }
+
+    #[test]
+    fn credentials_in_both_the_url_and_the_options_are_rejected() {
+        // Two ways in, not a merge: guessing which half of which source wins turns a mixed
+        // configuration into a silent surprise, so it is refused while it is being read. The
+        // message names both sources and echoes neither value.
+        for dedicated in [
+            json!({"ProxyUsername": "option-user", "ProxyPassword": "option-secret"}),
+            json!({"ProxyPassword": "option-secret"}),
+            json!({"ProxyUsername": "option-user"}),
+        ] {
+            let mut value = json!({
+                "Endpoint": "http://localhost:5001",
+                "ProxyAddress": "http://url-user:url-secret@proxy.corp:3128",
+            });
+            value
+                .as_object_mut()
+                .expect("a JSON object")
+                .extend(dedicated.as_object().expect("a JSON object").clone());
+
+            let rendered = error(value);
+            assert!(rendered.contains("set them one way"), "{rendered}");
+            assert!(rendered.contains("ProxyUsername"), "{rendered}");
+            assert!(
+                !rendered.contains("url-secret") && !rendered.contains("option-secret"),
+                "a password is echoed: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_configuration_keeps_the_password_out_of_its_debug_output() {
+        // `HttpConfig` is `Debug` and holds the password, so a careless `Debug` would put it
+        // anywhere a configuration gets printed. Both shapes are covered: a URL-carried password
+        // and a dedicated one.
+        for value in [
+            json!({
+                "Endpoint": "http://localhost:5001",
+                "ProxyAddress": "http://user:url-secret@proxy.corp:3128",
+            }),
+            json!({
+                "Endpoint": "http://localhost:5001",
+                "ProxyAddress": "http://proxy.corp:3128",
+                "ProxyUsername": "user",
+                "ProxyPassword": "option-secret",
+            }),
+        ] {
+            let rendered = format!("{:?}", config(value));
+            assert!(
+                !rendered.contains("option-secret") && !rendered.contains("url-secret"),
+                "password rendered: {rendered}"
+            );
+            assert!(
+                rendered.contains("user"),
+                "the username is not a secret and stays useful: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_rejected_proxy_url_does_not_echo_its_password() {
+        // A URL can be rejected for having no host, or for a "port" that is really a password
+        // whose `@host` part went missing, and still have carried a credential.
+        for value in ["http://user:s3cr3t@", "http://admin:hunter2"] {
+            let rendered = proxy_error(value);
+            assert!(
+                !rendered.contains("s3cr3t") && !rendered.contains("hunter2"),
+                "password echoed for {value:?}: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_proxy_url_whose_credentials_cannot_be_stripped_is_rejected_while_reading() {
+        // `@` is legal inside a bracketed authority, so this parses, yet what follows the
+        // credentials (`proxy]`) is not a host on its own. Accepting it would store the
+        // placeholder and fail only at connect time, against this option's fail-on-read contract;
+        // the rejection must not echo the password either.
+        let rendered = proxy_error("http://[user:s3cr3t@proxy]");
+
+        assert!(
+            rendered.contains("once its credentials are taken out"),
+            "{rendered}"
+        );
+        assert!(!rendered.contains("s3cr3t"), "password echoed: {rendered}");
+    }
+
+    #[test]
+    fn a_proxy_that_is_not_http_is_rejected_rather_than_reached_in_the_clear() {
+        // The `CONNECT` handshake goes out unencrypted, so a proxy expecting TLS would see
+        // gibberish. Accepting the URL and failing at connect time would report it as an
+        // unreachable proxy.
+        for value in ["https://proxy.corp:3128", "socks5://proxy.corp:1080"] {
+            let rendered = proxy_error(value);
+            assert!(
+                rendered.contains("only an `http` proxy"),
+                "{value}: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_proxy_without_a_host_is_rejected_and_names_its_own_option() {
+        // Reporting these through the endpoint's URI error would send whoever reads it looking at
+        // the wrong option.
+        for value in ["http:///no-host", "http://", "http://:3128", "://"] {
+            let rendered = proxy_error(value);
+            assert!(
+                rendered.contains("`ProxyAddress"),
+                "unexpected error for {value:?}: {rendered}"
+            );
+            assert!(
+                rendered.contains("is not a valid proxy URL"),
+                "unexpected error for {value:?}: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_port_that_is_not_one_is_rejected_rather_than_dialled_on_80() {
+        // `http::Uri` keeps the port as text and parses it lazily, so without the explicit check a
+        // typo would pass validation and the connector would quietly fall back to the scheme
+        // default.
+        for value in [
+            "proxy.corp:99999",
+            "proxy.corp:31z8",
+            "http://admin:hunter2",
+        ] {
+            let rendered = proxy_error(value);
+            assert!(
+                rendered.contains("does not name a valid port"),
+                "unexpected error for {value:?}: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_ipv6_proxy_is_accepted_with_and_without_a_port() {
+        // The port check must not mistake the colons of an IPv6 literal for an invalid port.
+        for (value, port) in [("http://[::1]:3128", Some(3128)), ("http://[::1]", None)] {
+            let config = proxy_config(value);
+            let ProxySource::Explicit(uri) = &config.proxy.source else {
+                panic!("expected an explicit proxy for {value:?}");
+            };
+            assert_eq!(uri.port_u16(), port, "{value:?}");
+        }
     }
 }

--- a/packages/rust/armonik-transport/src/proxy.rs
+++ b/packages/rust/armonik-transport/src/proxy.rs
@@ -44,6 +44,10 @@ pub enum ProxySource {
     #[default]
     System,
     /// Connect directly, ignoring any proxy configured in the environment.
+    ///
+    /// The credentials are left unread under this source, rather than refused next to it: a direct
+    /// connection has no proxy to authenticate to, and a deployment that turns proxying off
+    /// without first clearing the credentials it used to need is in a normal state.
     Disabled,
     /// Use this specific proxy, whatever the environment says: `NO_PROXY` does not apply to it.
     Explicit(Uri),
@@ -69,6 +73,9 @@ impl std::fmt::Debug for ProxySource {
 ///
 /// Purely textual, so it cannot fail and holds even for authorities that would not survive a
 /// round trip through the URI builder.
+///
+/// Not the same job as `elide_userinfo`, which takes text that never became a [`Uri`]: this one
+/// starts from a parsed one, so it can keep the username and the host, which are not secrets.
 struct RedactedUri<'a>(&'a Uri);
 
 impl std::fmt::Display for RedactedUri<'_> {
@@ -98,7 +105,16 @@ impl std::fmt::Display for RedactedUri<'_> {
 ///
 /// Proxying uses a `CONNECT` tunnel, so TLS, mutual TLS included, is negotiated end to end with the
 /// real server and the proxy never sees the plaintext.
+///
+/// Read from the flat `Address`/`Username`/`Password` options, under whichever prefix the embedding
+/// gives them: empty or `system` follows the environment, `none` forces a direct connection,
+/// anything else is the proxy URL.
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize),
+    serde(try_from = "RawProxy")
+)]
 #[non_exhaustive]
 pub struct ProxyConfig {
     /// Where to find the proxy.
@@ -253,6 +269,222 @@ impl ProxyConfig {
 /// carry the cleartext handshake, or the placeholder for a URI with no sanitized form - so
 /// whoever reports it names the offending URI once, and that URI never holds a password.
 pub(crate) type RouteResult = Result<Option<(Uri, Option<HeaderValue>)>, Uri>;
+
+/// The flat string options [`ProxyConfig`] is read from.
+///
+/// Each field carries its own name only; the embedding prepends the prefix it reads them under.
+#[cfg(feature = "serde")]
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "PascalCase", default)]
+struct RawProxy {
+    /// Where to find the proxy.
+    ///
+    /// Empty or `system` follows the environment (see [`ProxySource::System`]), `none` forces a
+    /// direct connection, otherwise the proxy URL, whose scheme has to be `http`: the `CONNECT`
+    /// handshake is written in the clear. `none` and `system` are the spellings every ArmoniK
+    /// client understands; other casings are accepted here but not everywhere.
+    ///
+    /// A URL can carry credentials in its authority (`http://user:password@proxy`), so the whole
+    /// value is a secret: redacted by `Debug` and zeroized on drop, like the password.
+    #[serde(deserialize_with = "crate::config_utils::secret_text")]
+    address: SecretString,
+    /// Username for proxy authentication. Mutually exclusive with credentials written into the
+    /// proxy URL.
+    #[serde(deserialize_with = "crate::config_utils::text")]
+    username: String,
+    /// Password for proxy authentication. Mutually exclusive with credentials written into the
+    /// proxy URL. Redacted by `Debug` and zeroized on drop.
+    #[serde(deserialize_with = "crate::config_utils::secret_text")]
+    password: SecretString,
+}
+
+/// The two shapes proxy credentials arrive in, the same way a TLS identity has its own shapes.
+///
+/// A value that fits neither shape, a URL carrying credentials next to non-empty dedicated fields,
+/// is refused rather than merged: guessing which half of which source wins would turn a mixed
+/// configuration into a silent surprise.
+///
+/// This is also the shape a document writes, so it is what describes the unit to a schema: the
+/// alternatives are spelled out rather than flattened into one bag of optional fields.
+#[cfg(feature = "serde")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema), schemars(untagged))]
+pub(crate) enum ProxyShape {
+    /// A clean URL (or `system`/`none`/empty) next to dedicated credential fields.
+    Fields {
+        /// Where to find the proxy: empty or `system` to follow the environment, `none` for a
+        /// direct connection, otherwise the proxy URL, carrying no credentials, whose scheme has
+        /// to be `http`.
+        #[cfg_attr(
+            feature = "schema",
+            schemars(rename = "Address", with = "String", default)
+        )]
+        config: ProxyConfig,
+        /// Username for proxy authentication.
+        #[cfg_attr(feature = "schema", schemars(rename = "Username", default))]
+        username: String,
+        /// Password for proxy authentication.
+        #[cfg_attr(
+            feature = "schema",
+            schemars(rename = "Password", with = "String", default)
+        )]
+        password: SecretString,
+    },
+    /// A URL that carries its credentials itself, `user:password@` in its authority; the dedicated
+    /// credential fields must stay empty.
+    Embedded {
+        /// The proxy URL, credentials included.
+        #[cfg_attr(feature = "schema", schemars(rename = "Address", with = "String"))]
+        config: ProxyConfig,
+    },
+}
+
+#[cfg(feature = "serde")]
+impl ProxyShape {
+    /// Which shape `raw` fits, if any. [`parse_proxy_address`] moves any URL credentials into the
+    /// config's fields, so a non-empty field there means the URL carried some.
+    fn classify(raw: RawProxy) -> Result<Self, crate::config::ConfigError> {
+        use crate::config::IncompatibleOptionsSnafu;
+
+        let config = parse_proxy_address(raw.address.expose_secret())?;
+        let url_carried =
+            !config.username.is_empty() || !config.password.expose_secret().is_empty();
+        let dedicated = !raw.username.is_empty() || !raw.password.expose_secret().is_empty();
+        match (url_carried, dedicated) {
+            (true, true) => IncompatibleOptionsSnafu {
+                msg: String::from(
+                    "credentials are set both inside the `ProxyAddress` URL and through \
+                     `ProxyUsername`/`ProxyPassword`; set them one way",
+                ),
+            }
+            .fail(),
+            (true, false) => Ok(Self::Embedded { config }),
+            (false, _) => Ok(Self::Fields {
+                config,
+                username: raw.username,
+                password: raw.password,
+            }),
+        }
+    }
+
+    /// The configuration either shape describes.
+    fn resolve(self) -> ProxyConfig {
+        match self {
+            Self::Embedded { config } => config,
+            Self::Fields {
+                config,
+                username,
+                password,
+            } => config.with_credentials(username, password),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl TryFrom<RawProxy> for ProxyConfig {
+    type Error = crate::config::ConfigError;
+
+    fn try_from(raw: RawProxy) -> Result<Self, Self::Error> {
+        ProxyShape::classify(raw).map(ProxyShape::resolve)
+    }
+}
+
+/// Interpret the address option.
+///
+/// Empty and `system` follow the environment, `none` forces a direct connection, anything else is a
+/// proxy URL, defaulting to the `http` scheme. A URL that cannot be dialled as written, a missing
+/// host, a port that is not one, or a scheme the `CONNECT` handshake cannot use, fails here, while
+/// the configuration is being read and the message can name the option, rather than at connect
+/// time. Every message elides the userinfo: a URL is rejected as often for a mistyped credential as
+/// for anything else.
+#[cfg(feature = "serde")]
+fn parse_proxy_address(proxy: &str) -> Result<ProxyConfig, crate::config::ConfigError> {
+    use crate::config::IncompatibleOptionsSnafu;
+    use snafu::ensure;
+
+    if proxy.is_empty() || proxy.eq_ignore_ascii_case("system") {
+        return Ok(ProxyConfig::system());
+    }
+    if proxy.eq_ignore_ascii_case("none") {
+        return Ok(ProxyConfig::disabled());
+    }
+
+    let with_scheme = if proxy.contains("://") {
+        proxy.to_owned()
+    } else {
+        format!("http://{proxy}")
+    };
+    // Not reported through the endpoint's URI error: its message names the endpoint, which would
+    // send whoever reads it looking at the wrong option.
+    let uri = Uri::try_from(&with_scheme).ok().filter(|uri| {
+        uri.authority()
+            .is_some_and(|authority| !authority.host().is_empty())
+    });
+    let Some(uri) = uri else {
+        return IncompatibleOptionsSnafu {
+            msg: format!(
+                "`ProxyAddress={}` is not a valid proxy URL. Expected `none`, `system`, or a URL \
+                 such as `http://proxy.example.com:3128`",
+                elide_userinfo(proxy)
+            ),
+        }
+        .fail();
+    };
+
+    ensure!(
+        uri.scheme_str().is_none_or(|scheme| scheme == "http"),
+        IncompatibleOptionsSnafu {
+            msg: format!(
+                "{}, and `ProxyAddress={}` names another scheme",
+                HTTP_ONLY_RULE,
+                elide_userinfo(proxy)
+            ),
+        }
+    );
+
+    let config = ProxyConfig::explicit(uri);
+    let ProxySource::Explicit(stripped) = &config.source else {
+        return IncompatibleOptionsSnafu {
+            msg: String::from("`ProxyAddress`: an explicit proxy should stay explicit"),
+        }
+        .fail();
+    };
+
+    // `explicit` swaps in the placeholder when the credential-stripped authority cannot be rebuilt
+    // (`@` is legal inside a bracketed authority, so `http://[user:password@proxy]` parses yet
+    // `proxy]` is not a host on its own). Routing refuses the placeholder anyway, but this option's
+    // contract is to fail while the configuration is read and name itself, elided.
+    ensure!(
+        stripped != &elided_proxy(),
+        IncompatibleOptionsSnafu {
+            msg: format!(
+                "`ProxyAddress={}` is not a valid proxy URL once its credentials are taken out. \
+                 Expected `none`, `system`, or a URL such as `http://proxy.example.com:3128`",
+                elide_userinfo(proxy)
+            ),
+        }
+    );
+
+    // `http::Uri` keeps the port as text and parses it lazily, so `proxy.corp:99999` or
+    // `proxy.corp:31z8` would otherwise be accepted here and silently dialled on port 80. Checked
+    // on the credential-stripped form, where the only `:` left outside an IPv6 literal is a port's.
+    let authority = stripped.authority().expect("checked above to have a host");
+    let written_port = authority
+        .as_str()
+        .rsplit_once(':')
+        .map(|(_, tail)| tail)
+        .filter(|tail| !tail.contains(']'));
+    ensure!(
+        written_port.is_none() || stripped.port_u16().is_some(),
+        IncompatibleOptionsSnafu {
+            msg: format!(
+                "`ProxyAddress={}` does not name a valid port",
+                elide_userinfo(proxy)
+            ),
+        }
+    );
+
+    Ok(config)
+}
 
 /// Wraps a TCP connector so that it tunnels through an HTTP proxy when one is configured.
 ///
@@ -423,6 +655,49 @@ fn translate(proxy: Uri, error: impl std::error::Error + Send + Sync + 'static) 
     TunnelFailedSnafu { proxy }.into_error(BoxError::from(error))
 }
 
+/// The one statement of the scheme rule, shared between the connect-time check and the
+/// configuration-time one so the two messages cannot drift apart.
+pub(crate) const HTTP_ONLY_RULE: &str =
+    "The `CONNECT` handshake is written in the clear, so only an `http` proxy can be reached";
+
+/// Render a proxy URL with any credentials elided, for a message or a log line.
+///
+/// Textual rather than through [`Uri`], because the values that most need eliding are the ones that
+/// failed to parse in the first place. Every ambiguity elides rather than shows: over-eliding loses
+/// a detail from a message, under-eliding prints a password. That is also why the whole userinfo
+/// goes, username included: with no parse to lean on, there is no telling the halves apart.
+///
+/// Not the same job as [`RedactedUri`], which renders a value that did parse.
+#[cfg(feature = "serde")]
+pub(crate) fn elide_userinfo(value: &str) -> String {
+    let (scheme, rest) = match value.split_once("://") {
+        Some((scheme, rest)) => (Some(scheme), rest),
+        None => (None, value),
+    };
+    let elided = |body: String| match scheme {
+        Some(scheme) => format!("{scheme}://{body}"),
+        None => body,
+    };
+
+    // The last `@` in the whole of the rest, not just up to the first `/`. A password containing an
+    // unescaped `/` is malformed, which is exactly the input that reaches this function, and
+    // looking only at the authority would leave such a password rendered in full.
+    if let Some((_, remainder)) = rest.rsplit_once('@') {
+        return elided(format!("***@{remainder}"));
+    }
+
+    // No `@`, but a `:` whose tail is not a port: userinfo written without a host
+    // (`http://admin:hunter2`), and the tail is the password. An IPv6 literal also lands here and
+    // is over-elided; nothing leaks.
+    if let Some((head, tail)) = rest.split_once(':') {
+        if !tail.is_empty() && tail.parse::<u16>().is_err() {
+            return elided(format!("{head}:***"));
+        }
+    }
+
+    String::from(value)
+}
+
 /// Failure to reach the endpoint through the proxy.
 #[derive(Debug, Snafu)]
 #[non_exhaustive]
@@ -446,7 +721,7 @@ pub enum ProxyError {
         location: snafu::Location,
     },
     #[snafu(display(
-        "The proxy requires authentication; configure proxy credentials [{location}]"
+        "The proxy requires authentication; set `ProxyUsername` and `ProxyPassword` [{location}]"
     ))]
     #[non_exhaustive]
     AuthenticationRequired {
@@ -461,10 +736,7 @@ pub enum ProxyError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
-    #[snafu(display(
-        "The `CONNECT` handshake is written in the clear, so only an `http` proxy can be reached, \
-         not {proxy} [{location}]"
-    ))]
+    #[snafu(display("{HTTP_ONLY_RULE}, not {proxy} [{location}]"))]
     #[non_exhaustive]
     UnsupportedProxy {
         proxy: Uri,
@@ -676,6 +948,55 @@ mod tests {
             credentials,
             Some((String::from("[user"), String::from("s3cr3t")))
         );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn eliding_hides_the_credentials_and_keeps_the_rest() {
+        for (written, expected) in [
+            (
+                "http://user:secret@proxy.corp:3128",
+                "http://***@proxy.corp:3128",
+            ),
+            ("http://user@proxy.corp", "http://***@proxy.corp"),
+            // Rejected for having no host, and still worth eliding.
+            ("http://user:secret@", "http://***@"),
+            ("user:secret@proxy.corp", "***@proxy.corp"),
+            (
+                "http://user:secret@proxy.corp/path",
+                "http://***@proxy.corp/path",
+            ),
+            // A `/` inside the password is malformed, which is how such a value reaches this
+            // function at all, and is why the split is on the last `@` rather than on the
+            // authority.
+            (
+                "http://user:my/pass@proxy.corp:3128",
+                "http://***@proxy.corp:3128",
+            ),
+            // Several `@`: the last one wins, so nothing before it survives.
+            ("http://user:p@ss@proxy.corp", "http://***@proxy.corp"),
+            // Credentials with the `@host` part missing entirely: the tail is not a port, so it is
+            // a password.
+            ("http://admin:hunter2", "http://admin:***"),
+            ("admin:hunter2", "admin:***"),
+        ] {
+            let elided = elide_userinfo(written);
+            assert_eq!(elided, expected, "{written}");
+            assert!(
+                !elided.contains("secret")
+                    && !elided.contains("pass")
+                    && !elided.contains("hunter"),
+                "{written} still shows its password as {elided}"
+            );
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn eliding_leaves_a_url_without_credentials_untouched() {
+        for value in ["http://proxy.corp:3128", "proxy.corp:3128", "", "none"] {
+            assert_eq!(elide_userinfo(value), value, "{value}");
+        }
     }
 
     #[test]

--- a/packages/rust/armonik-transport/src/proxy.rs
+++ b/packages/rust/armonik-transport/src/proxy.rs
@@ -309,8 +309,13 @@ struct RawProxy {
 #[cfg(feature = "serde")]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema), schemars(untagged))]
 pub(crate) enum ProxyShape {
-    /// A clean URL (or `system`/`none`/empty) next to dedicated credential fields.
-    Fields {
+    /// Credentials in the dedicated options, and an address carrying none.
+    ///
+    /// The address is a plain string here as everywhere, so this alternative cannot say that its
+    /// own `user:password@` is what the other one is for. Reading refuses an address carrying
+    /// credentials next to a non-empty `Username` or `Password`; a document validating against
+    /// this alternative is not therefore one the reader accepts.
+    AddressWithoutCredentials {
         /// Where to find the proxy: empty or `system` to follow the environment, `none` for a
         /// direct connection, otherwise the proxy URL, carrying no credentials, whose scheme has
         /// to be `http`.
@@ -329,9 +334,9 @@ pub(crate) enum ProxyShape {
         )]
         password: SecretString,
     },
-    /// A URL that carries its credentials itself, `user:password@` in its authority; the dedicated
-    /// credential fields must stay empty.
-    Embedded {
+    /// Credentials written into the address itself, `user:password@` in its authority, with the
+    /// dedicated options left unset. Setting both ways is refused rather than merged.
+    AddressCarryingCredentials {
         /// The proxy URL, credentials included.
         #[cfg_attr(feature = "schema", schemars(rename = "Address", with = "String"))]
         config: ProxyConfig,
@@ -357,8 +362,8 @@ impl ProxyShape {
                 ),
             }
             .fail(),
-            (true, false) => Ok(Self::Embedded { config }),
-            (false, _) => Ok(Self::Fields {
+            (true, false) => Ok(Self::AddressCarryingCredentials { config }),
+            (false, _) => Ok(Self::AddressWithoutCredentials {
                 config,
                 username: raw.username,
                 password: raw.password,
@@ -369,8 +374,8 @@ impl ProxyShape {
     /// The configuration either shape describes.
     fn resolve(self) -> ProxyConfig {
         match self {
-            Self::Embedded { config } => config,
-            Self::Fields {
+            Self::AddressCarryingCredentials { config } => config,
+            Self::AddressWithoutCredentials {
                 config,
                 username,
                 password,

--- a/packages/rust/armonik-transport/tests/proxy.rs
+++ b/packages/rust/armonik-transport/tests/proxy.rs
@@ -199,12 +199,16 @@ async fn a_missing_credential_is_reported_as_such() {
         .await
         .expect_err("the proxy should have refused the tunnel");
 
-    // The message has to say credentials are what is missing, otherwise a 407 is a dead end for
-    // whoever hits it.
+    // The message has to name the options to set, otherwise a 407 is a dead end for whoever hits
+    // it.
     let rendered = error_chain(error.as_ref());
     assert!(
         rendered.contains("requires authentication"),
         "unexpected error: {rendered}"
+    );
+    assert!(
+        rendered.contains("ProxyUsername"),
+        "the error should say which options to set: {rendered}"
     );
     // And the failure has to be matchable by type, not only by text: `find_in` is how a caller
     // reacts to this case in particular, e.g. by prompting for credentials.
@@ -442,6 +446,58 @@ async fn an_https_proxy_from_the_environment_is_refused_before_dialling() {
             .as_ref(),
     );
     assert!(error.contains("only an `http` proxy"), "{error}");
+}
+
+// --- the string-form options, from the words to the tunnel ---
+
+#[cfg(feature = "serde")]
+#[tokio::test]
+async fn the_proxy_options_reach_the_tunnel() {
+    // Through serde on purpose, so the reading is under test along with the tunnelling: accepting
+    // the options and then not proxying is the defect the whole feature exists to fix.
+    let server = spawn_server().await;
+    let (proxy, tunnels) = spawn_proxy(ProxyAuth::Required("dXNlcjpzZWNyZXQ=")).await;
+
+    let config: HttpConfig = serde_json::from_value(serde_json::json!({
+        "Endpoint": server,
+        "AllowUnsafeConnection": "true",
+        "ProxyAddress": format!("http://{proxy}"),
+        "ProxyUsername": "user",
+        "ProxyPassword": "secret",
+    }))
+    .expect("a valid configuration");
+
+    let answer = call_through(config)
+        .await
+        .expect("the call should succeed through the proxy the options name");
+
+    assert_eq!(answer, common::REPLY);
+    assert_eq!(tunnels.load(Ordering::SeqCst), 1);
+}
+
+#[cfg(feature = "serde")]
+#[tokio::test]
+#[serial_test::serial(env)]
+async fn the_system_address_takes_the_proxy_from_the_environment() {
+    let environment = ProxyEnvironment::cleared();
+    let server = spawn_server().await;
+    let (proxy, tunnels) = spawn_proxy(ProxyAuth::None).await;
+
+    let config: HttpConfig = serde_json::from_value(serde_json::json!({
+        "Endpoint": server,
+        "AllowUnsafeConnection": "true",
+        "ProxyAddress": "system",
+    }))
+    .expect("a valid configuration");
+
+    environment.set("HTTP_PROXY", format!("http://{proxy}"));
+    let outcome = call_through(config).await;
+
+    assert_eq!(
+        outcome.expect("the call should go through the proxy the environment names"),
+        common::REPLY
+    );
+    assert_eq!(tunnels.load(Ordering::SeqCst), 1);
 }
 
 // --- the handshake is bounded in time ---

--- a/packages/rust/armonik-transport/tests/schema.rs
+++ b/packages/rust/armonik-transport/tests/schema.rs
@@ -93,6 +93,9 @@ fn every_option_appears_under_its_flat_name() {
         "InitialBackOff",
         "MaxBackOff",
         "BackOffMultiplier",
+        "ProxyAddress",
+        "ProxyUsername",
+        "ProxyPassword",
     ] {
         assert!(names.iter().any(|name| name == option), "missing {option}");
     }
@@ -101,23 +104,16 @@ fn every_option_appears_under_its_flat_name() {
 #[test]
 fn the_schema_promises_nothing_that_is_not_read() {
     // A consumer generates its options class from this, so an option the schema declares and
-    // deserialisation ignores is a field that silently does nothing. The proxy and the retryable
-    // status codes are set programmatically and no option reads them.
+    // deserialisation ignores is a field that silently does nothing. The retryable status codes
+    // are set programmatically and no option reads them.
     let schema = schema();
     let mut names = Vec::new();
     property_names(&schema, &mut names);
 
-    for absent in [
-        "ProxyAddress",
-        "ProxyUsername",
-        "ProxyPassword",
-        "RetryableStatusCodes",
-    ] {
-        assert!(
-            !names.iter().any(|name| name == absent),
-            "`{absent}` is not read"
-        );
-    }
+    assert!(
+        !names.iter().any(|name| name == "RetryableStatusCodes"),
+        "`RetryableStatusCodes` is not read"
+    );
 }
 
 #[test]
@@ -137,6 +133,9 @@ fn the_prefixed_groups_keep_their_flat_spellings() {
         "KeepAliveTimeout",
         "KeepAliveWhileIdle",
         "MaxHeaderListSize",
+        "Address",
+        "Username",
+        "Password",
     ] {
         assert!(
             !names.iter().any(|name| name == unprefixed),
@@ -188,6 +187,35 @@ fn the_identity_alternatives_are_an_any_of() {
     assert!(
         identity.is_some(),
         "no anyOf spells the PEM pair and the PKCS#12 bundle as alternatives: {schema:#}"
+    );
+}
+
+#[test]
+fn the_proxy_alternatives_are_an_any_of() {
+    // Credentials come one of two ways, written into the URL or through the dedicated fields;
+    // deserialisation refuses a mix, so the schema spells the two shapes rather than flattening
+    // them into one bag a consumer could fill both halves of.
+    let schema = schema();
+    let mut found = Vec::new();
+    any_ofs(&schema, &mut found);
+
+    let proxy = found.iter().find(|alternatives| {
+        let with_fields = alternatives.iter().any(|alternative| {
+            let mut names = Vec::new();
+            property_names(alternative, &mut names);
+            names.iter().any(|name| name == "ProxyUsername")
+        });
+        let embedded = alternatives.iter().any(|alternative| {
+            let mut names = Vec::new();
+            property_names(alternative, &mut names);
+            names.iter().any(|name| name == "ProxyAddress")
+                && !names.iter().any(|name| name == "ProxyUsername")
+        });
+        with_fields && embedded
+    });
+    assert!(
+        proxy.is_some(),
+        "no anyOf spells the two proxy credential shapes: {schema:#}"
     );
 }
 


### PR DESCRIPTION
Gives the HTTP proxy an option surface. `HttpConfig::proxy` was `#[serde(skip)]` and no option
read it, so a deployment that set the proxy options got a direct connection and no error.

`ProxyConfig` becomes a unit read through `embed_prefixed!` under the `Proxy` prefix, so
`ProxyAddress`, `ProxyUsername` and `ProxyPassword` come from the prefix mechanism with no
hand-written rename. `ProxyAddress` takes the same four values as ArmoniK's C# client: empty and
`system` follow the environment, `none` forces a direct connection, anything else is the proxy URL,
defaulting to the `http` scheme.

Credentials go in one place or the other, never both. `ProxyShape` spells the two shapes the way
`RawIdentity` spells a TLS identity's: a clean URL next to dedicated credential options, or a URL
carrying `user:password@` itself. A mix is refused while the configuration is read, because
guessing which half of which source wins would turn it into a silent surprise. The same enum is
what describes the unit to the JSON schema, as an `anyOf` whose branches differ by which options
they declare.

A URL that cannot be dialled as written is refused at read time, where the message can name the
option, rather than at connect time where it would look like an unreachable proxy: no host, a
scheme other than `http`, a port that is not one (`http::Uri` parses the port lazily, so
`proxy.corp:31z8` would otherwise be dialled on 80), and one whose credentials cannot be stripped.
Every message elides the userinfo, since a URL is rejected as often for a mistyped credential as
for anything else.

`RawProxy.address` is a `SecretString`, not a `String`: a proxy URL can embed credentials and
`RawProxy` derives `Debug`. It reads through `config_utils::secret_text`.

The bare `Proxy` name is deliberately not read; a matching C# rename is tracked as its own issue. The
README gains a list of three divergences from the C# client - this naming, the `NONE` casing, and an
`https` proxy refused rather than passed on. Three assertions flip rather than being added: `tests/schema.rs`'s
`the_schema_promises_nothing_that_is_not_read` no longer lists the proxy options as absent,
`src/config.rs`'s `a_proxy_option_is_ignored_rather_than_refused` becomes
`a_proxy_option_is_read_rather_than_ignored`, and `a_missing_credential_is_reported_as_such` now
requires the 407 message to name the options to set.

Evidence, from `packages/rust`:

    cargo test -p armonik-transport --all-features
      test result: ok. 71 passed  (lib)
      test result: ok. 15 passed  (proxy)
      test result: ok. 6 passed   (schema)
      test result: ok. 6 passed   (timeout)
    cargo clippy -p armonik-transport --all-features --all-targets   0 warnings
    cargo clippy -p armonik --all-features --all-targets             0 warnings
    cargo check -p armonik-transport --no-default-features           0 warnings
    cargo fmt --check                                                clean
    cargo run -p armonik-transport --features schema --example generate_schema
      ProxyAddress / ProxyUsername / ProxyPassword present, as an anyOf of the two shapes

This PR adds 18 tests, counted with

    git diff wk/feat/rust-config-env-v2...wk/feat/rust-proxy-options | grep -cE '^\+\s*#\[(tokio::)?test\]'

The running suites grow by the same 18: 85 to 100 in the library, 13 to 15 in `proxy`, 5 to 6 in
`schema`. They cover the four `ProxyAddress` readings, credentials taken out of
the URL, the dedicated options, the three ways a mixed configuration can be written, both password
shapes kept out of `Debug`, the five rejections and their elision, IPv6 with and without a port,
`elide_userinfo` itself, the proxy `anyOf` in the schema, and two end-to-end tests taking the
options through a real tunnel and through the environment.
