### PR TITLE
feat(rust): re-export what a consumer driving the connector needs

### DIFF
--- a/packages/rust/Cargo.lock
+++ b/packages/rust/Cargo.lock
@@ -95,7 +95,9 @@ name = "armonik-transport"
 version = "3.29.2-beta-0"
 dependencies = [
  "base64",
+ "h2",
  "http",
+ "http-body-util",
  "humantime",
  "hyper",
  "hyper-rustls",

--- a/packages/rust/Cargo.toml
+++ b/packages/rust/Cargo.toml
@@ -30,6 +30,7 @@ cbindgen = { version = "0.29", default-features = false }
 csbindgen = "1.9"
 eyre = "0.6"
 futures = "0.3"
+h2 = "0.4"
 http = "1"
 http-body-util = "0.1"
 humantime = "2.3.0"

--- a/packages/rust/armonik-transport/Cargo.toml
+++ b/packages/rust/armonik-transport/Cargo.toml
@@ -40,11 +40,14 @@ hyper = { workspace = true, features = ["client", "http1", "http2"] }
 # `hyper-rustls` happens to turn it on: depending on that would break the day it stops.
 # `client-proxy` for the proxy matcher: the `*_PROXY` convention, `NO_PROXY` on curl's rules, and
 # taking credentials out of a proxy URL, none of which is worth writing again here.
+# `http1` and `http2` gate the legacy `Client` itself, which exists only if one of them is on, and
+# HTTP/2 is what a dependent driving this connector over `reexports::hyper_util` speaks.
 hyper-util = { workspace = true, features = [
   "client",
   "client-legacy",
   "client-proxy",
   "http1",
+  "http2",
   "tokio",
 ] }
 hyper-rustls = { workspace = true, features = [

--- a/packages/rust/armonik-transport/Cargo.toml
+++ b/packages/rust/armonik-transport/Cargo.toml
@@ -35,6 +35,14 @@ http.workspace = true
 snafu.workspace = true
 tracing.workspace = true
 hyper = { workspace = true, features = ["client", "http1", "http2"] }
+# Neither is used by this crate. Both are re-exported, so a dependent that drives an HTTP/2 client
+# over this connector reads an `h2::Reason` off a hyper error with the same `h2` hyper raised it
+# from, and hands hyper a body hyper accepts. `h2` is already in this crate's tree through `hyper`;
+# `http-body-util` is the one crate this adds, and the workspace had already resolved it.
+# Default features: `channel` costs a `tokio` edge and belongs to whoever feeds a request body, on
+# that crate's own dependency, where the cost is attached to the need.
+h2.workspace = true
+http-body-util.workspace = true
 # `client-legacy` for `HttpConnector` and for the `Tunnel` connector that performs the `CONNECT`
 # handshake; `tokio` for `TokioIo` and the runtime side of both. Each is named here even though
 # `hyper-rustls` happens to turn it on: depending on that would break the day it stops.

--- a/packages/rust/armonik-transport/README.md
+++ b/packages/rust/armonik-transport/README.md
@@ -13,6 +13,11 @@ wants the services as well needs only that one.
 
 ## Driving the connection yourself
 
+`Connector` is the stack `https_connector` returns, TCP then the proxy tunnel then TLS, so a
+consumer that wraps it in an engine of its own can name what it holds: `Client<Connector, B>` rather
+than a trait object erasing the connector. `ProxyConnector`, one of its layers, is exported for the
+same reason; it is assembled from an `HttpConfig`, never by hand.
+
 `armonik_transport::reexports` carries the crates the connector is built from and spoken to: `http`,
 `hyper`, `hyper_util`, `hyper_rustls`, `rustls`, `h2`, `http_body_util` and `tokio`. Take them from
 there rather than declaring your own requirement for the same crates, and no version of a shared

--- a/packages/rust/armonik-transport/README.md
+++ b/packages/rust/armonik-transport/README.md
@@ -11,6 +11,22 @@ Depend on it when you need the connection layer without generated protobuf types
 `protoc`/`tonic-prost-build` build step. [`armonik`](../armonik) re-exports all of it, so a client that
 wants the services as well needs only that one.
 
+## Driving the connection yourself
+
+`armonik_transport::reexports` carries the crates the connector is built from and spoken to: `http`,
+`hyper`, `hyper_util`, `hyper_rustls`, `rustls`, `h2`, `http_body_util` and `tokio`. Take them from
+there rather than declaring your own requirement for the same crates, and no version of a shared
+type can drift from the one the connection was built with. `h2` and `http_body_util` are re-exported
+for that alone; nothing in this crate uses them.
+
+Only the versions are guaranteed, not the features. Which parts of a re-exported crate exist is
+decided by what every crate in the build asks for together, and this one asks only for the features
+it needs itself. So a consumer that needs a runtime still declares `tokio` for that: the `tokio`
+re-exported here is the one whose stream types the connector hands back, not a runtime.
+`http_body_util` is likewise re-exported without `channel`, so a consumer that feeds a request body
+through `http_body_util::channel::Channel` turns that feature on itself, where the `tokio` edge it
+adds reads as that consumer's need rather than as this crate's.
+
 ## Reading the options from the environment
 
 The `env` feature adds `HttpConfig::from_env(prefix)`: one variable per option, named `prefix` plus

--- a/packages/rust/armonik-transport/README.md
+++ b/packages/rust/armonik-transport/README.md
@@ -5,7 +5,8 @@ configuration parsing, and TLS/mTLS connection setup.
 
 `https_connector` is where the crate stops: it hands back the connector a request goes out through,
 TCP then the proxy tunnel then TLS, and wrapping that in an HTTP/2 engine belongs to whoever
-consumes it. [`armonik`](../armonik) wraps it in a `tonic` channel.
+consumes it. [`armonik`](../armonik) wraps it in a `tonic` channel. It is synchronous and opens no
+connection, so it needs no runtime and can be called from inside one.
 
 Depend on it when you need the connection layer without generated protobuf types or a
 `protoc`/`tonic-prost-build` build step. [`armonik`](../armonik) re-exports all of it, so a client that

--- a/packages/rust/armonik-transport/src/connector.rs
+++ b/packages/rust/armonik-transport/src/connector.rs
@@ -17,6 +17,12 @@ use snafu::{ResultExt, Snafu};
 use crate::proxy::ProxyConnector;
 use crate::HttpConfig;
 
+/// The connector stack [`https_connector`] builds: TCP, then the proxy tunnel, then TLS or mTLS.
+///
+/// Named because it has to be nameable. A consumer wraps this in an HTTP/2 engine of its own and
+/// then has to hold the result, and Rust offers no way to infer the type of a struct field.
+pub type Connector = HttpsConnector<ProxyConnector<HttpConnector>>;
+
 /// Build the connector stack, TCP then the proxy tunnel then TLS or mTLS, that reaches the endpoint
 /// `config` names.
 ///
@@ -24,14 +30,10 @@ use crate::HttpConfig;
 /// the server certificate is verified against when `OverrideTargetName` moves it off the endpoint.
 /// Taken rather than resolved here, so a caller that needs it for the engine it builds on top
 /// resolves it once.
-///
-/// Hidden because its return type names this crate's dependencies rather than its own; `pub` only
-/// so the signature is expressible.
-#[doc(hidden)]
 pub async fn https_connector(
     config: HttpConfig,
     origin: Uri,
-) -> Result<HttpsConnector<ProxyConnector<HttpConnector>>, ConnectionError> {
+) -> Result<Connector, ConnectionError> {
     let endpoint = config.endpoint;
 
     // Get the default crypto provider or fallback to the ring crypto provider

--- a/packages/rust/armonik-transport/src/connector.rs
+++ b/packages/rust/armonik-transport/src/connector.rs
@@ -30,10 +30,11 @@ pub type Connector = HttpsConnector<ProxyConnector<HttpConnector>>;
 /// the server certificate is verified against when `OverrideTargetName` moves it off the endpoint.
 /// Taken rather than resolved here, so a caller that needs it for the engine it builds on top
 /// resolves it once.
-pub async fn https_connector(
-    config: HttpConfig,
-    origin: Uri,
-) -> Result<Connector, ConnectionError> {
+///
+/// Synchronous: this assembles a connector out of certificates the configuration already loaded,
+/// and opens nothing. That matters to a caller with no runtime, and to one already inside the only
+/// runtime it has, where blocking on a future would panic rather than wait.
+pub fn https_connector(config: HttpConfig, origin: Uri) -> Result<Connector, ConnectionError> {
     let endpoint = config.endpoint;
 
     // Get the default crypto provider or fallback to the ring crypto provider

--- a/packages/rust/armonik-transport/src/lib.rs
+++ b/packages/rust/armonik-transport/src/lib.rs
@@ -18,11 +18,12 @@ mod tls_config;
 mod utils;
 
 pub use config::{ConfigError, HttpConfig};
-pub use connector::{https_connector, ConnectionError};
+pub use connector::{https_connector, ConnectionError, Connector};
 #[cfg(feature = "env")]
 pub use env::EnvError;
 pub use http2_config::Http2Config;
-pub use proxy::{ProxyConfig, ProxyError, ProxySource};
+// `ProxyConnector` is a layer of the stack `Connector` names, so it has to be nameable too.
+pub use proxy::{ProxyConfig, ProxyConnector, ProxyError, ProxySource};
 pub use retry_config::RetryConfig;
 pub use tcp_config::TcpConfig;
 pub use tls_config::{Identity, TlsConfig};

--- a/packages/rust/armonik-transport/src/lib.rs
+++ b/packages/rust/armonik-transport/src/lib.rs
@@ -38,8 +38,13 @@ pub use connector::{IoSnafu, TlsSnafu};
 ///
 /// A dependent should take these rather than declare its own requirement for the same crates, so it
 /// cannot end up with a `rustls` other than the one the connection was built with.
+///
+/// Enough of them to build the HTTP/2 engine this crate leaves to its consumer: `h2` and
+/// `http_body_util` are here for that alone, and are used nowhere in this crate.
 pub mod reexports {
+    pub use h2;
     pub use http;
+    pub use http_body_util;
     pub use hyper;
     pub use hyper_rustls;
     pub use hyper_util;
@@ -49,4 +54,8 @@ pub mod reexports {
     pub use secrecy;
     #[cfg(feature = "serde")]
     pub use serde;
+    // Only the versions match. Which of tokio's modules exist is decided by the features every crate
+    // in the build asks for together, so a dependent that needs a runtime still declares tokio for
+    // that; taking it from here is what keeps the stream types the connector hands back the same.
+    pub use tokio;
 }

--- a/packages/rust/armonik-transport/src/proxy.rs
+++ b/packages/rust/armonik-transport/src/proxy.rs
@@ -496,6 +496,10 @@ fn parse_proxy_address(proxy: &str) -> Result<ProxyConfig, crate::config::Config
 /// A request that must not be proxied goes straight to the inner connector, leaving that path as it
 /// was. Generic over the connector because all this layer needs is something that turns a [`Uri`]
 /// into a TCP stream; which one is knowledge it has no use for.
+///
+/// Public because it is a layer of [`crate::Connector`], which a consumer has to be able to write
+/// down. It is assembled by [`crate::https_connector`] from an [`crate::HttpConfig`], never by hand,
+/// so it has no public constructor.
 #[derive(Debug, Clone)]
 pub struct ProxyConnector<S> {
     inner: S,

--- a/packages/rust/armonik/src/client/channel.rs
+++ b/packages/rust/armonik/src/client/channel.rs
@@ -22,9 +22,8 @@ pub async fn connect(config: HttpConfig) -> Result<Channel, ChannelError> {
     let timeout = config.timeout;
     let rate_limit = config.rate_limit;
 
-    let https = armonik_transport::https_connector(config, origin.clone())
-        .await
-        .context(ConnectorSnafu)?;
+    let https =
+        armonik_transport::https_connector(config, origin.clone()).context(ConnectorSnafu)?;
 
     // The endpoint is what gets dialled, the origin what requests are addressed to. No condition on
     // the two being the same: with no override they are, which is what a channel does by default.

--- a/packages/rust/armonik/src/client/mod.rs
+++ b/packages/rust/armonik/src/client/mod.rs
@@ -127,7 +127,6 @@ impl Client<tonic::transport::Channel> {
 
         let origin = hyper::Uri::try_from(&config).expect("An addressable endpoint");
         let https = armonik_transport::https_connector(config, origin)
-            .await
             .expect("Build connection information");
 
         let client = hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build(https);


### PR DESCRIPTION
Sits on `wk/feat/csharp-options-generator`, to merge first.

# Motivation

`armonik-transport` stops at the connector and leaves the HTTP/2 engine to whoever consumes it. It
therefore owes that consumer the crates the engine is spoken to, and a type it can write down to
hold the connector in.

# Description

`hyper-util`'s `http2` feature is declared rather than relied on transitively, since it was on only
because `hyper-rustls` happens to ask for it and another crate's feature list can change. Writing it
down turns nothing on, and `Cargo.lock` staying byte-identical is the proof.

`tokio`, `h2` and `http-body-util` are re-exported: the stream types the connector hands back, the
reason a stream was reset, the bodies hyper is given. The last two are dependencies for the
re-export alone, used nowhere in the crate, which is the point rather than the smell - taken from
crates.io separately, either can resolve to a version other than the one hyper was built against,
and the skew shows up as a type error at the seam.

`Connector` names `HttpsConnector<ProxyConnector<HttpConnector>>`, and `ProxyConnector` is exported
because it is a layer of it. That type was already public, being a public function's return type,
but unnameable outside the crate - the worst of both, since a consumer holding it in a struct field
had to erase it into a trait object for want of a name.

`https_connector` becomes synchronous: it awaits nothing, and being `async` charged every caller a
runtime for a future that never yields while leaving a caller already inside its only runtime with a
`block_on` that panics there rather than waits.

# Testing

No test is added or removed - this declares a feature, adds three re-exports, exports a type and
drops an `async`. `cargo test --workspace --all-features --no-fail-fast` is unmoved, and the check
the first commit rests on is `git diff --exit-code -- packages/rust/Cargo.lock` after a build.

# Impact

`https_connector` is no longer `async`, a breaking signature change; both callers are in `armonik`
and lose an `.await`, and the crate has no published release. A re-export guarantees versions, not
feature sets, which cargo unifies across the build; the README says so and names the case a consumer
is likeliest to meet.

# Additional Information

`tokio_stream` is deliberately not re-exported: it used to arrive through `tonic::codegen`, and
nothing in the crate or its connector speaks it now.

# Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary. (none needed here)
- [ ] Tests pass locally and in the CI. (locally yes; CI has not run this branch)
- [ ] I have assessed the performance impact of my modifications. (nothing measured)
