### PR TITLE
fix(cpp): send the communication token with CreateResultsMetaData

### DIFF
--- a/packages/cpp/ArmoniK.Api.Worker/source/Worker/TaskHandler.cpp
+++ b/packages/cpp/ArmoniK.Api.Worker/source/Worker/TaskHandler.cpp
@@ -263,6 +263,7 @@ std::vector<std::string> armonik::api::worker::TaskHandler::get_result_ids(
 
   *request.mutable_results() = {results.begin(), results.end()};
   request.set_session_id(session_id_);
+  request.set_communication_token(token_);
 
   Status status = stub_.CreateResultsMetaData(&context_client_writer, request, &reply);
   if (!status.ok()) {


### PR DESCRIPTION
# Motivation

Every call a worker makes to its agent must carry the `communication_token` it received in the
`ProcessRequest` — the agent uses it to authenticate the caller and associate the call with the task
being processed. An audit of the C++ worker's agent calls found one that does not send it.

# Description

`TaskHandler::get_result_ids` (`packages/cpp/ArmoniK.Api.Worker/source/Worker/TaskHandler.cpp`) builds
its `CreateResultsMetaDataRequest` with `results` and `session_id`, but never sets
`communication_token`, so `Agent.CreateResultsMetaData` was invoked with an empty token.

This adds the missing `request.set_communication_token(token_)`.

For reference, here is the state of every agent call reachable from the C++ worker:

| Agent RPC | C++ entry point | Token before | Token after |
| --- | --- | --- | --- |
| `CreateTask` (stream) | `create_tasks_async` | set on every streamed message (`init_request`, `init_task`, payload chunks, `data_complete`, `last_task`) | unchanged |
| `NotifyResultData` | `send_result` | set | unchanged |
| `CreateResultsMetaData` | `get_result_ids` | **missing** | set |

The remaining agent RPCs — `CreateResults`, `SubmitTasks`, `GetResourceData`, `GetCommonData` and
`GetDirectData` — have no C++ counterpart today, so there is nothing to fix there. They are covered by
the Python task handler, and whoever adds them to C++ will need to set the token on each request.

The field already exists in the proto (`CreateResultsMetaDataRequest.communication_token`,
`Protos/V1/agent_common.proto`), and both the C# (`TaskHandler.cs`) and Python (`taskhandler.py`) task
handlers already set it — this brings C++ in line with them. No proto or public API change.

# Testing

No test added: the C++ test suite requires a prebuilt `armonik-api-cpp` docker image and cannot be
built on the machine this was authored on, and there is no existing C++ test that asserts on the
contents of agent requests. The change was verified by reading the generated
`CreateResultsMetaDataRequest` accessors and by comparing against the C# and Python handlers. CI will
compile the C++ worker.

# Impact

Behavioural fix only, one line. Workers built against a Core version that validates the
communication token on `CreateResultsMetaData` will now succeed where they previously would have been
rejected. No performance, configuration, dependency or documentation impact.

# Additional Information

The token is only ever carried in the request body, never in gRPC metadata — consistent across the
C++, C# and Python workers, so nothing changes on that front.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.