### PR TITLE
fix(ci): pin pnpm/ni versions in ci.yml to match publish.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: npm i -g pnpm @antfu/ni
+      - run: npm i -g --ignore-scripts pnpm@10.18.0 @antfu/ni@30.3.0
 
       - name: Setup Node.js
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
@@ -255,7 +255,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: npm install -g pnpm @antfu/ni
+      - run: npm install -g --ignore-scripts pnpm@10.18.0 @antfu/ni@30.3.0
 
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
         with:
@@ -278,7 +278,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: npm i -g pnpm @antfu/ni
+      - run: npm i -g --ignore-scripts pnpm@10.18.0 @antfu/ni@30.3.0
 
       - name: Setup Node.js
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
@@ -311,7 +311,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: npm i -g pnpm @antfu/ni
+      - run: npm i -g --ignore-scripts pnpm@10.18.0 @antfu/ni@30.3.0
 
       - name: Setup Node.js
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4


### PR DESCRIPTION
# Motivation

`Build Angular`, `Build Web`, `Lint JS`, and `Verify Versions` were consistently failing in the `CI` workflow, on every PR, regardless of branch content. The actual build/lint/install steps succeeded, but the job was still reported as failed.

# Description

The failing step was `actions/setup-node`'s `Post Setup Node.js` (pnpm cache save), which errored with:

```
Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

Root cause: these jobs installed pnpm unpinned (`npm i -g pnpm @antfu/ni`), while `publish.yml`, which does not hit this failure, pins `pnpm@10.18.0 @antfu/ni@30.3.0`. Since `package.json` declares `"packageManager": "pnpm@10.18.0"`, corepack switches the actual dependency install to that pinned version, but `actions/setup-node`'s cache pre-step determines the pnpm store path using whichever (newer, unpinned) pnpm `npm i -g` happened to install. The two pnpm versions disagree on the default store directory, so the post-step tries to save a cache path that was never populated, and the job fails.

Fix: pin `pnpm`/`@antfu/ni` to the same versions used in `publish.yml` across all four jobs in `ci.yml`.

# Testing

Reproduced the failure on multiple unrelated branches/PRs (same four jobs, same `Post Setup Node.js` error) and confirmed `publish.yml`, which pins these versions, never hits it. CI on this branch will confirm the fix.

# Impact

CI workflow only. No functional or runtime changes to ArmoniK.Api itself.

# Additional Information

Split out of #754, where this fix was originally found and applied but doesn't belong.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.