### PR TITLE
feat(rust): name how long an idle pooled connection is kept

### DIFF
--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -67,6 +67,63 @@ embed_prefixed!(
     "Proxy"
 );
 
+/// What an intra-doc link into a unit renders as: the name a doc comment links to that unit by,
+/// the prefix this configuration reads it under, and the fields of it that name one option each.
+///
+/// Here, next to the embeddings that choose those prefixes, rather than in `config_utils`: the
+/// same unit is a different set of names under a different prefix.
+///
+/// The fields are listed rather than derived because a rustdoc path says nothing about what it
+/// landed on: `username` and `explicit` are spelled alike, and so are an option's field and one
+/// that groups several options or that no option reads. A name built for either would be a name
+/// no source spells - the very thing this rewriting exists to keep out of the schema.
+#[cfg(feature = "schema")]
+const OPTION_FIELDS: &[crate::config_utils::PrefixedUnit<'static>] = &[
+    (
+        "TlsConfig",
+        "",
+        &["allow_unsafe_connection", "ca_cert", "override_target_name"],
+    ),
+    (
+        "TcpConfig",
+        "Tcp",
+        &[
+            "keepalive",
+            "keepalive_interval",
+            "keepalive_retries",
+            "nagle_algorithm",
+        ],
+    ),
+    (
+        "Http2Config",
+        "Http2",
+        &[
+            "keep_alive_interval",
+            "keep_alive_timeout",
+            "keep_alive_while_idle",
+            "max_header_list_size",
+        ],
+    ),
+    (
+        "RetryConfig",
+        "",
+        &[
+            "max_attempts",
+            "initial_back_off",
+            "max_back_off",
+            "back_off_multiplier",
+        ],
+    ),
+    ("ProxyConfig", "Proxy", &["username", "password"]),
+];
+
+/// [`crate::config_utils::strip_rust_details`] over this configuration's own units: every type of
+/// the vocabulary transforms its schema through here, so all of them render a link the same way.
+#[cfg(feature = "schema")]
+pub(crate) fn strip_rust_details(schema: &mut schemars::Schema) {
+    crate::config_utils::strip_rust_details(OPTION_FIELDS, schema);
+}
+
 /// Options for creating a gRPC client.
 ///
 /// Deserializable but deliberately not serializable: the proxy password is a secret, and a type
@@ -82,7 +139,7 @@ embed_prefixed!(
 #[cfg_attr(
     feature = "schema",
     derive(schemars::JsonSchema),
-    schemars(transform = crate::config_utils::strip_rust_details)
+    schemars(transform = crate::config::strip_rust_details)
 )]
 #[non_exhaustive]
 pub struct HttpConfig {
@@ -353,6 +410,53 @@ mod tests {
         serde_json::from_value::<HttpConfig>(value)
             .expect_err("the configuration should be rejected")
             .to_string()
+    }
+
+    /// Every property name the schema declares, wherever `schemars` nested it.
+    #[cfg(feature = "schema")]
+    fn property_names(value: &serde_json::Value, names: &mut Vec<String>) {
+        match value {
+            serde_json::Value::Object(object) => {
+                for (key, child) in object {
+                    if key == "properties" {
+                        if let serde_json::Value::Object(properties) = child {
+                            names.extend(properties.keys().cloned());
+                        }
+                    }
+                    property_names(child, names);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for item in items {
+                    property_names(item, names);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    #[cfg(feature = "schema")]
+    #[test]
+    fn every_field_a_link_resolves_through_names_an_option_the_schema_declares() {
+        // The table is written by hand, so this is what keeps it from drifting: a field listed
+        // there under the wrong prefix, or one that stopped being an option, would put a name no
+        // deployment can set into a description a consumer generates its class from.
+        let schema = serde_json::to_value(schemars::schema_for!(HttpConfig))
+            .expect("a schema serialises to JSON");
+        let mut names = Vec::new();
+        property_names(&schema, &mut names);
+
+        for (unit, _, fields) in OPTION_FIELDS {
+            for field in *fields {
+                let path = format!("{unit}::{field}");
+                let flat = crate::config_utils::flat_name(&path, OPTION_FIELDS)
+                    .unwrap_or_else(|| panic!("`{path}` is listed and has to resolve"));
+                assert!(
+                    names.contains(&flat),
+                    "`{path}` renders `{flat}`, which no option spells"
+                );
+            }
+        }
     }
 
     #[test]

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -80,9 +80,11 @@ embed_prefixed!(
 #[cfg(feature = "schema")]
 const OPTION_FIELDS: &[crate::config_utils::PrefixedUnit<'static>] = &[
     (
+        // `ca_cert` is absent: it holds the certificate the reader loaded, where the option names
+        // the path it was read from, so a link to the field resolves to no option at all.
         "TlsConfig",
         "",
-        &["allow_unsafe_connection", "ca_cert", "override_target_name"],
+        &["allow_unsafe_connection", "override_target_name"],
     ),
     (
         "TcpConfig",

--- a/packages/rust/armonik-transport/src/config.rs
+++ b/packages/rust/armonik-transport/src/config.rs
@@ -106,6 +106,13 @@ pub struct HttpConfig {
     #[cfg_attr(feature = "serde", serde(deserialize_with = "optional_duration"))]
     #[cfg_attr(feature = "schema", schemars(with = "String"))]
     pub timeout: Option<Duration>,
+    /// How long an idle connection is kept in a pool before it is closed. `PoolIdleTimeout`.
+    ///
+    /// Applied by whoever drives the pool: a channel is one connection and has none, so nothing
+    /// in `connect` reads it.
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "optional_duration"))]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
+    pub pool_idle_timeout: Option<Duration>,
     /// Rate limit for requests, written `count/duration` (e.g. `100/1s`), defaults to no rate
     /// limit. `RateLimit`.
     #[cfg_attr(feature = "serde", serde(deserialize_with = "rate_limit"))]
@@ -158,6 +165,7 @@ impl Default for HttpConfig {
             tls: TlsConfig::default(),
             connect_timeout: Some(DEFAULT_CONNECT_TIMEOUT),
             timeout: None,
+            pool_idle_timeout: None,
             rate_limit: None,
             tcp: TcpConfig::default(),
             http2: Http2Config::default(),
@@ -411,6 +419,7 @@ mod tests {
             "Endpoint": "http://localhost:5001",
             "ConnectTimeout": "",
             "Timeout": "",
+            "PoolIdleTimeout": "",
             "RateLimit": "",
             "TcpKeepalive": "",
             "TcpKeepaliveRetries": "",
@@ -423,6 +432,7 @@ mod tests {
 
         assert_eq!(config.connect_timeout, Some(DEFAULT_CONNECT_TIMEOUT));
         assert_eq!(config.timeout, None);
+        assert_eq!(config.pool_idle_timeout, None);
         assert_eq!(config.rate_limit, None);
         assert_eq!(config.tcp.keepalive, None);
         assert_eq!(config.tcp.keepalive_retries, None);
@@ -437,12 +447,14 @@ mod tests {
         let config = config(json!({
             "Endpoint": "http://localhost:5001",
             "ConnectTimeout": "500ms",
+            "PoolIdleTimeout": "90s",
             "TcpKeepalive": "30s",
             "TcpKeepaliveInterval": "2m",
             "Http2KeepAliveInterval": "1h",
         }));
 
         assert_eq!(config.connect_timeout, Some(Duration::from_millis(500)));
+        assert_eq!(config.pool_idle_timeout, Some(Duration::from_secs(90)));
         assert_eq!(config.tcp.keepalive, Some(Duration::from_secs(30)));
         assert_eq!(
             config.tcp.keepalive_interval,

--- a/packages/rust/armonik-transport/src/config_utils/mod.rs
+++ b/packages/rust/armonik-transport/src/config_utils/mod.rs
@@ -71,12 +71,53 @@ macro_rules! embed_prefixed {
 #[cfg(feature = "serde")]
 pub(crate) use embed_prefixed;
 
-/// Rewrites a rustdoc intra-doc link into plain text: ``[`a::b::c`]`` becomes ```c```.
+/// One unit an embedding reads under a prefix: the name a doc comment links to it as, that prefix,
+/// and the fields of it that name one flat name each.
 ///
-/// Only the last segment survives: the module path names types that exist on this side of code
-/// generation and nowhere else.
+/// The last of the three is what makes a link resolvable at all: a rustdoc path says nothing about
+/// whether it landed on a field or on a method, and both are spelled the same way.
 #[cfg(feature = "schema")]
-fn plain_text(description: &str) -> String {
+pub(crate) type PrefixedUnit<'a> = (&'a str, &'a str, &'a [&'a str]);
+
+/// The last segment of a Rust path.
+#[cfg(feature = "schema")]
+fn last_segment(path: &str) -> &str {
+    path.rsplit_once("::").map_or(path, |(_, last)| last)
+}
+
+/// The flat name `path` spells, `None` for a link `units` cannot place.
+///
+/// A name is only ever built from a field one of `units` declares, its prefix followed by that
+/// field the way `serde` renames it. Anything else yields nothing: a name invented here is exactly
+/// the name no source spells that this rewriting exists to keep out.
+#[cfg(feature = "schema")]
+pub(crate) fn flat_name(path: &str, units: &[PrefixedUnit<'_>]) -> Option<String> {
+    let (owner, field) = path.rsplit_once("::")?;
+    let owner = last_segment(owner);
+    let prefix = units.iter().find_map(|(unit, prefix, fields)| {
+        (*unit == owner && fields.contains(&field)).then_some(*prefix)
+    })?;
+
+    let mut name = String::from(prefix);
+    for word in field.split('_') {
+        let mut letters = word.chars();
+        if let Some(first) = letters.next() {
+            name.extend(first.to_uppercase());
+            name.push_str(letters.as_str());
+        }
+    }
+    Some(name)
+}
+
+/// Rewrites a rustdoc intra-doc link into the name a document spells.
+///
+/// A link that lands on a field one of `units` declares becomes that field's flat name, prefix
+/// included: with `Unit` read under `Pre`, ``[`a::Unit::some_field`]`` becomes ```PreSomeField```.
+///
+/// Any other link keeps its last segment alone, ``[`a::b::c`]`` becoming ```c```: the module path
+/// names types that exist on this side of code generation and nowhere else.
+#[cfg(feature = "schema")]
+fn plain_text(description: &str, units: &[PrefixedUnit<'_>]) -> String {
     let mut out = String::with_capacity(description.len());
     let mut rest = description;
     while let Some(start) = rest.find("[`") {
@@ -91,7 +132,10 @@ fn plain_text(description: &str) -> String {
         };
         let path = &body[..end];
         out.push('`');
-        out.push_str(path.rsplit_once("::").map_or(path, |(_, last)| last));
+        match flat_name(path, units) {
+            Some(flat) => out.push_str(&flat),
+            None => out.push_str(last_segment(path)),
+        }
         out.push('`');
         rest = &body[end + 2..];
     }
@@ -109,34 +153,36 @@ fn plain_text(description: &str) -> String {
 ///
 /// A `description` is the doc comment verbatim, and reaches a generated options class the same
 /// way. A Rust path resolves to nothing there, and the brackets around it read as broken markup.
+/// `units` is what turns a link on a field into the name a document spells, and is the embedding's
+/// to supply: the same unit is a different set of names under a different prefix.
 #[cfg(feature = "schema")]
-pub(crate) fn strip_rust_details(schema: &mut schemars::Schema) {
-    fn clean(object: &mut serde_json::Map<String, serde_json::Value>) {
+pub(crate) fn strip_rust_details(units: &[PrefixedUnit<'_>], schema: &mut schemars::Schema) {
+    fn clean(object: &mut serde_json::Map<String, serde_json::Value>, units: &[PrefixedUnit<'_>]) {
         object.remove("default");
         if let Some(serde_json::Value::String(description)) = object.get_mut("description") {
-            *description = plain_text(description);
+            *description = plain_text(description, units);
         }
     }
-    fn strip(value: &mut serde_json::Value) {
+    fn strip(value: &mut serde_json::Value, units: &[PrefixedUnit<'_>]) {
         match value {
             serde_json::Value::Object(object) => {
-                clean(object);
+                clean(object, units);
                 for child in object.values_mut() {
-                    strip(child);
+                    strip(child, units);
                 }
             }
             serde_json::Value::Array(items) => {
                 for item in items {
-                    strip(item);
+                    strip(item, units);
                 }
             }
             _ => {}
         }
     }
     let object = schema.ensure_object();
-    clean(object);
+    clean(object, units);
     for child in object.values_mut() {
-        strip(child);
+        strip(child, units);
     }
 }
 
@@ -362,7 +408,47 @@ where
 
 #[cfg(all(test, feature = "schema"))]
 mod tests {
-    use super::schema_with_prefix;
+    use super::{plain_text, schema_with_prefix, PrefixedUnit};
+
+    /// Two units an embedding declares, one under a prefix and one under none. Invented, like the
+    /// type below: what is under test is the rewriting, not any particular vocabulary.
+    const UNITS: &[PrefixedUnit<'static>] = &[
+        ("Prefixed", "Pre", &["keep_alive_interval"]),
+        ("Bare", "", &["allow_it_p12"]),
+    ];
+
+    #[test]
+    fn a_link_into_a_unit_renders_the_name_with_the_prefix_it_is_read_under() {
+        // The bare field name is a name no source spells either: a unit's names carry its
+        // embedding's prefix, so the rendering has to carry it too.
+        assert_eq!(
+            plain_text("See [`a::b::Prefixed::keep_alive_interval`].", UNITS),
+            "See `PreKeepAliveInterval`."
+        );
+        assert_eq!(
+            plain_text("See [`crate::Bare::allow_it_p12`].", UNITS),
+            "See `AllowItP12`."
+        );
+    }
+
+    #[test]
+    fn a_link_the_units_cannot_place_keeps_the_last_segment_it_had() {
+        // Rendering a name for a target no unit declares would put into the contract exactly the
+        // name no source spells that this rewriting exists to keep out. `load` is the trap: a
+        // method of a unit that is declared is spelled exactly like a field of it.
+        for (written, expected) in [
+            ("[`Prefixed::load`]", "`load`"),
+            ("[`Self::load`]", "`load`"),
+            (
+                "[`Elsewhere::keep_alive_interval`]",
+                "`keep_alive_interval`",
+            ),
+            ("[`Prefixed::MAX_SIZE`]", "`MAX_SIZE`"),
+            ("[`crate::Prefixed`]", "`Prefixed`"),
+        ] {
+            assert_eq!(plain_text(written, UNITS), expected, "{written}");
+        }
+    }
 
     /// A unit whose shapes are selected untagged, so its schema is a union of branches and the
     /// names live one level down rather than at the top.

--- a/packages/rust/armonik-transport/src/env.rs
+++ b/packages/rust/armonik-transport/src/env.rs
@@ -217,6 +217,17 @@ mod tests {
     }
 
     #[test]
+    fn an_option_nothing_here_applies_is_read_all_the_same() {
+        // `PoolIdleTimeout` is for whoever drives a pool, so the read is the only thing that
+        // proves the option exists at all.
+        let config =
+            HttpConfig::from_env_vars("Prefix__", variables([("Prefix__PoolIdleTimeout", "90s")]))
+                .expect("a valid configuration");
+
+        assert_eq!(config.pool_idle_timeout, Some(Duration::from_secs(90)));
+    }
+
+    #[test]
     fn a_variable_declared_empty_reads_as_the_option_default_like_an_absent_one() {
         // A deployment that declares every variable with an empty default has to behave exactly
         // like one that declares none.

--- a/packages/rust/armonik-transport/src/http2_config.rs
+++ b/packages/rust/armonik-transport/src/http2_config.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 #[cfg_attr(
     feature = "schema",
     derive(schemars::JsonSchema),
-    schemars(transform = crate::config_utils::strip_rust_details)
+    schemars(transform = crate::config::strip_rust_details)
 )]
 #[non_exhaustive]
 pub struct Http2Config {

--- a/packages/rust/armonik-transport/src/retry_config.rs
+++ b/packages/rust/armonik-transport/src/retry_config.rs
@@ -115,7 +115,7 @@ impl RetryConfig {
 #[cfg_attr(
     feature = "schema",
     derive(schemars::JsonSchema),
-    schemars(transform = crate::config_utils::strip_rust_details)
+    schemars(transform = crate::config::strip_rust_details)
 )]
 #[serde(rename_all = "PascalCase", default)]
 pub(crate) struct RawRetry {

--- a/packages/rust/armonik-transport/src/tcp_config.rs
+++ b/packages/rust/armonik-transport/src/tcp_config.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 #[cfg_attr(
     feature = "schema",
     derive(schemars::JsonSchema),
-    schemars(transform = crate::config_utils::strip_rust_details)
+    schemars(transform = crate::config::strip_rust_details)
 )]
 #[non_exhaustive]
 pub struct TcpConfig {

--- a/packages/rust/armonik-transport/src/tls_config.rs
+++ b/packages/rust/armonik-transport/src/tls_config.rs
@@ -154,7 +154,7 @@ pub struct TlsConfig {
 #[cfg_attr(
     feature = "schema",
     derive(schemars::JsonSchema),
-    schemars(transform = crate::config_utils::strip_rust_details)
+    schemars(transform = crate::config::strip_rust_details)
 )]
 #[serde(rename_all = "PascalCase")]
 pub(crate) struct RawTls {

--- a/packages/rust/armonik-transport/tests/schema.rs
+++ b/packages/rust/armonik-transport/tests/schema.rs
@@ -79,6 +79,7 @@ fn every_option_appears_under_its_flat_name() {
         "OverrideTargetName",
         "ConnectTimeout",
         "Timeout",
+        "PoolIdleTimeout",
         "RateLimit",
         "TcpKeepalive",
         "TcpKeepaliveInterval",

--- a/packages/rust/armonik-transport/tests/schema.rs
+++ b/packages/rust/armonik-transport/tests/schema.rs
@@ -117,30 +117,63 @@ fn the_schema_promises_nothing_that_is_not_read() {
     );
 }
 
+/// Every `description` anywhere in the schema.
+fn descriptions(value: &serde_json::Value, found: &mut Vec<String>) {
+    match value {
+        serde_json::Value::Object(object) => {
+            if let Some(serde_json::Value::String(description)) = object.get("description") {
+                found.push(description.clone());
+            }
+            for child in object.values() {
+                descriptions(child, found);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                descriptions(item, found);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn a_description_names_an_option_the_way_a_document_spells_it() {
+    // A description reaches a generated options class verbatim, so a Rust field name in it names
+    // an option no deployment can set: `allow_unsafe_connection` is spelled `AllowUnsafeConnection`
+    // everywhere a source writes it. The prefix matters as much as the casing, which is why the
+    // rendering goes through the embeddings rather than through the field name alone.
+    let schema = schema();
+    let mut found = Vec::new();
+    descriptions(&schema, &mut found);
+
+    assert!(!found.is_empty(), "no descriptions at all: {schema:#}");
+    for description in &found {
+        for quoted in description.split('`').skip(1).step_by(2) {
+            let rust_field = quoted.starts_with(|first: char| first.is_ascii_lowercase())
+                && quoted.contains('_')
+                && quoted
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_');
+            assert!(
+                !rust_field,
+                "`{quoted}` is a Rust field name, not an option: {description}"
+            );
+        }
+    }
+    assert!(
+        found
+            .iter()
+            .any(|description| description.contains("`AllowUnsafeConnection`")),
+        "no description resolved a link to its flat name: {found:#?}"
+    );
+}
+
 #[test]
 fn no_description_carries_a_rust_doc_link() {
     // A description reaches a generated options class verbatim. An intra-doc link resolves to
     // nothing there and its brackets read as broken markup, so the schema keeps the prose and
     // drops the path.
-    fn descriptions(value: &serde_json::Value, found: &mut Vec<String>) {
-        match value {
-            serde_json::Value::Object(object) => {
-                if let Some(serde_json::Value::String(description)) = object.get("description") {
-                    found.push(description.clone());
-                }
-                for child in object.values() {
-                    descriptions(child, found);
-                }
-            }
-            serde_json::Value::Array(items) => {
-                for item in items {
-                    descriptions(item, found);
-                }
-            }
-            _ => {}
-        }
-    }
-
     let schema = schema();
     let mut found = Vec::new();
     descriptions(&schema, &mut found);


### PR DESCRIPTION
Sits on #738, which has to merge first.

# Motivation

A schema description reaches a generated options class verbatim, so what the vocabulary spells is
what a consumer writes. One description names a Rust field no deployment can set, and a pooled
deployment has no option at all for how long an idle connection is kept.

# Description

`PoolIdleTimeout` joins the vocabulary at the root, under no prefix: it bounds a connection's idle
life in a pool, which is neither a TCP nor an HTTP/2 setting. Nothing in this crate applies it, on
the model the `retry` field already sets - a channel is one connection and has no pool, so `connect`
has nothing to hand it to, and whoever drives the pool reads it.

Schema descriptions then spell the flat option name instead of the Rust field: `allow_unsafe_connection`
becomes `AllowUnsafeConnection`. Where the vocabulary cannot place a link, it keeps exactly the
rendering it has today, its last segment in backticks - the change never invents a name.

The prefix is the trap: a field of an embedded unit is spelled with its embedding's prefix, so
`keep_alive_interval` of `Http2Config` is `Http2KeepAliveInterval`. The units, their prefixes and
their option fields are declared in `config.rs` next to the `embed_prefixed!` calls that choose
those prefixes, and `config_utils` learns no vocabulary. They are listed rather than inferred
because a rustdoc path says nothing about what it landed on: `ProxyConfig::username` and
`ProxyConfig::explicit` are spelled alike, so inference would render `ProxyExplicit`, the very
defect being fixed.

# Testing

Adds 5. One reads `PoolIdleTimeout` from the environment, the only thing that proves an option
exists when no code consumes the value. Four cover the rewriting, among them a drift check walking
the hand-written table against the generated schema and requiring every listed field to render a
name the schema declares; mutated with the proxy prefix written `Prox`, it fails as it should.

`cargo test -p armonik-transport --all-features`, all green.

# Impact

Descriptions change wording and the vocabulary gains one name; no existing option moves.

# Additional Information

Two commits in one PR because they share a subject: both change what the option vocabulary tells the
consumer generating a class from it, which was wrong in the two ways it can be - a name missing from
it, and a description naming something no deployment can spell. Neither depends on the other.

# Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI. (locally yes; CI has not run this branch)
- [ ] I have assessed the performance impact of my modifications. (nothing measured)
