### PR TITLE
ci(publish): pin a pull request to the commit that triggered the run

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -188,12 +188,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          # The version generator reads the current branch name, so a pull
-          # request has to build on its head rather than on the detached merge
-          # ref: otherwise every PR resolves to the same `-head.*` version.
-          # Empty on every other event, which leaves the default checkout.
-          ref: ${{ github.head_ref }}
+          # The commit that triggered the run, not the merge ref and not the
+          # branch: a branch name resolves to wherever the branch stands when
+          # this step runs, so a run that waits in the queue while its branch
+          # moves builds, and names, a commit that is not its own head. Empty on
+          # every other event, which leaves the default checkout.
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+
+      # The checkout above is detached, and the version generator reads the
+      # current branch name (`git rev-parse --abbrev-ref HEAD`) both as the
+      # pre-release label and as the end of the commit range it counts. Detached
+      # that name is `HEAD`, which makes every pull request resolve to the same
+      # `-head.*` version. Name the pinned commit without moving it, so the
+      # generator sees the branch and the commit the run was triggered on.
+      - name: Restore the branch name
+        if: github.event_name == 'pull_request'
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: git checkout -B "$HEAD_REF"
 
       - run: npm i -g --ignore-scripts pnpm@10.18.0 @antfu/ni@30.3.0
 
@@ -435,9 +448,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          # Build the pull request's head, as the previous workflow did, not the
-          # merge ref. Empty on every other event.
-          ref: ${{ github.head_ref }}
+          # The commit that triggered the run, not the merge ref and not the
+          # branch, which resolves to wherever it has moved by now. This is the
+          # commit the version resolved by the context job names. Empty on every
+          # other event.
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Install .NET Core
@@ -684,9 +699,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          # Build the pull request's head, as the previous workflow did, not the
-          # merge ref. Empty on every other event.
-          ref: ${{ github.head_ref }}
+          # The commit that triggered the run, not the merge ref and not the
+          # branch, which resolves to wherever it has moved by now. This is the
+          # commit the version resolved by the context job names. Empty on every
+          # other event.
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       # Pinned: the angular package is published from its generated `dist`


### PR DESCRIPTION
# Motivation

Three checkout steps in `publish.yml` used `ref: ${{ github.head_ref }}`. That is a branch name, so
`actions/checkout` resolves it to wherever the branch stands when the step runs rather than to the
commit that triggered the run: a run that waits in the queue while its branch moves builds the newer
commit under the older run's identity.

Seen on another branch of this repository, where two commits landed five minutes apart. The run
triggered by the first reached its context job eighteen minutes later, by which time the branch
stood at the second; it resolved a version naming that second commit, not its own head, and
published it. The run whose head really was that commit then failed with `409 Conflict`. Five red
checks, and - the part that matters - a run reported against one commit that had built another.

# Description

All three checkouts pin `github.event.pull_request.head.sha`, the head when the event was delivered,
which `actions/checkout` treats as a commit and checks out detached. The context job gains a step
putting the branch name back on that commit with `git checkout -B`: the version generator reads
`git rev-parse --abbrev-ref HEAD` as both the pre-release label and the end of the range it counts,
so detached, every pull request would resolve to the same `-head.*` version.

All three rather than the context job alone, because the version and the package it names have to
come from one commit: `csharp` and `npm` carried the same pattern, so pinning the version by itself
would name one commit on a package built from another's source.

The generator was reproduced rather than taken on trust, on a synthetic repository whose tip had
moved one commit past the pin: the branch name gives a version naming the wrong commit, a detached
SHA gives `-head.*`, the SHA plus `checkout -B` gives the right label and the right commit, and the
commit count was wrong too, not only the hash. All of it rests on `fetch-depth: 0`, which still
fetches every tag when `ref` is a bare SHA; remove it and the version silently becomes garbage.

# Testing

The workflow has never run and cannot be run from here. Checked instead: the YAML parses and passes
`@action-validator/cli`'s workflow schema, and the generator's three states were reproduced locally.
Not checked: that `pull_request.head.sha` is populated on every `synchronize` sub-event, and the
fork path.

# Impact

A pull request run now builds and names the commit it was triggered on. On every other event the
expression is empty, leaving the default checkout as before.

# Additional Information

This incidentally fixes publishing from a fork, whose checkout cannot resolve a branch name absent
from the base repository - the expected consequence of pinning a SHA, not something tested.
`.github/workflows/test.yml` carries the identical pattern, left alone to keep this standalone; it
publishes nothing, so it is a reporting problem rather than a registry one.

# Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary. (see Testing)
- [ ] Tests pass locally and in the CI. (the workflow has never run)
- [ ] I have assessed the performance impact of my modifications. (nothing measured)
