### PR TITLE
feat(rust): keep Rust doc links out of the generated schema

### DIFF
--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -82,7 +82,7 @@ embed_prefixed!(
 #[cfg_attr(
     feature = "schema",
     derive(schemars::JsonSchema),
-    schemars(transform = crate::config_utils::strip_defaults)
+    schemars(transform = crate::config_utils::strip_rust_details)
 )]
 #[non_exhaustive]
 pub struct HttpConfig {

--- a/packages/rust/armonik-transport/src/config_utils/mod.rs
+++ b/packages/rust/armonik-transport/src/config_utils/mod.rs
@@ -71,17 +71,56 @@ macro_rules! embed_prefixed {
 #[cfg(feature = "serde")]
 pub(crate) use embed_prefixed;
 
-/// Remove every `default` from the generated schema, recursively.
+/// Rewrites a rustdoc intra-doc link into plain text: ``[`a::b::c`]`` becomes ```c```.
+///
+/// Only the last segment survives: the module path names types that exist on this side of code
+/// generation and nowhere else.
+#[cfg(feature = "schema")]
+fn plain_text(description: &str) -> String {
+    let mut out = String::with_capacity(description.len());
+    let mut rest = description;
+    while let Some(start) = rest.find("[`") {
+        let (before, from) = rest.split_at(start);
+        out.push_str(before);
+        let body = &from[2..];
+        // An opening delimiter with no closing one is not a link: the rest is prose, and rewriting
+        // it would eat text a reader needs.
+        let Some(end) = body.find("`]") else {
+            out.push_str(from);
+            return out;
+        };
+        let path = &body[..end];
+        out.push('`');
+        out.push_str(path.rsplit_once("::").map_or(path, |(_, last)| last));
+        out.push('`');
+        rest = &body[end + 2..];
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Take out of the generated schema what belongs to this crate rather than to the vocabulary:
+/// every `default`, and the rustdoc links inside every `description`. Recursive, because
+/// `schemars` is free to nest.
 ///
 /// A `default` here is a Rust field's `Default`, serialised in the field's own type rather than in
 /// the option's text form: `false` on an option whose schema type is string. Every option's real
 /// contract is already stated once, as text: an empty or absent option reads as its default.
+///
+/// A `description` is the doc comment verbatim, and reaches a generated options class the same
+/// way. A Rust path resolves to nothing there, and the brackets around it read as broken markup.
 #[cfg(feature = "schema")]
-pub(crate) fn strip_defaults(schema: &mut schemars::Schema) {
+pub(crate) fn strip_rust_details(schema: &mut schemars::Schema) {
+    fn clean(object: &mut serde_json::Map<String, serde_json::Value>) {
+        object.remove("default");
+        if let Some(serde_json::Value::String(description)) = object.get_mut("description") {
+            *description = plain_text(description);
+        }
+    }
     fn strip(value: &mut serde_json::Value) {
         match value {
             serde_json::Value::Object(object) => {
-                object.remove("default");
+                clean(object);
                 for child in object.values_mut() {
                     strip(child);
                 }
@@ -95,7 +134,7 @@ pub(crate) fn strip_defaults(schema: &mut schemars::Schema) {
         }
     }
     let object = schema.ensure_object();
-    object.remove("default");
+    clean(object);
     for child in object.values_mut() {
         strip(child);
     }

--- a/packages/rust/armonik-transport/src/http2_config.rs
+++ b/packages/rust/armonik-transport/src/http2_config.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 #[cfg_attr(
     feature = "schema",
     derive(schemars::JsonSchema),
-    schemars(transform = crate::config_utils::strip_defaults)
+    schemars(transform = crate::config_utils::strip_rust_details)
 )]
 #[non_exhaustive]
 pub struct Http2Config {

--- a/packages/rust/armonik-transport/src/retry_config.rs
+++ b/packages/rust/armonik-transport/src/retry_config.rs
@@ -115,7 +115,7 @@ impl RetryConfig {
 #[cfg_attr(
     feature = "schema",
     derive(schemars::JsonSchema),
-    schemars(transform = crate::config_utils::strip_defaults)
+    schemars(transform = crate::config_utils::strip_rust_details)
 )]
 #[serde(rename_all = "PascalCase", default)]
 pub(crate) struct RawRetry {

--- a/packages/rust/armonik-transport/src/tcp_config.rs
+++ b/packages/rust/armonik-transport/src/tcp_config.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 #[cfg_attr(
     feature = "schema",
     derive(schemars::JsonSchema),
-    schemars(transform = crate::config_utils::strip_defaults)
+    schemars(transform = crate::config_utils::strip_rust_details)
 )]
 #[non_exhaustive]
 pub struct TcpConfig {

--- a/packages/rust/armonik-transport/src/tls_config.rs
+++ b/packages/rust/armonik-transport/src/tls_config.rs
@@ -154,7 +154,7 @@ pub struct TlsConfig {
 #[cfg_attr(
     feature = "schema",
     derive(schemars::JsonSchema),
-    schemars(transform = crate::config_utils::strip_defaults)
+    schemars(transform = crate::config_utils::strip_rust_details)
 )]
 #[serde(rename_all = "PascalCase")]
 pub(crate) struct RawTls {

--- a/packages/rust/armonik-transport/tests/schema.rs
+++ b/packages/rust/armonik-transport/tests/schema.rs
@@ -117,6 +117,47 @@ fn the_schema_promises_nothing_that_is_not_read() {
 }
 
 #[test]
+fn no_description_carries_a_rust_doc_link() {
+    // A description reaches a generated options class verbatim. An intra-doc link resolves to
+    // nothing there and its brackets read as broken markup, so the schema keeps the prose and
+    // drops the path.
+    fn descriptions(value: &serde_json::Value, found: &mut Vec<String>) {
+        match value {
+            serde_json::Value::Object(object) => {
+                if let Some(serde_json::Value::String(description)) = object.get("description") {
+                    found.push(description.clone());
+                }
+                for child in object.values() {
+                    descriptions(child, found);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for item in items {
+                    descriptions(item, found);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let schema = schema();
+    let mut found = Vec::new();
+    descriptions(&schema, &mut found);
+
+    assert!(!found.is_empty(), "no descriptions at all: {schema:#}");
+    for description in &found {
+        assert!(
+            !description.contains("[`"),
+            "a rustdoc link survives: {description}"
+        );
+        assert!(
+            !description.contains("crate::"),
+            "a crate path survives: {description}"
+        );
+    }
+}
+
+#[test]
 fn the_prefixed_groups_keep_their_flat_spellings() {
     // `serde_with::with_prefix!` has no `schemars` integration, so without the prefix helper the
     // schema would list each group under its unprefixed field names.


### PR DESCRIPTION
A `description` in the generated schema reaches a generated options class verbatim. Three of them
carried rustdoc intra-doc links:

```
"Send HTTP/2 keepalive PINGs even when idle, defaults to false.
 See [`crate::TlsConfig::allow_unsafe_connection`] for the accepted spellings."
```

A Rust path resolves to nothing on the other side of code generation, and the brackets around it
read as broken markup in a C# doc comment nobody can follow.

## What changes

The transform that already removes Rust-typed defaults now cleans descriptions as well, so it is
renamed for what it does: take out what belongs to this crate rather than to the option vocabulary.
Five call sites follow the rename.

A link keeps only its last path segment, and the prose around it is untouched:

```
"... See `allow_unsafe_connection` for the accepted spellings."
```

## The segment is not cased into an option name

`allow_unsafe_connection` is a Rust field; the option a consumer sees is `AllowUnsafeConnection`.
Converting snake_case to PascalCase would produce the right name for a field reference and a wrong
one for a type or a method - `Self::load` would become `Load`, which names nothing at all. Inventing
a name that resolves to nothing is what this PR removes, so the segment stays as written.

Two of the three links point at a field and would survive that conversion; the third does not. If
the remaining Rust-shaped names are still noise once the C# generator exists and it can be seen in
context, the honest fix is to reword those three doc comments rather than to guess in a transform.

## Scope

Kept out of the schema PR it belongs to: the transform is applied at five sites, one of which is
`retry_config.rs`, a file that does not exist at that point in the stack. The rename could not be
made correctly there.

## Tests

Adds 1: `no_description_carries_a_rust_doc_link` walks every description in the generated schema and
asserts none contains link markup or a crate path. It asserts the walk found descriptions at all
first, so it cannot pass by finding nothing.

`cargo test -p armonik-transport --all-features`: 128 passed, 0 failed.
`cargo clippy -p armonik-transport -p armonik --all-features --all-targets`: clean.
`cargo check -p armonik-transport --no-default-features`: clean.
Generated schema: zero occurrences of link markup remain.
