### PR TITLE
ci: build the whole Rust workspace before the tests run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,9 +150,10 @@ jobs:
           components: rust-src,rust-docs,rustfmt${{contains(matrix.language.toolchain, 'nightly') && ',miri' || ''}}
       - name: Build Rust package
         if: ${{ matrix.language.lang == 'Rust' }}
-        working-directory: packages/rust/armonik
+        # The workspace root, so this pre-builds every member the test command covers.
+        working-directory: packages/rust
         run: |
-          cargo build --locked --tests
+          cargo build --locked --workspace --all-features --tests
 
       # Prepare C++
       - name: Build C++ package


### PR DESCRIPTION
The Rust test entries in `test.yml` run

```
cargo test --locked --workspace --all-features
```

from `packages/rust` - the matrix's `dir: rust` is resolved by `scripts/mock_test.sh`, which does
`cd packages/$TEST_DIR`.

The step meant to pre-build them did not match on either count:

```yaml
working-directory: packages/rust/armonik
run: cargo build --locked --tests
```

One member instead of the workspace, and no `--all-features`.

## What that costs

`cargo tree -e normal --depth 0` from `packages/rust/armonik` reports only `armonik`, so
`armonik-transport/tests/timeout.rs` was never pre-built by the step whose purpose is to pre-build
the tests. Nor was any feature-gated code, since `--all-features` was absent.

That compilation does not disappear - it moves into the test step, which runs *after*
`mock_test.sh` has started the mock server and slept 5 seconds. So the server sits waiting through
a compile the build step was supposed to have done.

## The fix

The workspace root, and the same scope the test command uses:

```yaml
working-directory: packages/rust
run: cargo build --locked --workspace --all-features --tests
```

`ci.yml` already makes exactly this choice, with a comment giving exactly this reason ("The
workspace root, so every `--workspace` below covers both members rather than just one"). `test.yml`
is the file that was missed.

## Verification

`cargo build --locked --workspace --all-features --tests` from `packages/rust`: clean, exit 0.

Beyond that this is only provable by running: the value is in what CI does across both toolchains
and both operating systems, which no local run reproduces. Worth watching this PR's own matrix
before trusting it.

## What this does not claim to fix

Two Rust test jobs on the config stack failed recently, both with connections refused to the mock
server on `127.0.0.1:5003`, and in different shapes: run `31221030503` failed one test of 114, run
`31195009808` failed seven of 115. `client::agent::tests::create_results_metadata` is in both.

Pre-building shortens the window between starting that server and the first test, so this *may*
make those failures rarer. It is not a fix for them, and I have not shown a causal link.
