### PR TITLE
refactor(cpp): Support for pre-allocated buffer in download

### DIFF
--- a/packages/cpp/ArmoniK.Api.Client/header/results/ResultsClient.h
+++ b/packages/cpp/ArmoniK.Api.Client/header/results/ResultsClient.h
@@ -137,6 +137,15 @@ public:
   std::string download_result_data(std::string session_id, std::string result_id);
 
   /**
+   * Retrieve data from a result
+   * @param session_id Session id
+   * @param result_id Result Id
+   * @param output The output buffer where the data will be downloaded
+   * @remarks If output is pre-allocated to the right size, no reallocation will happen
+   */
+  void download_result_data_in(std::string session_id, std::string result_id, std::string &output);
+
+  /**
    * Deletes the results data
    * @param session_id Session id
    * @param result_ids Result ids

--- a/packages/cpp/ArmoniK.Api.Client/source/results/ResultsClient.cpp
+++ b/packages/cpp/ArmoniK.Api.Client/source/results/ResultsClient.cpp
@@ -205,6 +205,13 @@ std::map<std::string, std::string> ResultsClient::get_owner_task_id(std::string 
 }
 
 std::string ResultsClient::download_result_data(std::string session_id, std::string result_id) {
+  std::string output{};
+  download_result_data_in(std::move(session_id), std::move(result_id), output);
+  output.shrink_to_fit();
+  return output;
+}
+
+void ResultsClient::download_result_data_in(std::string session_id, std::string result_id, std::string &output) {
   ::grpc::ClientContext context;
   armonik::api::grpc::v1::results::DownloadResultDataRequest request;
   armonik::api::grpc::v1::results::DownloadResultDataResponse response;
@@ -212,11 +219,9 @@ std::string ResultsClient::download_result_data(std::string session_id, std::str
   *request.mutable_session_id() = std::move(session_id);
   *request.mutable_result_id() = std::move(result_id);
 
-  std::string received_data;
-
   auto stream = stub->DownloadResultData(&context, request);
   while (stream->Read(&response)) {
-    received_data.append(response.data_chunk());
+    output.append(response.data_chunk());
   }
   auto status = stream->Finish();
   if (!status.ok()) {
@@ -226,8 +231,6 @@ std::string ResultsClient::download_result_data(std::string session_id, std::str
     auto str = message.str();
     throw armonik::api::common::exceptions::ArmoniKApiException(str);
   }
-
-  return received_data;
 }
 
 ResultsClient::Configuration ResultsClient::get_service_configuration() {

--- a/packages/cpp/ArmoniK.Api.Tests/source/ResultsClientTest.cpp
+++ b/packages/cpp/ArmoniK.Api.Tests/source/ResultsClientTest.cpp
@@ -164,14 +164,23 @@ TEST_F(Results, test_results_upload_download) {
 
   init(channel, task_options, log);
 
+  const char *payload = "Test payload long enough it is not stored in the SSO buffer of std::string";
+
   auto client = armonik::api::client::ResultsClient(armonik::api::grpc::v1::results::Results::NewStub(channel));
   auto session_id = armonik::api::client::SessionsClient(armonik::api::grpc::v1::sessions::Sessions::NewStub(channel))
                         .create_session(task_options);
   auto map = client.create_results_metadata(session_id, std::vector<std::string>{"0"});
   ASSERT_EQ(map.size(), 1);
   ASSERT_NO_THROW(map.at("0"));
-  ASSERT_NO_THROW(client.upload_result_data(session_id, map.at("0"), "TestPayload"));
-  ASSERT_EQ(client.download_result_data(session_id, map.at("0")), "TestPayload");
+  ASSERT_NO_THROW(client.upload_result_data(session_id, map.at("0"), payload));
+  ASSERT_EQ(client.download_result_data(session_id, map.at("0")), payload);
+
+  std::string output;
+  output.reserve(strlen(payload));
+  const char *old_buffer = output.data();
+  ASSERT_NO_THROW(client.download_result_data_in(session_id, map.at("0"), output));
+  ASSERT_EQ(output, payload);
+  ASSERT_EQ(output.data(), old_buffer);
 }
 
 /**


### PR DESCRIPTION
# Motivation

Downloading a data using C++ bindings would always allocate a new string, and would go through buffer growth during the download. The returned string would overallocate in the process to support this buffer growth.

# Description

- Add an overload for download that writes the data in a pre-allocated std::string&
- Call shrink_to_fit on the overload that creates a new std::string for the downloaded result.

# Testing

Works under the CI. The new test ensures that downloading into a string that was pre-allocated does not reallocates.

# Impact

The string returning download that was there before now shrink to fits in order to reduce the memory consumption.
No other impact on existing code.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
